### PR TITLE
Add XML comment stripping integration tests for RSS, Atom, and RDF

### DIFF
--- a/src/feeds/atom/parse/index.test.ts
+++ b/src/feeds/atom/parse/index.test.ts
@@ -1180,4 +1180,36 @@ describe('parse', () => {
       })
     })
   })
+
+  describe('xml comment stripping', () => {
+    it('should strip XML comments from element content', () => {
+      const value = `
+        <?xml version="1.0" encoding="UTF-8"?>
+        <feed xmlns="http://www.w3.org/2005/Atom">
+          <title>Test<!-- hidden --> Feed</title>
+          <id>urn:uuid:test</id>
+          <updated>2024-01-01T00:00:00Z</updated>
+          <entry>
+            <title>Post<!-- comment --> Title</title>
+            <id>urn:uuid:1</id>
+            <updated>2024-01-01T00:00:00Z</updated>
+          </entry>
+        </feed>
+      `
+      const expected = {
+        title: 'Test Feed',
+        id: 'urn:uuid:test',
+        updated: '2024-01-01T00:00:00Z',
+        entries: [
+          {
+            title: 'Post Title',
+            id: 'urn:uuid:1',
+            updated: '2024-01-01T00:00:00Z',
+          },
+        ],
+      }
+
+      expect(parse(value)).toEqual(expected)
+    })
+  })
 })

--- a/src/feeds/rdf/parse/index.test.ts
+++ b/src/feeds/rdf/parse/index.test.ts
@@ -1540,4 +1540,38 @@ describe('parse', () => {
       expect(parse(commonValue, { maxItems: undefined })).toEqual(expected)
     })
   })
+
+  describe('xml comment stripping', () => {
+    it('should strip XML comments from element content', () => {
+      const value = `
+        <?xml version="1.0" encoding="UTF-8"?>
+        <rdf:RDF
+          xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+          xmlns="http://purl.org/rss/1.0/">
+          <channel>
+            <title>Test<!-- hidden --> Feed</title>
+            <link>http://example.com</link>
+            <description>Test</description>
+          </channel>
+          <item>
+            <title>Post<!-- comment --> Title</title>
+            <link>http://example.com/post</link>
+          </item>
+        </rdf:RDF>
+      `
+      const expected = {
+        title: 'Test Feed',
+        link: 'http://example.com',
+        description: 'Test',
+        items: [
+          {
+            title: 'Post Title',
+            link: 'http://example.com/post',
+          },
+        ],
+      }
+
+      expect(parse(value)).toEqual(expected)
+    })
+  })
 })

--- a/src/feeds/rss/parse/index.test.ts
+++ b/src/feeds/rss/parse/index.test.ts
@@ -954,4 +954,30 @@ describe('parse', () => {
       expect(parse(value, { maxItems: undefined })).toEqual(expected)
     })
   })
+
+  describe('xml comment stripping', () => {
+    it('should strip XML comments from element content', () => {
+      const value = `
+        <?xml version="1.0" encoding="UTF-8"?>
+        <rss version="2.0">
+          <channel>
+            <title>Test<!-- hidden --> Feed</title>
+            <link>https://example.com</link>
+            <description>Test</description>
+            <item>
+              <title>Post<!-- comment --> Title</title>
+            </item>
+          </channel>
+        </rss>
+      `
+      const expected = {
+        title: 'Test Feed',
+        link: 'https://example.com',
+        description: 'Test',
+        items: [{ title: 'Post Title' }],
+      }
+
+      expect(parse(value)).toEqual(expected)
+    })
+  })
 })


### PR DESCRIPTION
This PR adds integration tests for XML comment stripping, covering RSS, Atom and RDF end to end.

- Add integration tests verifying XML comment stripping works end-to-end in RSS, Atom, and RDF feed parsing
- Complements the unit tests added in #258 with full parse pipeline coverage
