### PR TITLE
Strip XML comments from stop node text content

### DIFF
--- a/src/common/utils.test.ts
+++ b/src/common/utils.test.ts
@@ -990,6 +990,34 @@ describe('parseString', () => {
     expect(parseString(value)).toBe('test')
   })
 
+  it('should strip XML comments from text', () => {
+    expect(parseString('Test<!-- hidden --> Feed')).toBe('Test Feed')
+  })
+
+  it('should strip multiple XML comments', () => {
+    expect(parseString('A<!-- one -->B<!-- two -->C')).toBe('ABC')
+  })
+
+  it('should strip XML comment leaving only remaining text', () => {
+    expect(parseString('<!-- full comment -->visible')).toBe('visible')
+  })
+
+  it('should return undefined when entire content is a comment', () => {
+    expect(parseString('<!-- only comment -->')).toBeUndefined()
+  })
+
+  it('should handle malformed XML comment without closing tag', () => {
+    expect(parseString('<!-- no closing tag')).toBe('<!-- no closing tag')
+  })
+
+  it('should strip XML comments and decode entities in remaining text', () => {
+    expect(parseString('Hello<!-- comment --> &amp; World')).toBe('Hello & World')
+  })
+
+  it('should strip XML comments alongside CDATA sections', () => {
+    expect(parseString('<!-- comment --><![CDATA[content]]>')).toBe('content')
+  })
+
   it('should return number as string', () => {
     const value = 420
 

--- a/src/common/utils.test.ts
+++ b/src/common/utils.test.ts
@@ -1014,6 +1014,14 @@ describe('parseString', () => {
     expect(parseString('Hello<!-- comment --> &amp; World')).toBe('Hello & World')
   })
 
+  it('should handle nested comment start marker inside comment', () => {
+    expect(parseString('A<!-- first <!-- second -->B')).toBe('AB')
+  })
+
+  it('should handle extra closing comment marker as plain text', () => {
+    expect(parseString('A<!-- comment --> -->B')).toBe('A -->B')
+  })
+
   it('should strip XML comments alongside CDATA sections', () => {
     expect(parseString('<!-- comment --><![CDATA[content]]>')).toBe('content')
   })

--- a/src/common/utils.ts
+++ b/src/common/utils.ts
@@ -144,12 +144,41 @@ export const generateSingularOrArray = <V>(
   }
 }
 
+const commentStartTag = '<!--'
+const commentEndTag = '-->'
 const cdataStartTag = '<![CDATA['
 const cdataEndTag = ']]>'
 
 export const hasEntities = (text: string) => {
   const ampIndex = text.indexOf('&')
   return ampIndex !== -1 && text.indexOf(';', ampIndex) !== -1
+}
+
+const stripComments = (text: string): string => {
+  let currentIndex = text.indexOf(commentStartTag)
+
+  if (currentIndex === -1) {
+    return text
+  }
+
+  let result = ''
+  let lastIndex = 0
+
+  while (currentIndex !== -1) {
+    result += text.substring(lastIndex, currentIndex)
+    const endIndex = text.indexOf(commentEndTag, currentIndex + commentStartTag.length)
+
+    if (endIndex === -1) {
+      return text
+    }
+
+    lastIndex = endIndex + commentEndTag.length
+    currentIndex = text.indexOf(commentStartTag, lastIndex)
+  }
+
+  result += text.substring(lastIndex)
+
+  return result
 }
 
 const decodeWithCdata = (text: string): string => {
@@ -197,7 +226,7 @@ export const parseString: ParseExactUtil<string> = (value) => {
       return
     }
 
-    const string = decodeWithCdata(value).trim()
+    const string = decodeWithCdata(stripComments(value)).trim()
 
     return string || undefined
   }


### PR DESCRIPTION
This PR strips XML comments from the text content of stop nodes, the same way CDATA markers already are.

- Strip XML comments (`<!-- ... -->`) from text content in stop node elements, similar to how CDATA markers are already stripped
- Comments inside stop nodes were preserved as raw text because the XML parser doesn't process stop node content

Closes #257
