### PR TITLE
feat: Implement XML namespace and integrate to feed parse/generate

### DIFF
--- a/src/feeds/atom/common/types.ts
+++ b/src/feeds/atom/common/types.ts
@@ -11,6 +11,7 @@ import type { Item as SlashItem } from '../../../namespaces/slash/common/types.j
 import type { Feed as SyFeed } from '../../../namespaces/sy/common/types.js'
 import type { Item as ThrItem, Link as ThrLink } from '../../../namespaces/thr/common/types.js'
 import type { Item as WfwItem } from '../../../namespaces/wfw/common/types.js'
+import type { ItemOrFeed as XmlItemOrFeed } from '../../../namespaces/xml/common/types.js'
 import type { Feed as YtFeed, Item as YtItem } from '../../../namespaces/yt/common/types.js'
 
 export type ParsePartialFunction<R> = (
@@ -92,6 +93,7 @@ export type Entry<TDate extends DateLike> = {
   thr?: ThrItem
   wfw?: WfwItem
   yt?: YtItem
+  xml?: XmlItemOrFeed
 }
 
 export type Feed<TDate extends DateLike> = {
@@ -115,5 +117,6 @@ export type Feed<TDate extends DateLike> = {
   media?: MediaItemOrFeed
   georss?: GeoRssItemOrFeed
   yt?: YtFeed
+  xml?: XmlItemOrFeed
 }
 // #endregion reference

--- a/src/feeds/atom/generate/utils.ts
+++ b/src/feeds/atom/generate/utils.ts
@@ -25,6 +25,7 @@ import {
   generateLink as generateThrLink,
 } from '../../../namespaces/thr/generate/utils.js'
 import { generateItem as generateWfwItem } from '../../../namespaces/wfw/generate/utils.js'
+import { generateItemOrFeed as generateXmlItemOrFeed } from '../../../namespaces/xml/generate/utils.js'
 import {
   generateFeed as generateYtFeed,
   generateItem as generateYtItem,
@@ -182,6 +183,7 @@ export const generateEntry: GenerateFunction<Entry<DateLike>> = (entry, options)
     ...generateThrItem(entry.thr),
     ...generateWfwItem(entry.wfw),
     ...generateYtItem(entry.yt),
+    ...generateXmlItemOrFeed(entry.xml),
   }
 }
 
@@ -240,6 +242,7 @@ export const generateFeed: GenerateFunction<Feed<DateLike>> = (feed, options) =>
     ...generateMediaItemOrFeed(feed.media),
     ...generateGeoRssItemOrFeed(feed.georss),
     ...generateYtFeed(feed.yt),
+    ...generateXmlItemOrFeed(feed.xml),
     ...valueEntries,
   }
 

--- a/src/feeds/atom/parse/utils.ts
+++ b/src/feeds/atom/parse/utils.ts
@@ -25,6 +25,7 @@ import {
   retrieveLink as retrieveThrLink,
 } from '../../../namespaces/thr/parse/utils.js'
 import { retrieveItem as retrieveWfwItem } from '../../../namespaces/wfw/parse/utils.js'
+import { retrieveItemOrFeed as retrieveXmlItemOrFeed } from '../../../namespaces/xml/parse/utils.js'
 import {
   retrieveFeed as retrieveYtFeed,
   retrieveItem as retrieveYtItem,
@@ -235,6 +236,7 @@ export const parseEntry: ParsePartialFunction<Entry<string>> = (value, options) 
     thr: namespaces?.has('thr') ? retrieveThrItem(value) : undefined,
     wfw: namespaces?.has('wfw') ? retrieveWfwItem(value) : undefined,
     yt: namespaces?.has('yt') ? retrieveYtItem(value) : undefined,
+    xml: retrieveXmlItemOrFeed(value),
   }
 
   return trimObject(entry)
@@ -268,6 +270,7 @@ export const parseFeed: ParsePartialFunction<Feed<string>> = (value, options) =>
     media: namespaces?.has('media') ? retrieveMediaItemOrFeed(value) : undefined,
     georss: namespaces?.has('georss') ? retrieveGeoRssItemOrFeed(value) : undefined,
     yt: namespaces?.has('yt') ? retrieveYtFeed(value) : undefined,
