### PR TITLE
fix: Handle malformed RSS feeds with items, image, and textInput outside channel

### DIFF
--- a/src/feeds/rss/parse/config.ts
+++ b/src/feeds/rss/parse/config.ts
@@ -1,6 +1,33 @@
 import { XMLParser } from 'fast-xml-parser'
 import { parserConfig } from '../../../common/config.js'
 
+// These elements can appear both inside <channel> and as direct children of
+// <rss> in malformed feeds, so stop nodes are generated for both paths.
+const sharedStopNodes = [
+  'image.description',
+  'image.height',
+  'image.link',
+  'image.title',
+  'image.url',
+  'image.width',
+  'textinput.title',
+  'textinput.description',
+  'textinput.name',
+  'textinput.link',
+  'item.title',
+  'item.link',
+  'item.description',
+  // INFO: Added support for nested *.name under author to support cases as
+  // described here: https://github.com/macieklamberski/feedsmith/issues/22.
+  'item.author.name',
+  'item.category',
+  'item.comments',
+  'item.enclosure',
+  'item.guid',
+  'item.pubdate',
+  'item.source',
+]
+
 export const stopNodes = [
   'rss.channel.title',
   'rss.channel.link',
@@ -17,32 +44,11 @@ export const stopNodes = [
   'rss.channel.docs',
   'rss.channel.cloud',
   'rss.channel.ttl',
-  'rss.channel.image.description',
-  'rss.channel.image.height',
-  'rss.channel.image.link',
-  'rss.channel.image.title',
-  'rss.channel.image.url',
-  'rss.channel.image.width',
   'rss.channel.rating',
-  'rss.channel.textinput.title',
-  'rss.channel.textinput.description',
-  'rss.channel.textinput.name',
-  'rss.channel.textinput.link',
   'rss.channel.skiphours.hour',
   'rss.channel.skipdays.day',
-  'rss.channel.item.title',
-  'rss.channel.item.link',
-  'rss.channel.item.description',
-  // INFO: Added support for nested *.name under author to support cases as
-  // described here: https://github.com/macieklamberski/feedsmith/issues/22.
-  'rss.channel.item.author.name',
-  'rss.channel.item.category',
-  'rss.channel.item.comments',
-  'rss.channel.item.enclosure',
-  'rss.channel.item.guid',
-  'rss.channel.item.pubdate',
-  'rss.channel.item.source',
-  // TODO: What about the namespaces?
+  ...sharedStopNodes.map((node) => `rss.channel.${node}`),
+  ...sharedStopNodes.map((node) => `rss.${node}`),
 ]
 
 export const parser = new XMLParser({

--- a/src/feeds/rss/parse/utils.test.ts
+++ b/src/feeds/rss/parse/utils.test.ts
@@ -13,6 +13,9 @@ import {
   parseSource,
   parseTextInput,
   retrieveFeed,
+  retrieveImage,
+  retrieveItems,
+  retrieveTextInput,
 } from './utils.js'
 
 describe('parsePerson', () => {
@@ -1566,6 +1569,177 @@ describe('parseFeed', () => {
     }
 
     expect(parseFeed(value)).toEqual(expected)
+  })
+})
+
+describe('retrieveImage', () => {
+  it('should retrieve image from channel', () => {
+    const value = {
+      channel: {
+        image: {
+          url: 'https://example.com/image.jpg',
+          title: 'Channel Image',
+        },
+      },
+    }
+    const expected = {
+      url: 'https://example.com/image.jpg',
+      title: 'Channel Image',
+    }
+
+    expect(retrieveImage(value)).toEqual(expected)
+  })
+
+  it('should retrieve image from root when channel has no image', () => {
+    const value = {
+      channel: {
+        title: 'Feed Title',
+      },
+      image: {
+        url: 'https://example.com/outside.jpg',
+        title: 'Outside Image',
+      },
+    }
+    const expected = {
+      url: 'https://example.com/outside.jpg',
+      title: 'Outside Image',
+    }
+
+    expect(retrieveImage(value)).toEqual(expected)
+  })
+
+  it('should prefer channel image over root image', () => {
+    const value = {
+      channel: {
+        image: {
+          url: 'https://example.com/channel.jpg',
+          title: 'Channel Image',
+        },
+      },
+      image: {
+        url: 'https://example.com/outside.jpg',
+        title: 'Outside Image',
+      },
+    }
+    const expected = {
+      url: 'https://example.com/channel.jpg',
+      title: 'Channel Image',
+    }
+
+    expect(retrieveImage(value)).toEqual(expected)
+  })
+
+  it('should return undefined when no image exists', () => {
+    expect(retrieveImage({ channel: {} })).toBeUndefined()
+    expect(retrieveImage({})).toBeUndefined()
+    expect(retrieveImage(undefined)).toBeUndefined()
+  })
+})
+
+describe('retrieveTextInput', () => {
+  it('should retrieve textInput from channel', () => {
+    const value = {
+      channel: {
+        textinput: {
+          title: 'Search',
+          name: 'q',
+        },
+      },
+    }
+    const expected = {
+      title: 'Search',
+      name: 'q',
+    }
+
+    expect(retrieveTextInput(value)).toEqual(expected)
+  })
+
+  it('should retrieve textInput from root when channel has no textInput', () => {
+    const value = {
+      channel: {
+        title: 'Feed Title',
+      },
+      textinput: {
+        title: 'Outside Search',
+        name: 'query',
+      },
+    }
+    const expected = {
+      title: 'Outside Search',
+      name: 'query',
+    }
+
+    expect(retrieveTextInput(value)).toEqual(expected)
+  })
+
+  it('should prefer channel textInput over root textInput', () => {
+    const value = {
+      channel: {
+        textinput: {
+          title: 'Channel Search',
+          name: 'q',
+        },
+      },
+      textinput: {
+        title: 'Outside Search',
+        name: 'query',
+      },
+    }
+    const expected = {
+      title: 'Channel Search',
+      name: 'q',
+    }
+
+    expect(retrieveTextInput(value)).toEqual(expected)
+  })
+
+  it('should return undefined when no textInput exists', () => {
+    expect(retrieveTextInput({ channel: {} })).toBeUndefined()
+    expect(retrieveTextInput({})).toBeUndefined()
+    expect(retrieveTextInput(undefined)).toBeUndefined()
+  })
+})
+
+describe('retrieveItems', () => {
+  it('should retrieve items from channel', () => {
+    const value = {
+      channel: {
+        item: [{ title: 'Item 1' }, { title: 'Item 2' }],
+      },
+    }
+    const expected = [{ title: 'Item 1' }, { title: 'Item 2' }]
+
+    expect(retrieveItems(value)).toEqual(expected)
+  })
+
+  it('should retrieve items from root when channel has no items', () => {
+    const value = {
+      channel: {
+        title: 'Feed Title',
+      },
+      item: [{ title: 'Outside Item 1' }, { title: 'Outside Item 2' }],
+    }
+    const expected = [{ title: 'Outside Item 1' }, { title: 'Outside Item 2' }]
+
+    expect(retrieveItems(value)).toEqual(expected)
+  })
+
+  it('should prefer channel items over root items', () => {
+    const value = {
+      channel: {
+        item: { title: 'Channel Item' },
+      },
+      item: { title: 'Outside Item' },
+    }
+    const expected = [{ title: 'Channel Item' }]
+
+    expect(retrieveItems(value)).toEqual(expected)
+  })
+
+  it('should return undefined when no items exist', () => {
+    expect(retrieveItems({ channel: {} })).toBeUndefined()
+    expect(retrieveItems({})).toBeUndefined()
+    expect(retrieveItems(undefined)).toBeUndefined()
   })
 })
 

--- a/src/feeds/rss/parse/utils.test.ts
+++ b/src/feeds/rss/parse/utils.test.ts
@@ -1053,7 +1053,7 @@ describe('parseFeed', () => {
   }
 
   it('should parse complete feed object (with #text)', () => {
-    const value = {
+    const channel = {
       title: { '#text': 'Feed Title' },
       link: { '#text': 'https://example.com' },
       description: { '#text': 'Feed Description' },
@@ -1106,12 +1106,13 @@ describe('parseFeed', () => {
         },
       ],
     }
+    const value = { channel }
 
     expect(parseFeed(value)).toEqual(expectedFull)
   })
 
   it('should parse complete feed object (without #text)', () => {
-    const value = {
+    const channel = {
       title: 'Feed Title',
       link: 'https://example.com',
       description: 'Feed Description',
@@ -1164,12 +1165,13 @@ describe('parseFeed', () => {
         },
       ],
     }
+    const value = { channel }
 
     expect(parseFeed(value)).toEqual(expectedFull)
   })
 
   it('should parse complete feed object (with array of values)', () => {
-    const value = {
+    const channel = {
       title: ['Feed Title', 'Alternative Feed Title'],
       link: ['https://example.com', 'https://example.com/alternate'],
       description: ['Feed Description', 'Extended Feed Description'],
@@ -1243,14 +1245,16 @@ describe('parseFeed', () => {
         },
       ],
     }
+    const value = { channel }
 
     expect(parseFeed(value)).toEqual(expectedFull)
   })
 
   it('should handle minimal feed with only required fields', () => {
-    const value = {
+    const channel = {
       title: { '#text': 'Feed Title' },
     }
+    const value = { channel }
     const expected = {
       title: 'Feed Title',
     }
@@ -1259,9 +1263,10 @@ describe('parseFeed', () => {
   })
 
   it('should handle partial objects (missing required fields)', () => {
-    const value = {
+    const channel = {
       description: { '#text': 'Feed Description' },
     }
+    const value = { channel }
     const expected = {
       description: 'Feed Description',
     }
@@ -1270,7 +1275,7 @@ describe('parseFeed', () => {
   })
 
   it('should handle coercible values', () => {
-    const value = {
+    const channel = {
       title: { '#text': 123 },
       link: { '#text': 456 },
       ttl: { '#text': '60' },
@@ -1282,6 +1287,7 @@ describe('parseFeed', () => {
         },
       ],
     }
+    const value = { channel }
     const expected = {
       title: '123',
       link: '456',
@@ -1305,7 +1311,7 @@ describe('parseFeed', () => {
   })
 
   it('should handle complex nested structures', () => {
-    const value = {
+    const channel = {
       title: { '#text': 'Feed Title' },
       link: { '#text': 'https://example.com' },
       item: [
@@ -1335,6 +1341,7 @@ describe('parseFeed', () => {
         width: { '#text': '32' },
       },
     }
+    const value = { channel }
     const expected = {
       title: 'Feed Title',
       link: 'https://example.com',
@@ -1372,11 +1379,12 @@ describe('parseFeed', () => {
   })
 
   it('should handle atom namespace', () => {
-    const value = {
+    const channel = {
       title: { '#text': 'Feed Title' },
       link: { '#text': 'https://example.com' },
       'atom:link': { '@href': 'http://example.com', '@rel': 'self' },
     }
+    const value = { channel }
     const expected = {
       title: 'Feed Title',
       link: 'https://example.com',
@@ -1387,11 +1395,12 @@ describe('parseFeed', () => {
   })
 
   it('should handle dc namespace', () => {
-    const value = {
+    const channel = {
       title: { '#text': 'Feed Title' },
       link: { '#text': 'https://example.com' },
       'dc:creator': { '#text': 'John Doe' },
     }
+    const value = { channel }
     const expected = {
       title: 'Feed Title',
       link: 'https://example.com',
@@ -1405,11 +1414,12 @@ describe('parseFeed', () => {
   })
 
   it('should handle sy namespace', () => {
-    const value = {
+    const channel = {
       title: { '#text': 'Example Feed' },
       link: { '#text': 'https://example.com' },
       'sy:updatefrequency': { '#text': '5' },
     }
+    const value = { channel }
     const expected = {
       title: 'Example Feed',
       link: 'https://example.com',
@@ -1420,12 +1430,13 @@ describe('parseFeed', () => {
   })
 
   it('should handle dcterms namespace', () => {
-    const value = {
+    const channel = {
       title: { '#text': 'Example Feed' },
       link: { '#text': 'https://example.com' },
       'dcterms:created': { '#text': '2023-01-01T00:00:00Z' },
       'dcterms:license': { '#text': 'Creative Commons Attribution 4.0' },
     }
+    const value = { channel }
     const expected = {
       title: 'Example Feed',
       link: 'https://example.com',
@@ -1440,12 +1451,13 @@ describe('parseFeed', () => {
   })
 
   it('should handle itunes namespace', () => {
-    const value = {
+    const channel = {
       title: { '#text': 'Podcast Feed' },
       link: { '#text': 'https://example.com' },
       'itunes:author': { '#text': 'Podcast Author' },
       'itunes:category': { '@text': 'Technology' },
     }
+    const value = { channel }
     const expected = {
       title: 'Podcast Feed',
       link: 'https://example.com',
@@ -1459,11 +1471,12 @@ describe('parseFeed', () => {
   })
 
   it('should handle podcast namespace', () => {
-    const value = {
+    const channel = {
       title: { '#text': 'Podcast 2.0 Feed' },
       link: { '#text': 'https://example.com' },
       'podcast:guid': { '#text': 'podcast-feed-guid-123' },
     }
+    const value = { channel }
     const expected = {
       title: 'Podcast 2.0 Feed',
       link: 'https://example.com',
@@ -1476,11 +1489,12 @@ describe('parseFeed', () => {
   })
 
   it('should handle media namespace', () => {
-    const value = {
+    const channel = {
       title: { '#text': 'Media Feed' },
       link: { '#text': 'https://example.com' },
       'media:copyright': { '#text': '2024 Example Corp' },
     }
+    const value = { channel }
     const expected = {
       title: 'Media Feed',
       link: 'https://example.com',
@@ -1493,11 +1507,12 @@ describe('parseFeed', () => {
   })
 
   it('should handle georss namespace', () => {
-    const value = {
+    const channel = {
       title: { '#text': 'Location Feed' },
       link: { '#text': 'https://example.com' },
       'georss:point': { '#text': '37.7749 -122.4194' },
     }
+    const value = { channel }
     const expected = {
       title: 'Location Feed',
       link: 'https://example.com',
@@ -1510,12 +1525,13 @@ describe('parseFeed', () => {
   })
 
   it('should handle source namespace', () => {
-    const value = {
+    const channel = {
       title: { '#text': 'Source Feed' },
       link: { '#text': 'https://example.com' },
       'source:account': { '@service': 'twitter', '#text': 'johndoe' },
       'source:blogroll': { '#text': 'https://example.com/blogroll.opml' },
     }
+    const value = { channel }
     const expected = {
       title: 'Source Feed',
       link: 'https://example.com',
@@ -1529,7 +1545,7 @@ describe('parseFeed', () => {
   })
 
   it('should handle admin namespace', () => {
-    const value = {
+    const channel = {
       title: { '#text': 'Admin Feed' },
       link: { '#text': 'https://example.com' },
       'admin:errorreportsto': {
@@ -1539,6 +1555,7 @@ describe('parseFeed', () => {
         '@rdf:resource': 'http://www.movabletype.org/?v=3.2',
       },
     }
+    const value = { channel }
     const expected = {
       title: 'Admin Feed',
       link: 'https://example.com',
@@ -1601,5 +1618,156 @@ describe('retrieveFeed', () => {
     }
 
     expect(retrieveFeed(value)).toEqual(expectedFull)
+  })
+
+  describe('lenient parsing', () => {
+    it('should use items placed outside channel as fallback', () => {
+      const value = {
+        rss: {
+          channel: {
+            title: 'Feed Title',
+            link: 'https://example.com',
+          },
+          item: [{ title: 'Outside Item 1' }, { title: 'Outside Item 2' }],
+        },
+      }
+      const expected = {
+        title: 'Feed Title',
+        link: 'https://example.com',
+        items: [{ title: 'Outside Item 1' }, { title: 'Outside Item 2' }],
+      }
+
+      expect(retrieveFeed(value)).toEqual(expected)
+    })
+
+    it('should prefer channel items over outside items', () => {
+      const value = {
+        rss: {
+          channel: {
+            title: 'Feed Title',
+            link: 'https://example.com',
+            item: { title: 'Channel Item' },
+          },
+          item: { title: 'Outside Item' },
+        },
+      }
+      const expected = {
+        title: 'Feed Title',
+        link: 'https://example.com',
+        items: [{ title: 'Channel Item' }],
+      }
+
+      expect(retrieveFeed(value)).toEqual(expected)
+    })
+
+    it('should use image placed outside channel as fallback', () => {
+      const value = {
+        rss: {
+          channel: {
+            title: 'Feed Title',
+            link: 'https://example.com',
+          },
+          image: {
+            url: 'https://example.com/image.jpg',
+            title: 'Outside Image',
+          },
+        },
+      }
+      const expected = {
+        title: 'Feed Title',
+        link: 'https://example.com',
+        image: {
+          url: 'https://example.com/image.jpg',
+          title: 'Outside Image',
+        },
+      }
+
+      expect(retrieveFeed(value)).toEqual(expected)
+    })
+
+    it('should prefer channel image over outside image', () => {
+      const value = {
+        rss: {
+          channel: {
+            title: 'Feed Title',
+            link: 'https://example.com',
+            image: {
+              url: 'https://example.com/channel-image.jpg',
+              title: 'Channel Image',
+            },
+          },
+          image: {
+            url: 'https://example.com/outside-image.jpg',
+            title: 'Outside Image',
+          },
+        },
+      }
+      const expected = {
+        title: 'Feed Title',
+        link: 'https://example.com',
+        image: {
+          url: 'https://example.com/channel-image.jpg',
+          title: 'Channel Image',
+        },
+      }
+
+      expect(retrieveFeed(value)).toEqual(expected)
+    })
+
+    it('should use textInput placed outside channel as fallback', () => {
+      const value = {
+        rss: {
+          channel: {
+            title: 'Feed Title',
+            link: 'https://example.com',
+          },
+          textinput: {
+            title: 'Search',
+            name: 'q',
+            link: 'https://example.com/search',
+          },
+        },
+      }
+      const expected = {
+        title: 'Feed Title',
+        link: 'https://example.com',
+        textInput: {
+          title: 'Search',
+          name: 'q',
+          link: 'https://example.com/search',
+        },
+      }
+
+      expect(retrieveFeed(value)).toEqual(expected)
+    })
+
+    it('should prefer channel textInput over outside textInput', () => {
+      const value = {
+        rss: {
+          channel: {
+            title: 'Feed Title',
+            link: 'https://example.com',
+            textinput: {
+              title: 'Channel Search',
+              name: 'q',
+            },
+          },
+          textinput: {
+            title: 'Outside Search',
+            name: 'query',
+          },
+        },
+      }
+      const expected = {
+        title: 'Feed Title',
+        link: 'https://example.com',
+        textInput: {
+          title: 'Channel Search',
+          name: 'q',
+        },
+      }
+
+      expect(retrieveFeed(value)).toEqual(expected)
+    })
   })
 })

--- a/src/feeds/rss/parse/utils.ts
+++ b/src/feeds/rss/parse/utils.ts
@@ -6,6 +6,7 @@ import {
   parseBoolean,
   parseDate,
   parseNumber,
+  parseSingular,
   parseSingularOf,
   parseString,
   retrieveText,
@@ -133,6 +134,33 @@ export const parseTextInput: ParsePartialUtil<Rss.TextInput> = (value) => {
   return trimObject(textInput)
 }
 
+export const retrieveImage: ParsePartialUtil<Rss.Image> = (value) => {
+  const channel = parseSingular(value?.channel)
+
+  return parseSingularOf(channel?.image, parseImage) ?? parseSingularOf(value?.image, parseImage)
+}
+
+export const retrieveTextInput: ParsePartialUtil<Rss.TextInput> = (value) => {
+  const channel = parseSingular(value?.channel)
+
+  return (
+    parseSingularOf(channel?.textinput, parseTextInput) ??
+    parseSingularOf(value?.textinput, parseTextInput)
+  )
+}
+
+export const retrieveItems: ParsePartialUtil<Array<Rss.Item<string>>, ParseOptions> = (
+  value,
+  options,
+) => {
+  const channel = parseSingular(value?.channel)
+
+  return (
+    parseArrayOf(channel?.item, parseItem, options?.maxItems) ??
+    parseArrayOf(value?.item, parseItem, options?.maxItems)
+  )
+}
+
 export const parseSkipHours: ParsePartialUtil<Array<number>> = (value) => {
   return trimArray(value?.hour, (value) => parseNumber(retrieveText(value)))
 }
@@ -221,61 +249,65 @@ export const parseItem: ParsePartialUtil<Rss.Item<string>> = (value) => {
 }
 
 export const parseFeed: ParsePartialUtil<Rss.Feed<string>, ParseOptions> = (value, options) => {
-  if (!isObject(value)) {
+  const channel = parseSingular(value?.channel)
+
+  if (!isObject(channel)) {
     return
   }
 
-  const namespaces = detectNamespaces(value)
+  const namespaces = detectNamespaces(channel)
   const feed = {
-    title: parseSingularOf(value.title, (value) => parseString(retrieveText(value))),
-    link: parseSingularOf(value.link, (value) => parseString(retrieveText(value))),
-    description: parseSingularOf(value.description, (value) => parseString(retrieveText(value))),
-    language: parseSingularOf(value.language, (value) => parseString(retrieveText(value))),
-    copyright: parseSingularOf(value.copyright, (value) => parseString(retrieveText(value))),
-    managingEditor: parseSingularOf(value.managingeditor, parsePerson),
-    webMaster: parseSingularOf(value.webmaster, parsePerson),
-    pubDate: parseSingularOf(value.pubdate, (value) => parseDate(retrieveText(value))),
-    lastBuildDate: parseSingularOf(value.lastbuilddate, (value) => parseDate(retrieveText(value))),
-    categories: parseArrayOf(value.category, parseCategory),
-    generator: parseSingularOf(value.generator, (value) => parseString(retrieveText(value))),
-    docs: parseSingularOf(value.docs, (value) => parseString(retrieveText(value))),
-    cloud: parseSingularOf(value.cloud, parseCloud),
-    ttl: parseSingularOf(value.ttl, (value) => parseNumber(retrieveText(value))),
-    image: parseSingularOf(value.image, parseImage),
-    rating: parseSingularOf(value.rating, (value) => parseString(retrieveText(value))),
-    textInput: parseSingularOf(value.textinput, parseTextInput),
-    skipHours: parseSingularOf(value.skiphours, parseSkipHours),
-    skipDays: parseSingularOf(value.skipdays, parseSkipDays),
-    items: parseArrayOf(value.item, parseItem, options?.maxItems),
-    atom: namespaces.has('atom') ? retrieveAtomFeed(value) : undefined,
-    cc: namespaces.has('cc') ? retrieveCc(value) : undefined,
-    dc: namespaces.has('dc') ? retrieveDcItemOrFeed(value) : undefined,
-    sy: namespaces.has('sy') ? retrieveSyFeed(value) : undefined,
-    itunes: namespaces.has('itunes') ? retrieveItunesFeed(value) : undefined,
-    podcast: namespaces.has('podcast') ? retrievePodcastFeed(value) : undefined,
-    googleplay: namespaces.has('googleplay') ? retrieveGooglePlayFeed(value) : undefined,
-    media: namespaces.has('media') ? retrieveMediaItemOrFeed(value) : undefined,
-    georss: namespaces.has('georss') ? retrieveGeoRssItemOrFeed(value) : undefined,
-    geo: namespaces.has('geo') ? retrieveGeoItemOrFeed(value) : undefined,
-    dcterms: namespaces.has('dcterms') ? retrieveDctermsItemOrFeed(value) : undefined,
-    prism: namespaces.has('prism') ? retrievePrismFeed(value) : undefined,
+    title: parseSingularOf(channel.title, (value) => parseString(retrieveText(value))),
+    link: parseSingularOf(channel.link, (value) => parseString(retrieveText(value))),
+    description: parseSingularOf(channel.description, (value) => parseString(retrieveText(value))),
+    language: parseSingularOf(channel.language, (value) => parseString(retrieveText(value))),
+    copyright: parseSingularOf(channel.copyright, (value) => parseString(retrieveText(value))),
+    managingEditor: parseSingularOf(channel.managingeditor, parsePerson),
+    webMaster: parseSingularOf(channel.webmaster, parsePerson),
+    pubDate: parseSingularOf(channel.pubdate, (value) => parseDate(retrieveText(value))),
+    lastBuildDate: parseSingularOf(channel.lastbuilddate, (value) =>
+      parseDate(retrieveText(value)),
+    ),
+    categories: parseArrayOf(channel.category, parseCategory),
+    generator: parseSingularOf(channel.generator, (value) => parseString(retrieveText(value))),
+    docs: parseSingularOf(channel.docs, (value) => parseString(retrieveText(value))),
+    cloud: parseSingularOf(channel.cloud, parseCloud),
+    ttl: parseSingularOf(channel.ttl, (value) => parseNumber(retrieveText(value))),
+    image: retrieveImage(value),
+    rating: parseSingularOf(channel.rating, (value) => parseString(retrieveText(value))),
+    textInput: retrieveTextInput(value),
+    skipHours: parseSingularOf(channel.skiphours, parseSkipHours),
+    skipDays: parseSingularOf(channel.skipdays, parseSkipDays),
+    items: retrieveItems(value, options),
+    atom: namespaces.has('atom') ? retrieveAtomFeed(channel) : undefined,
+    cc: namespaces.has('cc') ? retrieveCc(channel) : undefined,
+    dc: namespaces.has('dc') ? retrieveDcItemOrFeed(channel) : undefined,
+    sy: namespaces.has('sy') ? retrieveSyFeed(channel) : undefined,
+    itunes: namespaces.has('itunes') ? retrieveItunesFeed(channel) : undefined,
+    podcast: namespaces.has('podcast') ? retrievePodcastFeed(channel) : undefined,
+    googleplay: namespaces.has('googleplay') ? retrieveGooglePlayFeed(channel) : undefined,
+    media: namespaces.has('media') ? retrieveMediaItemOrFeed(channel) : undefined,
+    georss: namespaces.has('georss') ? retrieveGeoRssItemOrFeed(channel) : undefined,
+    geo: namespaces.has('geo') ? retrieveGeoItemOrFeed(channel) : undefined,
+    dcterms: namespaces.has('dcterms') ? retrieveDctermsItemOrFeed(channel) : undefined,
+    prism: namespaces.has('prism') ? retrievePrismFeed(channel) : undefined,
     creativeCommons: namespaces.has('creativecommons')
-      ? retrieveCreativeCommonsItemOrFeed(value)
+      ? retrieveCreativeCommonsItemOrFeed(channel)
       : undefined,
-    feedpress: namespaces.has('feedpress') ? retrieveFeedPressFeed(value) : undefined,
-    opensearch: namespaces.has('opensearch') ? retrieveOpenSearchFeed(value) : undefined,
-    admin: namespaces.has('admin') ? retrieveAdminFeed(value) : undefined,
-    sourceNs: namespaces.has('source') ? retrieveSourceFeed(value) : undefined,
-    blogChannel: namespaces.has('blogchannel') ? retrieveBlogChannelFeed(value) : undefined,
-    rawvoice: namespaces.has('rawvoice') ? retrieveRawVoiceFeed(value) : undefined,
-    spotify: namespaces.has('spotify') ? retrieveSpotifyFeed(value) : undefined,
-    pingback: namespaces.has('pingback') ? retrievePingbackFeed(value) : undefined,
-    acast: namespaces.has('acast') ? retrieveAcastFeed(value) : undefined,
+    feedpress: namespaces.has('feedpress') ? retrieveFeedPressFeed(channel) : undefined,
+    opensearch: namespaces.has('opensearch') ? retrieveOpenSearchFeed(channel) : undefined,
+    admin: namespaces.has('admin') ? retrieveAdminFeed(channel) : undefined,
+    sourceNs: namespaces.has('source') ? retrieveSourceFeed(channel) : undefined,
+    blogChannel: namespaces.has('blogchannel') ? retrieveBlogChannelFeed(channel) : undefined,
+    rawvoice: namespaces.has('rawvoice') ? retrieveRawVoiceFeed(channel) : undefined,
+    spotify: namespaces.has('spotify') ? retrieveSpotifyFeed(channel) : undefined,
+    pingback: namespaces.has('pingback') ? retrievePingbackFeed(channel) : undefined,
+    acast: namespaces.has('acast') ? retrieveAcastFeed(channel) : undefined,
   }
 
   return trimObject(feed)
 }
 
 export const retrieveFeed: ParsePartialUtil<Rss.Feed<string>, ParseOptions> = (value, options) => {
-  return parseSingularOf(value?.rss?.channel, (value) => parseFeed(value, options))
+  return parseSingularOf(value?.rss, (value) => parseFeed(value, options))
 }


### PR DESCRIPTION
This PR handles malformed RSS feeds that place `<item>`, `<image>` or `<textInput>` as siblings of `<channel>` instead of children.

- Leniently handle malformed RSS feeds where `<item>`, `<image>`, or `<textInput>` are placed as siblings of `<channel>` instead of children
- Channel elements are preferred; outside-channel elements are used as fallback
- Extract `retrieveImage`, `retrieveTextInput`, `retrieveItems` helpers (matching the RDF pattern) to DRY element retrieval from both locations
- Refactor `parseFeed` to receive the `<rss>` level value and extract `<channel>` internally

Closes #260
