### PR TITLE
fix: Use Atom link text content as href when href attribute is missing

### DIFF
--- a/src/feeds/atom/parse/utils.test.ts
+++ b/src/feeds/atom/parse/utils.test.ts
@@ -161,13 +161,46 @@ describe('parseLink', () => {
     expect(parseLink(value)).toEqual(expected)
   })
 
-  it('should return undefined if href is missing', () => {
+  it('should fall back to text content as href when href attribute is missing', () => {
     const value = {
+      '#text': 'https://example.com/image.jpg',
+      '@rel': 'enclosure',
+      '@type': 'image/jpeg',
+    }
+    const expected = {
+      href: 'https://example.com/image.jpg',
+      rel: 'enclosure',
+      type: 'image/jpeg',
+    }
+
+    expect(parseLink(value)).toEqual(expected)
+  })
+
+  it('should prefer href attribute over text content', () => {
+    const value = {
+      '@href': 'https://example.com/correct',
+      '#text': 'https://example.com/fallback',
+      '@rel': 'alternate',
+    }
+    const expected = {
+      href: 'https://example.com/correct',
+      rel: 'alternate',
+    }
+
+    expect(parseLink(value)).toEqual(expected)
+  })
+
+  it('should parse link without href when neither href attribute nor text content exist', () => {
+    const value = {
+      '@rel': 'alternate',
+      '@type': 'text/html',
+    }
+    const expected = {
       rel: 'alternate',
       type: 'text/html',
     }
 
-    expect(parseLink(value)).toBeUndefined()
+    expect(parseLink(value)).toEqual(expected)
   })
 
   it('should return undefined for non-object input', () => {

--- a/src/feeds/atom/parse/utils.ts
+++ b/src/feeds/atom/parse/utils.ts
@@ -69,7 +69,7 @@ export const parseLink: ParsePartialUtil<Atom.Link<string>> = (value) => {
 
   const namespaces = detectNamespaces(value)
   const link = {
-    href: parseString(value['@href']),
+    href: parseString(value['@href']) ?? parseString(retrieveText(value)),
     rel: parseString(value['@rel']),
     type: parseString(value['@type']),
     hreflang: parseString(value['@hreflang']),


### PR DESCRIPTION
Closes https://github.com/macieklamberski/feedsmith/issues/255.