+    xml: retrieveXmlItemOrFeed(value),
   }
 
   return trimObject(feed)

--- a/src/feeds/atom/references/atom-03.xml
+++ b/src/feeds/atom/references/atom-03.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<feed version="0.3" xmlns="http://purl.org/atom/ns#" xml:base="http://example.org/" xml:lang="en">
+<feed version="0.3" xmlns="http://purl.org/atom/ns#">
   <title type="text/plain" mode="escaped">
     Sample Feed
   </title>
@@ -66,7 +66,7 @@
     <summary type="text/plain" mode="escaped">
       Watch out for nasty tricks
     </summary>
-    <content type="application/xhtml+xml" mode="xml" xml:base="http://example.org/entry/3" xml:lang="en-US">
+    <content type="application/xhtml+xml" mode="xml">
       <div xmlns="http://www.w3.org/1999/xhtml">Watch out for <span style="background-image: url(javascript:window.location='http://example.org/')"> nasty tricks</span></div>
     </content>
     <source>
@@ -111,7 +111,7 @@
     <summary>
       This is an entry showing a text version of content
     </summary>
-    <content type="application/xhtml+xml" mode="xml" xml:base="http://example.org/entry/3" xml:lang="en-US">
+    <content type="application/xhtml+xml" mode="xml">
       <div xmlns="http://www.w3.org/1999/xhtml">Watch out for <span style="background-image: url(javascript:window.location='http://example.org/')"> nasty tricks</span></div>
     </content>
   </entry>

--- a/src/feeds/atom/references/atom-10.xml
+++ b/src/feeds/atom/references/atom-10.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<feed xmlns="http://www.w3.org/2005/Atom" xml:base="http://example.org/" xml:lang="en">
+<feed xmlns="http://www.w3.org/2005/Atom">
   <title type="text">Comprehensive Atom 1.0 Example Feed</title>
   <subtitle type="html">A &lt;em&gt;comprehensive&lt;/em&gt; example showing all Atom 1.0 elements</subtitle>
   <link rel="alternate" type="text/html" href="/"/>
@@ -77,7 +77,7 @@
     <summary type="text">
       This is a comprehensive example entry showing all possible Atom 1.0 elements in an entry.
     </summary>
-    <content type="xhtml" xml:base="http://example.org/entry/1" xml:lang="en-US">
+    <content type="xhtml">
       <div xmlns="http://www.w3.org/1999/xhtml">
         <h1>Comprehensive Atom 1.0 Entry</h1>
         <p>This entry demonstrates all possible elements in an Atom 1.0 entry.</p>
@@ -158,14 +158,14 @@
       This entry has multiple authors to demonstrate how multiple author elements can be used.
     </content>
   </entry>
-  <entry xml:lang="fr">
+  <entry>
     <title>Exemple de Contenu en Français</title>
     <id>tag:example.org,2023:entry-6</id>
     <updated>2023-01-10T11:05:00Z</updated>
     <content type="text">
       Cet article est écrit en français pour démontrer l'utilisation de l'attribut xml:lang.
     </content>
-    <summary xml:lang="en">
+    <summary>
       This is an English summary of a French entry to demonstrate language-specific content.
     </summary>
   </entry>

--- a/src/feeds/atom/references/atom-ns.json
+++ b/src/feeds/atom/references/atom-ns.json
@@ -536,7 +536,11 @@
             "updated": "2025-05-10T16:45:00Z"
           }
         }
-      ]
+      ],
+      "xml": {
+        "lang": "fr",
+        "id": "entry-with-xml-attrs"
+      }
     }
   ],
   "dc": {
@@ -1055,5 +1059,9 @@
     "elev": 360,
     "floor": 4,
     "radius": 50000
+  },
+  "xml": {
+    "lang": "en",
+    "base": "http://example.org/"
   }
 }

--- a/src/feeds/atom/references/atom-ns.xml
+++ b/src/feeds/atom/references/atom-ns.xml
@@ -9,6 +9,8 @@
   xmlns:slash="http://purl.org/rss/1.0/modules/slash/"
   xmlns:thr="http://purl.org/syndication/thread/1.0"
   xmlns:yt="http://www.youtube.com/xml/schemas/2015"
+  xml:lang="en"
+  xml:base="http://example.org/"
 >
   <title>Example Feed</title>
   <id>example-feed</id>
