### PR TITLE
chore: Export the Opml `Outline`  type

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -19,6 +19,6 @@ export { detect as detectRssFeed } from './feeds/rss/detect/index.js'
 export { generate as generateRssFeed } from './feeds/rss/generate/index.js'
 export { parse as parseRssFeed } from './feeds/rss/parse/index.js'
 
-export type { Opml } from './opml/common/types.js'
+export type { Opml, Outline } from './opml/common/types.js'
 export { generate as generateOpml } from './opml/generate/index.js'
 export { parse as parseOpml } from './opml/parse/index.js'


### PR DESCRIPTION
Export the Outline type so that it is easier to deal with the output from `parseOpml`.