@@ -230,7 +232,7 @@
   <georss:floor>4</georss:floor>
   <georss:radius>50000</georss:radius>
 
-  <entry>
+  <entry xml:lang="fr" xml:id="entry-with-xml-attrs">
     <title>Example Entry</title>
     <id>example-entry</id>
 

--- a/src/namespaces/xml/common/types.ts
+++ b/src/namespaces/xml/common/types.ts
@@ -1,0 +1,11 @@
+// TODO: Rename to XmlElement when PR #69 (text structure) is implemented. This will
+// allow XML attributes on content/summary elements, not just feed/entry.
+
+// #region reference
+export type ItemOrFeed = {
+  lang?: string
+  base?: string
+  space?: string
+  id?: string
+}
+// #endregion reference

--- a/src/namespaces/xml/generate/utils.test.ts
+++ b/src/namespaces/xml/generate/utils.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from 'bun:test'
+import { generateItemOrFeed } from './utils.js'
+
+describe('generateItemOrFeed', () => {
+  it('should generate valid XML namespace object with all properties', () => {
+    const value = {
+      lang: 'en-US',
+      base: 'http://example.org/base/',
+      space: 'preserve',
+      id: 'unique-xml-id',
+    }
+    const expected = {
+      '@xml:lang': 'en-US',
+      '@xml:base': 'http://example.org/base/',
+      '@xml:space': 'preserve',
+      '@xml:id': 'unique-xml-id',
+    }
+
+    expect(generateItemOrFeed(value)).toEqual(expected)
+  })
+
+  it('should generate XML namespace with minimal properties', () => {
+    const value = {
+      lang: 'fr-FR',
+    }
+    const expected = {
+      '@xml:lang': 'fr-FR',
+    }
+
+    expect(generateItemOrFeed(value)).toEqual(expected)
+  })
+
+  it('should handle object with only undefined/empty properties', () => {
+    const value = {
+      lang: undefined,
+      base: undefined,
+      space: undefined,
+      id: undefined,
+    }
+
+    // @ts-expect-error: This is for testing purposes.
+    expect(generateItemOrFeed(value)).toBeUndefined()
+  })
+
+  it('should handle empty object', () => {
+    const value = {}
+
+    // @ts-expect-error: This is for testing purposes.
+    expect(generateItemOrFeed(value)).toBeUndefined()
+  })
+
+  it('should handle non-object inputs gracefully', () => {
+    expect(generateItemOrFeed(undefined)).toBeUndefined()
+    expect(generateItemOrFeed(null)).toBeUndefined()
+    // @ts-expect-error: This is for testing purposes.
+    expect(generateItemOrFeed('not an object')).toBeUndefined()
+    // @ts-expect-error: This is for testing purposes.
+    expect(generateItemOrFeed([])).toBeUndefined()
+  })
+
+  it('should filter out empty string values', () => {
+    const value = {
+      lang: '',
+      base: 'http://example.org/',
+      space: '',
+      id: 'valid-id',
+    }
+    const expected = {
+      '@xml:base': 'http://example.org/',
+      '@xml:id': 'valid-id',
+    }
+
+    expect(generateItemOrFeed(value)).toEqual(expected)
+  })
+
+  it('should filter out null values', () => {
+    const value = {
+      lang: null,
+      base: 'http://example.org/',
+      space: undefined,
+      id: 'valid-id',
+    }
+    const expected = {
+      '@xml:base': 'http://example.org/',
+      '@xml:id': 'valid-id',
+    }
+
+    // @ts-expect-error: This is for testing purposes.
+    expect(generateItemOrFeed(value)).toEqual(expected)
+  })
+
+  it('should handle object with all properties having null/empty values', () => {
+    const value = {
+      lang: null,
+      base: '',
+      space: undefined,
+      id: '',
+    }
+
+    // @ts-expect-error: This is for testing purposes.
+    expect(generateItemOrFeed(value)).toBeUndefined()
+  })
+})

--- a/src/namespaces/xml/generate/utils.ts
+++ b/src/namespaces/xml/generate/utils.ts
@@ -1,0 +1,18 @@
+import type { GenerateFunction } from '../../../common/types.js'
+import { generatePlainString, isObject, trimObject } from '../../../common/utils.js'
+import type { ItemOrFeed } from '../common/types.js'
+
+export const generateItemOrFeed: GenerateFunction<ItemOrFeed> = (itemOrFeed) => {
+  if (!isObject(itemOrFeed)) {
+    return
+  }
+
+  const value = {
+    '@xml:lang': generatePlainString(itemOrFeed.lang),
+    '@xml:base': generatePlainString(itemOrFeed.base),
+    '@xml:space': generatePlainString(itemOrFeed.space),
+    '@xml:id': generatePlainString(itemOrFeed.id),
+  }
+
+  return trimObject(value)
+}

--- a/src/namespaces/xml/parse/utils.test.ts
+++ b/src/namespaces/xml/parse/utils.test.ts
@@ -1,0 +1,176 @@
+import { describe, expect, it } from 'bun:test'
+import { retrieveItemOrFeed } from './utils.js'
+
+describe('retrieveItemOrFeed', () => {
+  it('should parse complete XML namespace object with all properties', () => {
+    const value = {
+      '@xml:lang': 'en-US',
+      '@xml:base': 'http://example.org/base/',
+      '@xml:space': 'preserve',
+      '@xml:id': 'unique-xml-id',
+    }
+    const expected = {
+      lang: 'en-US',
+      base: 'http://example.org/base/',
+      space: 'preserve',
+      id: 'unique-xml-id',
+    }
+
+    expect(retrieveItemOrFeed(value)).toEqual(expected)
+  })
+
+  it('should parse object with only lang property', () => {
+    const value = {
+      '@xml:lang': 'fr-FR',
+    }
+    const expected = {
+      lang: 'fr-FR',
+    }
+
+    expect(retrieveItemOrFeed(value)).toEqual(expected)
+  })
+
+  it('should parse object with only base property', () => {
+    const value = {
+      '@xml:base': 'https://example.com/path/',
+    }
+    const expected = {
+      base: 'https://example.com/path/',
+    }
+
+    expect(retrieveItemOrFeed(value)).toEqual(expected)
+  })
+
+  it('should parse object with only space property', () => {
+    const value = {
+      '@xml:space': 'default',
+    }
+    const expected = {
+      space: 'default',
+    }
+
+    expect(retrieveItemOrFeed(value)).toEqual(expected)
+  })
+
+  it('should parse object with only id property', () => {
+    const value = {
+      '@xml:id': 'test-element-id',
+    }
+    const expected = {
+      id: 'test-element-id',
+    }
+
+    expect(retrieveItemOrFeed(value)).toEqual(expected)
+  })
+
+  it('should handle coercible values', () => {
+    const value = {
+      '@xml:lang': 'en',
+      '@xml:id': 123,
+      '@xml:space': true,
+    }
+    const expected = {
+      lang: 'en',
+      id: '123',
+    }
+
+    expect(retrieveItemOrFeed(value)).toEqual(expected)
+  })
+
+  it('should return undefined for empty object', () => {
+    const value = {}
+
+    expect(retrieveItemOrFeed(value)).toBeUndefined()
+  })
+
+  it('should return undefined for non-object input', () => {
+    expect(retrieveItemOrFeed('not an object')).toBeUndefined()
+    expect(retrieveItemOrFeed(undefined)).toBeUndefined()
+    expect(retrieveItemOrFeed(null)).toBeUndefined()
+    expect(retrieveItemOrFeed([])).toBeUndefined()
+  })
+
+  it('should return undefined when no XML namespace properties can be parsed', () => {
+    const value = {
+      'other:property': 'value',
+      'unknown:field': 'data',
+      '@href': 'http://example.com',
+      '@title': 'Not XML namespace',
+    }
+
+    expect(retrieveItemOrFeed(value)).toBeUndefined()
+  })
+
+  it('should handle objects with empty string values', () => {
+    const value = {
+      '@xml:lang': '',
+      '@xml:base': 'http://example.org/',
+      '@xml:space': '',
+      '@xml:id': 'valid-id',
+    }
+    const expected = {
+      base: 'http://example.org/',
+      id: 'valid-id',
+    }
+
+    expect(retrieveItemOrFeed(value)).toEqual(expected)
+  })
+
+  it('should handle null values in properties', () => {
+    const value = {
+      '@xml:lang': null,
+      '@xml:base': 'http://example.org/',
+      '@xml:space': undefined,
+      '@xml:id': 'valid-id',
+    }
+    const expected = {
+      base: 'http://example.org/',
+      id: 'valid-id',
+    }
+
+    expect(retrieveItemOrFeed(value)).toEqual(expected)
+  })
+
+  it('should handle object with all properties having null/empty values', () => {
+    const value = {
+      '@xml:lang': null,
+      '@xml:base': '',
+      '@xml:space': undefined,
+      '@xml:id': '',
+    }
+
+    expect(retrieveItemOrFeed(value)).toBeUndefined()
+  })
+
+  it('should ignore non-XML namespace attributes', () => {
+    const value = {
+      '@xml:lang': 'en-US',
+      '@href': 'http://example.com',
+      '@title': 'Some title',
+      '@rel': 'alternate',
+      '@xml:base': 'http://example.org/',
+      '@type': 'text/html',
+    }
+    const expected = {
+      lang: 'en-US',
+      base: 'http://example.org/',
+    }
+
+    expect(retrieveItemOrFeed(value)).toEqual(expected)
+  })
+
+  it('should handle boolean-like values', () => {
+    const value = {
+      '@xml:lang': false,
+      '@xml:base': true,
+      '@xml:space': 0,
+      '@xml:id': 1,
+    }
+    const expected = {
+      space: '0',
+      id: '1',
+    }
+
+    expect(retrieveItemOrFeed(value)).toEqual(expected)
+  })
+})

--- a/src/namespaces/xml/parse/utils.ts
+++ b/src/namespaces/xml/parse/utils.ts
@@ -1,0 +1,18 @@
+import type { ParsePartialFunction } from '../../../common/types.js'
+import { isObject, parseString, trimObject } from '../../../common/utils.js'
+import type { ItemOrFeed } from '../common/types.js'
+
+export const retrieveItemOrFeed: ParsePartialFunction<ItemOrFeed> = (value) => {
+  if (!isObject(value)) {
+    return
+  }
+
+  const itemOrFeed = {
+    lang: parseString(value['@xml:lang']),
+    base: parseString(value['@xml:base']),
+    space: parseString(value['@xml:space']),
+    id: parseString(value['@xml:id']),
+  }
+
+  return trimObject(itemOrFeed)
+}


### PR DESCRIPTION
Adds support for standard XML namespace attributes (xml:lang, xml:base, xml:space, xml:id) in Atom feeds. These attributes enable language specification, base URI resolution, whitespace preservation control, and element identification as defined in the XML specification.

## Implementation

- New namespace module: /src/namespaces/xml/ with parse/generate utilities
- Atom integration: Added xml property to Feed and Entry types
- Always-on parsing: XML attributes don't require namespace declarations, so no conditional parsing needed
- Comprehensive tests: 22 test cases covering parsing and generation scenarios
- Reference examples: Updated atom-ns.xml and atom-ns.json with XML namespace demonstrations

## Current Scope

- ✅ Atom feeds (Feed and Entry level)
- ❌ RSS/RDF feeds (not implemented)
- ❌ Content/Summary elements (waiting for PR #69 text structure)

## Open Design Question: RSS/RDF Root Element Attributes

RSS and RDF feeds have a structural challenge with XML attributes on root elements:

```xml
<!-- RSS -->
<rss version="2.0" xml:lang="en">      <!-- Root attributes -->
<channel xml:base="http://...">      <!-- Channel attributes -->

<!-- RDF -->
<rdf:RDF xml:lang="en">                <!-- Root attributes -->
<channel xml:base="http://...">       <!-- Channel attributes -->
```

Unlike Atom (single <feed> element), RSS/RDF split the "feed" concept across two elements.

Proposed approach: Merge root and channel XML attributes during parsing into channel.xml, and apply to <channel> during generation. This maintains API consistency with Atom while preserving semantic meaning,
though with some loss of structural fidelity.

Alternative approaches:
1. Add separate root.xml property (breaking change)
2. Only support channel-level attributes (loses root attributes)

Decision deferred pending further consideration.

## TODO
- Rename ItemOrFeed → XmlElement when PR #69 lands (to support content/summary elements)
- Decide on RSS/RDF root element handling before implementing