### PR TITLE
test: Add real-world feed parsing tests covering edge cases and malformed feeds

### DIFF
--- a/src/feeds/atom/parse/index.test.ts
+++ b/src/feeds/atom/parse/index.test.ts
@@ -1181,8 +1181,1991 @@ describe('parse', () => {
     })
   })
 
+  // Catalogue: plans/real_world_test_suite.md
   describe('real world feeds', () => {
-    // TODO: Add real world feeds with problematic edge cases.
+    describe('character encoding', () => {
+      it('RW-E01: should decode HTML numeric character references in entry title', () => {
+        const value = `
+          <?xml version="1.0" encoding="UTF-8"?>
+          <feed xmlns="http://www.w3.org/2005/Atom">
+            <title>Test</title>
+            <id>urn:uuid:test</id>
+            <updated>2024-01-01T00:00:00Z</updated>
+            <entry>
+              <title>Caf&#233; Culture</title>
+              <id>urn:uuid:1</id>
+              <updated>2024-01-01T00:00:00Z</updated>
+            </entry>
+          </feed>
+        `
+        const expected = {
+          title: 'Test',
+          id: 'urn:uuid:test',
+          updated: '2024-01-01T00:00:00Z',
+          entries: [{
+            title: 'Caf\u00e9 Culture',
+            id: 'urn:uuid:1',
+            updated: '2024-01-01T00:00:00Z',
+          }],
+        }
+
+        expect(parse(value)).toEqual(expected)
+      })
+
+      it('RW-E03: should decode named HTML entities in summary', () => {
+        const value = `
+          <?xml version="1.0" encoding="UTF-8"?>
+          <feed xmlns="http://www.w3.org/2005/Atom">
+            <title>Test</title>
+            <id>urn:uuid:test</id>
+            <updated>2024-01-01T00:00:00Z</updated>
+            <entry>
+              <title>Post</title>
+              <id>urn:uuid:1</id>
+              <updated>2024-01-01T00:00:00Z</updated>
+              <summary>First &ndash; Second</summary>
+            </entry>
+          </feed>
+        `
+        const expected = {
+          title: 'Test',
+          id: 'urn:uuid:test',
+          updated: '2024-01-01T00:00:00Z',
+          entries: [{
+            title: 'Post',
+            id: 'urn:uuid:1',
+            updated: '2024-01-01T00:00:00Z',
+            summary: 'First \u2013 Second',
+          }],
+        }
+
+        expect(parse(value)).toEqual(expected)
+      })
+
+      it('RW-E04: should single-decode double-encoded entities', () => {
+        const value = `
+          <?xml version="1.0" encoding="UTF-8"?>
+          <feed xmlns="http://www.w3.org/2005/Atom">
+            <title>Test</title>
+            <id>urn:uuid:test</id>
+            <updated>2024-01-01T00:00:00Z</updated>
+            <entry>
+              <title>Tom &amp;amp; Jerry</title>
+              <id>urn:uuid:1</id>
+              <updated>2024-01-01T00:00:00Z</updated>
+            </entry>
+          </feed>
+        `
+        const expected = {
+          title: 'Test',
+          id: 'urn:uuid:test',
+          updated: '2024-01-01T00:00:00Z',
+          entries: [{
+            title: 'Tom &amp; Jerry',
+            id: 'urn:uuid:1',
+            updated: '2024-01-01T00:00:00Z',
+          }],
+        }
+
+        expect(parse(value)).toEqual(expected)
+      })
+    })
+
+    describe('content handling', () => {
+      it('RW-D12: should parse entry content with HTML in CDATA', () => {
+        const value = `
+          <?xml version="1.0" encoding="UTF-8"?>
+          <feed xmlns="http://www.w3.org/2005/Atom">
+            <title>Test</title>
+            <id>urn:uuid:test</id>
+            <updated>2024-01-01T00:00:00Z</updated>
+            <entry>
+              <title>Post</title>
+              <id>urn:uuid:1</id>
+              <updated>2024-01-01T00:00:00Z</updated>
+              <content><![CDATA[<p>Full <strong>HTML</strong> content</p>]]></content>
+            </entry>
+          </feed>
+        `
+        const expected = {
+          title: 'Test',
+          id: 'urn:uuid:test',
+          updated: '2024-01-01T00:00:00Z',
+          entries: [{
+            title: 'Post',
+            id: 'urn:uuid:1',
+            updated: '2024-01-01T00:00:00Z',
+            content: '<p>Full <strong>HTML</strong> content</p>',
+          }],
+        }
+
+        expect(parse(value)).toEqual(expected)
+      })
+
+      it('RW-D05: should parse entry with both summary and content', () => {
+        const value = `
+          <?xml version="1.0" encoding="UTF-8"?>
+          <feed xmlns="http://www.w3.org/2005/Atom">
+            <title>Test</title>
+            <id>urn:uuid:test</id>
+            <updated>2024-01-01T00:00:00Z</updated>
+            <entry>
+              <title>Post</title>
+              <id>urn:uuid:1</id>
+              <updated>2024-01-01T00:00:00Z</updated>
+              <summary>A brief summary</summary>
+              <content>Full content here</content>
+            </entry>
+          </feed>
+        `
+        const expected = {
+          title: 'Test',
+          id: 'urn:uuid:test',
+          updated: '2024-01-01T00:00:00Z',
+          entries: [{
+            title: 'Post',
+            id: 'urn:uuid:1',
+            updated: '2024-01-01T00:00:00Z',
+            summary: 'A brief summary',
+            content: 'Full content here',
+          }],
+        }
+
+        expect(parse(value)).toEqual(expected)
+      })
+
+      it('RW-D11: should handle empty content element', () => {
+        const value = `
+          <?xml version="1.0" encoding="UTF-8"?>
+          <feed xmlns="http://www.w3.org/2005/Atom">
+            <title>Test</title>
+            <id>urn:uuid:test</id>
+            <updated>2024-01-01T00:00:00Z</updated>
+            <entry>
+              <title>Post</title>
+              <id>urn:uuid:1</id>
+              <updated>2024-01-01T00:00:00Z</updated>
+              <content/>
+            </entry>
+          </feed>
+        `
+        const expected = {
+          title: 'Test',
+          id: 'urn:uuid:test',
+          updated: '2024-01-01T00:00:00Z',
+          entries: [{
+            title: 'Post',
+            id: 'urn:uuid:1',
+            updated: '2024-01-01T00:00:00Z',
+          }],
+        }
+
+        expect(parse(value)).toEqual(expected)
+      })
+
+      it('RW-D07: should extract raw content from type="xhtml" with div wrapper', () => {
+        const value = `
+          <?xml version="1.0" encoding="UTF-8"?>
+          <feed xmlns="http://www.w3.org/2005/Atom">
+            <title>Test</title>
+            <id>urn:uuid:test</id>
+            <updated>2024-01-01T00:00:00Z</updated>
+            <entry>
+              <title>Post</title>
+              <id>urn:uuid:1</id>
+              <updated>2024-01-01T00:00:00Z</updated>
+              <content type="xhtml"><div xmlns="http://www.w3.org/1999/xhtml"><p>Hello <em>world</em></p></div></content>
+            </entry>
+          </feed>
+        `
+        const expected = {
+          title: 'Test',
+          id: 'urn:uuid:test',
+          updated: '2024-01-01T00:00:00Z',
+          entries: [{
+            title: 'Post',
+            id: 'urn:uuid:1',
+            updated: '2024-01-01T00:00:00Z',
+            content: '<div xmlns="http://www.w3.org/1999/xhtml"><p>Hello <em>world</em></p></div>',
+          }],
+        }
+
+        expect(parse(value)).toEqual(expected)
+      })
+
+      it('RW-D13: should parse content with src attribute as empty (src not captured)', () => {
+        const value = `
+          <?xml version="1.0" encoding="UTF-8"?>
+          <feed xmlns="http://www.w3.org/2005/Atom">
+            <title>Test</title>
+            <id>urn:uuid:test</id>
+            <updated>2024-01-01T00:00:00Z</updated>
+            <entry>
+              <title>Post</title>
+              <id>urn:uuid:1</id>
+              <updated>2024-01-01T00:00:00Z</updated>
+              <content type="text/html" src="https://example.com/content.html"/>
+            </entry>
+          </feed>
+        `
+        const expected = {
+          title: 'Test',
+          id: 'urn:uuid:test',
+          updated: '2024-01-01T00:00:00Z',
+          entries: [{
+            title: 'Post',
+            id: 'urn:uuid:1',
+            updated: '2024-01-01T00:00:00Z',
+          }],
+        }
+
+        expect(parse(value)).toEqual(expected)
+      })
+
+      it('RW-D17: should preserve raw XHTML content with nested div', () => {
+        const value = `
+          <?xml version="1.0" encoding="UTF-8"?>
+          <feed xmlns="http://www.w3.org/2005/Atom">
+            <title>Test</title>
+            <id>urn:uuid:test</id>
+            <updated>2024-01-01T00:00:00Z</updated>
+            <entry>
+              <title>Post</title>
+              <id>urn:uuid:1</id>
+              <updated>2024-01-01T00:00:00Z</updated>
+              <content type="xhtml"><div xmlns="http://www.w3.org/1999/xhtml"><div class="article"><p>Text</p></div></div></content>
+            </entry>
+          </feed>
+        `
+        const expected = {
+          title: 'Test',
+          id: 'urn:uuid:test',
+          updated: '2024-01-01T00:00:00Z',
+          entries: [{
+            title: 'Post',
+            id: 'urn:uuid:1',
+            updated: '2024-01-01T00:00:00Z',
+            content: '<div xmlns="http://www.w3.org/1999/xhtml"><div class="article"><p>Text</p></div></div>',
+          }],
+        }
+
+        expect(parse(value)).toEqual(expected)
+      })
+
+      it('RW-D19: should parse content with non-text MIME type as plain text', () => {
+        const value = `
+          <?xml version="1.0" encoding="UTF-8"?>
+          <feed xmlns="http://www.w3.org/2005/Atom">
+            <title>Test</title>
+            <id>urn:uuid:test</id>
+            <updated>2024-01-01T00:00:00Z</updated>
+            <entry>
+              <title>Post</title>
+              <id>urn:uuid:1</id>
+              <updated>2024-01-01T00:00:00Z</updated>
+              <content type="image/png">iVBORw0KGgo=</content>
+            </entry>
+          </feed>
+        `
+        const expected = {
+          title: 'Test',
+          id: 'urn:uuid:test',
+          updated: '2024-01-01T00:00:00Z',
+          entries: [{
+            title: 'Post',
+            id: 'urn:uuid:1',
+            updated: '2024-01-01T00:00:00Z',
+            content: 'iVBORw0KGgo=',
+          }],
+        }
+
+        expect(parse(value)).toEqual(expected)
+      })
+
+      it('RW-D20: should decode entity-encoded markup in type="text" title', () => {
+        const value = `
+          <?xml version="1.0" encoding="UTF-8"?>
+          <feed xmlns="http://www.w3.org/2005/Atom">
+            <title type="text">&lt;b&gt;Bold Title&lt;/b&gt;</title>
+            <id>urn:uuid:test</id>
+            <updated>2024-01-01T00:00:00Z</updated>
+          </feed>
+        `
+        const expected = {
+          title: '<b>Bold Title</b>',
+          id: 'urn:uuid:test',
+          updated: '2024-01-01T00:00:00Z',
+        }
+
+        expect(parse(value)).toEqual(expected)
+      })
+
+      it('RW-D21: should preserve raw XHTML content without div wrapper', () => {
+        const value = `
+          <?xml version="1.0" encoding="UTF-8"?>
+          <feed xmlns="http://www.w3.org/2005/Atom">
+            <title>Test</title>
+            <id>urn:uuid:test</id>
+            <updated>2024-01-01T00:00:00Z</updated>
+            <entry>
+              <title>Post</title>
+              <id>urn:uuid:1</id>
+              <updated>2024-01-01T00:00:00Z</updated>
+              <content type="xhtml"><p>No wrapper</p></content>
+            </entry>
+          </feed>
+        `
+        const expected = {
+          title: 'Test',
+          id: 'urn:uuid:test',
+          updated: '2024-01-01T00:00:00Z',
+          entries: [{
+            title: 'Post',
+            id: 'urn:uuid:1',
+            updated: '2024-01-01T00:00:00Z',
+            content: '<p>No wrapper</p>',
+          }],
+        }
+
+        expect(parse(value)).toEqual(expected)
+      })
+    })
+
+    describe('link handling', () => {
+      it('RW-L04: should parse multiple link elements with different rel values', () => {
+        const value = `
+          <?xml version="1.0" encoding="UTF-8"?>
+          <feed xmlns="http://www.w3.org/2005/Atom">
+            <title>Test</title>
+            <id>urn:uuid:test</id>
+            <updated>2024-01-01T00:00:00Z</updated>
+            <link href="https://example.com/" rel="alternate"/>
+            <link href="https://example.com/feed.xml" rel="self" type="application/atom+xml"/>
+            <entry>
+              <title>Post</title>
+              <id>urn:uuid:1</id>
+              <updated>2024-01-01T00:00:00Z</updated>
+              <link href="https://example.com/post/1" rel="alternate"/>
+              <link href="https://example.com/post/1/comments" rel="replies"/>
+            </entry>
+          </feed>
+        `
+        const expected = {
+          title: 'Test',
+          id: 'urn:uuid:test',
+          updated: '2024-01-01T00:00:00Z',
+          links: [
+            { href: 'https://example.com/', rel: 'alternate' },
+            { href: 'https://example.com/feed.xml', rel: 'self', type: 'application/atom+xml' },
+          ],
+          entries: [{
+            title: 'Post',
+            id: 'urn:uuid:1',
+            updated: '2024-01-01T00:00:00Z',
+            links: [
+              { href: 'https://example.com/post/1', rel: 'alternate' },
+              { href: 'https://example.com/post/1/comments', rel: 'replies' },
+            ],
+          }],
+        }
+
+        expect(parse(value)).toEqual(expected)
+      })
+
+      it('RW-L05: should parse link with hreflang attribute', () => {
+        const value = `
+          <?xml version="1.0" encoding="UTF-8"?>
+          <feed xmlns="http://www.w3.org/2005/Atom">
+            <title>Test</title>
+            <id>urn:uuid:test</id>
+            <updated>2024-01-01T00:00:00Z</updated>
+            <entry>
+              <title>Post</title>
+              <id>urn:uuid:1</id>
+              <updated>2024-01-01T00:00:00Z</updated>
+              <link href="https://example.com/en/post" rel="alternate" hreflang="en"/>
+              <link href="https://example.com/fr/post" rel="alternate" hreflang="fr"/>
+            </entry>
+          </feed>
+        `
+        const expected = {
+          title: 'Test',
+          id: 'urn:uuid:test',
+          updated: '2024-01-01T00:00:00Z',
+          entries: [{
+            title: 'Post',
+            id: 'urn:uuid:1',
+            updated: '2024-01-01T00:00:00Z',
+            links: [
+              { href: 'https://example.com/en/post', rel: 'alternate', hreflang: 'en' },
+              { href: 'https://example.com/fr/post', rel: 'alternate', hreflang: 'fr' },
+            ],
+          }],
+        }
+
+        expect(parse(value)).toEqual(expected)
+      })
+
+      it('RW-L01: should preserve relative URLs in links', () => {
+        const value = `
+          <?xml version="1.0" encoding="UTF-8"?>
+          <feed xmlns="http://www.w3.org/2005/Atom">
+            <title>Test</title>
+            <id>urn:uuid:test</id>
+            <updated>2024-01-01T00:00:00Z</updated>
+            <entry>
+              <title>Post</title>
+              <id>urn:uuid:1</id>
+              <updated>2024-01-01T00:00:00Z</updated>
+              <link href="/blog/post-1" rel="alternate"/>
+            </entry>
+          </feed>
+        `
+        const expected = {
+          title: 'Test',
+          id: 'urn:uuid:test',
+          updated: '2024-01-01T00:00:00Z',
+          entries: [{
+            title: 'Post',
+            id: 'urn:uuid:1',
+            updated: '2024-01-01T00:00:00Z',
+            links: [{ href: '/blog/post-1', rel: 'alternate' }],
+          }],
+        }
+
+        expect(parse(value)).toEqual(expected)
+      })
+
+      it('RW-L11: should handle link with no href attribute', () => {
+        const value = `
+          <?xml version="1.0" encoding="UTF-8"?>
+          <feed xmlns="http://www.w3.org/2005/Atom">
+            <title>Test</title>
+            <id>urn:uuid:test</id>
+            <updated>2024-01-01T00:00:00Z</updated>
+            <link rel="alternate" type="text/html"/>
+            <entry>
+              <title>Post</title>
+              <id>urn:uuid:1</id>
+              <updated>2024-01-01T00:00:00Z</updated>
+              <link rel="alternate"/>
+            </entry>
+          </feed>
+        `
+        const expected = {
+          title: 'Test',
+          id: 'urn:uuid:test',
+          updated: '2024-01-01T00:00:00Z',
+          links: [{ rel: 'alternate', type: 'text/html' }],
+          entries: [{
+            title: 'Post',
+            id: 'urn:uuid:1',
+            updated: '2024-01-01T00:00:00Z',
+            links: [{ rel: 'alternate' }],
+          }],
+        }
+
+        expect(parse(value)).toEqual(expected)
+      })
+
+      it('RW-L18: should parse link rel="replies" after rel="alternate"', () => {
+        const value = `
+          <?xml version="1.0" encoding="UTF-8"?>
+          <feed xmlns="http://www.w3.org/2005/Atom">
+            <title>Test</title>
+            <id>urn:uuid:test</id>
+            <updated>2024-01-01T00:00:00Z</updated>
+            <entry>
+              <title>Post</title>
+              <id>urn:uuid:1</id>
+              <updated>2024-01-01T00:00:00Z</updated>
+              <link rel="alternate" href="https://example.com/post"/>
+              <link rel="replies" href="https://example.com/post/comments"/>
+            </entry>
+          </feed>
+        `
+        const expected = {
+          title: 'Test',
+          id: 'urn:uuid:test',
+          updated: '2024-01-01T00:00:00Z',
+          entries: [{
+            title: 'Post',
+            id: 'urn:uuid:1',
+            updated: '2024-01-01T00:00:00Z',
+            links: [
+              { href: 'https://example.com/post', rel: 'alternate' },
+              { href: 'https://example.com/post/comments', rel: 'replies' },
+            ],
+          }],
+        }
+
+        expect(parse(value)).toEqual(expected)
+      })
+
+      it('RW-L19: should fall back to text content as href when link has no href attribute', () => {
+        const value = `
+          <?xml version="1.0" encoding="UTF-8"?>
+          <feed xmlns="http://www.w3.org/2005/Atom">
+            <title>Test</title>
+            <id>urn:uuid:test</id>
+            <updated>2024-01-01T00:00:00Z</updated>
+            <entry>
+              <title>Post</title>
+              <id>urn:uuid:1</id>
+              <updated>2024-01-01T00:00:00Z</updated>
+              <link rel="enclosure" type="image/jpeg">https://example.com/image.jpg</link>
+              <link rel="alternate" href="https://example.com/post"/>
+            </entry>
+          </feed>
+        `
+        const expected = {
+          title: 'Test',
+          id: 'urn:uuid:test',
+          updated: '2024-01-01T00:00:00Z',
+          entries: [{
+            title: 'Post',
+            id: 'urn:uuid:1',
+            updated: '2024-01-01T00:00:00Z',
+            links: [
+              { href: 'https://example.com/image.jpg', rel: 'enclosure', type: 'image/jpeg' },
+              { href: 'https://example.com/post', rel: 'alternate' },
+            ],
+          }],
+        }
+
+        expect(parse(value)).toEqual(expected)
+      })
+    })
+
+    describe('author handling', () => {
+      it('RW-M03: should parse multiple authors on entry', () => {
+        const value = `
+          <?xml version="1.0" encoding="UTF-8"?>
+          <feed xmlns="http://www.w3.org/2005/Atom">
+            <title>Test</title>
+            <id>urn:uuid:test</id>
+            <updated>2024-01-01T00:00:00Z</updated>
+            <entry>
+              <title>Co-authored Post</title>
+              <id>urn:uuid:1</id>
+              <updated>2024-01-01T00:00:00Z</updated>
+              <author>
+                <name>Alice</name>
+                <email>alice@example.com</email>
+              </author>
+              <author>
+                <name>Bob</name>
+                <uri>https://bob.example.com</uri>
+              </author>
+            </entry>
+          </feed>
+        `
+        const expected = {
+          title: 'Test',
+          id: 'urn:uuid:test',
+          updated: '2024-01-01T00:00:00Z',
+          entries: [{
+            title: 'Co-authored Post',
+            id: 'urn:uuid:1',
+            updated: '2024-01-01T00:00:00Z',
+            authors: [
+              { name: 'Alice', email: 'alice@example.com' },
+              { name: 'Bob', uri: 'https://bob.example.com' },
+            ],
+          }],
+        }
+
+        expect(parse(value)).toEqual(expected)
+      })
+
+      it('RW-M03: should parse feed-level author', () => {
+        const value = `
+          <?xml version="1.0" encoding="UTF-8"?>
+          <feed xmlns="http://www.w3.org/2005/Atom">
+            <title>Test</title>
+            <id>urn:uuid:test</id>
+            <updated>2024-01-01T00:00:00Z</updated>
+            <author>
+              <name>Feed Author</name>
+              <uri>https://author.example.com</uri>
+              <email>author@example.com</email>
+            </author>
+          </feed>
+        `
+        const expected = {
+          title: 'Test',
+          id: 'urn:uuid:test',
+          updated: '2024-01-01T00:00:00Z',
+          authors: [{
+            name: 'Feed Author',
+            uri: 'https://author.example.com',
+            email: 'author@example.com',
+          }],
+        }
+
+        expect(parse(value)).toEqual(expected)
+      })
+
+      it('RW-M03: should parse contributor elements', () => {
+        const value = `
+          <?xml version="1.0" encoding="UTF-8"?>
+          <feed xmlns="http://www.w3.org/2005/Atom">
+            <title>Test</title>
+            <id>urn:uuid:test</id>
+            <updated>2024-01-01T00:00:00Z</updated>
+            <entry>
+              <title>Post</title>
+              <id>urn:uuid:1</id>
+              <updated>2024-01-01T00:00:00Z</updated>
+              <author><name>Main Author</name></author>
+              <contributor><name>Editor</name></contributor>
+              <contributor><name>Reviewer</name></contributor>
+            </entry>
+          </feed>
+        `
+        const expected = {
+          title: 'Test',
+          id: 'urn:uuid:test',
+          updated: '2024-01-01T00:00:00Z',
+          entries: [{
+            title: 'Post',
+            id: 'urn:uuid:1',
+            updated: '2024-01-01T00:00:00Z',
+            authors: [{ name: 'Main Author' }],
+            contributors: [{ name: 'Editor' }, { name: 'Reviewer' }],
+          }],
+        }
+
+        expect(parse(value)).toEqual(expected)
+      })
+
+      it('RW-N17: should parse author with only email, no name', () => {
+        const value = `
+          <?xml version="1.0" encoding="UTF-8"?>
+          <feed xmlns="http://www.w3.org/2005/Atom">
+            <title>Test</title>
+            <id>urn:uuid:test</id>
+            <updated>2024-01-01T00:00:00Z</updated>
+            <entry>
+              <title>Post</title>
+              <id>urn:uuid:1</id>
+              <updated>2024-01-01T00:00:00Z</updated>
+              <author>
+                <email>author@example.com</email>
+              </author>
+            </entry>
+          </feed>
+        `
+        const expected = {
+          title: 'Test',
+          id: 'urn:uuid:test',
+          updated: '2024-01-01T00:00:00Z',
+          entries: [{
+            title: 'Post',
+            id: 'urn:uuid:1',
+            updated: '2024-01-01T00:00:00Z',
+            authors: [{ email: 'author@example.com' }],
+          }],
+        }
+
+        expect(parse(value)).toEqual(expected)
+      })
+
+      it('RW-N19: should parse author with only uri, no name', () => {
+        const value = `
+          <?xml version="1.0" encoding="UTF-8"?>
+          <feed xmlns="http://www.w3.org/2005/Atom">
+            <title>Test</title>
+            <id>urn:uuid:test</id>
+            <updated>2024-01-01T00:00:00Z</updated>
+            <entry>
+              <title>Post</title>
+              <id>urn:uuid:1</id>
+              <updated>2024-01-01T00:00:00Z</updated>
+              <author>
+                <uri>https://author.example.com</uri>
+              </author>
+            </entry>
+          </feed>
+        `
+        const expected = {
+          title: 'Test',
+          id: 'urn:uuid:test',
+          updated: '2024-01-01T00:00:00Z',
+          entries: [{
+            title: 'Post',
+            id: 'urn:uuid:1',
+            updated: '2024-01-01T00:00:00Z',
+            authors: [{ uri: 'https://author.example.com' }],
+          }],
+        }
+
+        expect(parse(value)).toEqual(expected)
+      })
+
+      it('RW-N24: should parse contributor with missing name', () => {
+        const value = `
+          <?xml version="1.0" encoding="UTF-8"?>
+          <feed xmlns="http://www.w3.org/2005/Atom">
+            <title>Test</title>
+            <id>urn:uuid:test</id>
+            <updated>2024-01-01T00:00:00Z</updated>
+            <entry>
+              <title>Post</title>
+              <id>urn:uuid:1</id>
+              <updated>2024-01-01T00:00:00Z</updated>
+              <contributor>
+                <email>jane@example.com</email>
+                <uri>https://jane.example.com</uri>
+              </contributor>
+            </entry>
+          </feed>
+        `
+        const expected = {
+          title: 'Test',
+          id: 'urn:uuid:test',
+          updated: '2024-01-01T00:00:00Z',
+          entries: [{
+            title: 'Post',
+            id: 'urn:uuid:1',
+            updated: '2024-01-01T00:00:00Z',
+            contributors: [{
+              email: 'jane@example.com',
+              uri: 'https://jane.example.com',
+            }],
+          }],
+        }
+
+        expect(parse(value)).toEqual(expected)
+      })
+    })
+
+    describe('namespace edge cases', () => {
+      it('RW-Q01: should parse YouTube feed with yt namespace', () => {
+        const value = `
+          <?xml version="1.0" encoding="UTF-8"?>
+          <feed xmlns="http://www.w3.org/2005/Atom"
+                xmlns:yt="http://www.youtube.com/xml/schemas/2015"
+                xmlns:media="http://search.yahoo.com/mrss/">
+            <title>YouTube Channel</title>
+            <id>urn:uuid:yt-channel</id>
+            <updated>2024-01-01T00:00:00Z</updated>
+            <yt:channelId>UCxxxxxxxx</yt:channelId>
+            <entry>
+              <title>Video Title</title>
+              <id>urn:uuid:yt-video</id>
+              <updated>2024-01-01T00:00:00Z</updated>
+              <yt:videoId>dQw4w9WgXcQ</yt:videoId>
+              <yt:channelId>UCxxxxxxxx</yt:channelId>
+              <media:group>
+                <media:title>Video Title</media:title>
+                <media:description>Video description</media:description>
+                <media:thumbnail url="https://img.youtube.com/thumb.jpg" width="480" height="360"/>
+              </media:group>
+            </entry>
+          </feed>
+        `
+        const result = parse(value)
+
+        expect(result.title).toBe('YouTube Channel')
+        expect(result.yt?.channelId).toBe('UCxxxxxxxx')
+        expect(result.entries?.[0]?.yt?.videoId).toBe('dQw4w9WgXcQ')
+        expect(result.entries?.[0]?.yt?.channelId).toBe('UCxxxxxxxx')
+        expect(result.entries?.[0]?.media?.groups?.[0]?.title?.value).toBe('Video Title')
+        expect(result.entries?.[0]?.media?.groups?.[0]?.description?.value).toBe('Video description')
+        expect(result.entries?.[0]?.media?.groups?.[0]?.thumbnails?.[0]?.url).toBe('https://img.youtube.com/thumb.jpg')
+      })
+
+      it('RW-NS05: should parse feed with media:content on entry', () => {
+        const value = `
+          <?xml version="1.0" encoding="UTF-8"?>
+          <feed xmlns="http://www.w3.org/2005/Atom"
+                xmlns:media="http://search.yahoo.com/mrss/">
+            <title>Media Feed</title>
+            <id>urn:uuid:test</id>
+            <updated>2024-01-01T00:00:00Z</updated>
+            <entry>
+              <title>Post with Image</title>
+              <id>urn:uuid:1</id>
+              <updated>2024-01-01T00:00:00Z</updated>
+              <media:content url="https://example.com/image.jpg" type="image/jpeg" medium="image"/>
+              <media:thumbnail url="https://example.com/thumb.jpg" width="150" height="150"/>
+            </entry>
+          </feed>
+        `
+        const result = parse(value)
+
+        expect(result.entries?.[0]?.media?.contents?.[0]?.url).toBe('https://example.com/image.jpg')
+        expect(result.entries?.[0]?.media?.contents?.[0]?.type).toBe('image/jpeg')
+        expect(result.entries?.[0]?.media?.thumbnails?.[0]?.url).toBe('https://example.com/thumb.jpg')
+      })
+
+      it('RW-NS01: should handle non-standard prefix for known namespace URI', () => {
+        const value = `
+          <?xml version="1.0" encoding="UTF-8"?>
+          <feed xmlns="http://www.w3.org/2005/Atom"
+                xmlns:dublincore="http://purl.org/dc/elements/1.1/">
+            <title>Test</title>
+            <id>urn:uuid:test</id>
+            <updated>2024-01-01T00:00:00Z</updated>
+            <entry>
+              <title>Post</title>
+              <id>urn:uuid:1</id>
+              <updated>2024-01-01T00:00:00Z</updated>
+              <dublincore:creator>Author Name</dublincore:creator>
+            </entry>
+          </feed>
+        `
+        const expected = {
+          title: 'Test',
+          id: 'urn:uuid:test',
+          updated: '2024-01-01T00:00:00Z',
+          entries: [{
+            title: 'Post',
+            id: 'urn:uuid:1',
+            updated: '2024-01-01T00:00:00Z',
+            dc: {
+              creators: ['Author Name'],
+              creator: 'Author Name',
+            },
+          }],
+        }
+
+        expect(parse(value)).toEqual(expected)
+      })
+
+      it('RW-M10: should parse entry with multiple media:content elements', () => {
+        const value = `
+          <?xml version="1.0" encoding="UTF-8"?>
+          <feed xmlns="http://www.w3.org/2005/Atom"
+                xmlns:media="http://search.yahoo.com/mrss/">
+            <title>Test</title>
+            <id>urn:uuid:test</id>
+            <updated>2024-01-01T00:00:00Z</updated>
+            <entry>
+              <title>Post</title>
+              <id>urn:uuid:1</id>
+              <updated>2024-01-01T00:00:00Z</updated>
+              <media:content url="https://example.com/video.mp4" type="video/mp4" medium="video"/>
+              <media:content url="https://example.com/audio.mp3" type="audio/mpeg" medium="audio"/>
+            </entry>
+          </feed>
+        `
+        const result = parse(value)
+
+        expect(result.entries?.[0]?.media?.contents).toHaveLength(2)
+        expect(result.entries?.[0]?.media?.contents?.[0]?.url).toBe('https://example.com/video.mp4')
+        expect(result.entries?.[0]?.media?.contents?.[0]?.type).toBe('video/mp4')
+        expect(result.entries?.[0]?.media?.contents?.[0]?.medium).toBe('video')
+        expect(result.entries?.[0]?.media?.contents?.[1]?.url).toBe('https://example.com/audio.mp3')
+        expect(result.entries?.[0]?.media?.contents?.[1]?.type).toBe('audio/mpeg')
+        expect(result.entries?.[0]?.media?.contents?.[1]?.medium).toBe('audio')
+      })
+
+      it('RW-D22: should parse Atom 0.3 entry with mode="escaped" content', () => {
+        const value = `
+          <?xml version="1.0" encoding="UTF-8"?>
+          <feed xmlns="http://purl.org/atom/ns#">
+            <title>Atom 0.3 Feed</title>
+            <id>urn:uuid:test</id>
+            <modified>2024-01-01T00:00:00Z</modified>
+            <entry>
+              <title>Post</title>
+              <id>urn:uuid:1</id>
+              <modified>2024-01-01T00:00:00Z</modified>
+              <content mode="escaped" type="text/html">&lt;p&gt;Hello &lt;b&gt;world&lt;/b&gt;&lt;/p&gt;</content>
+            </entry>
+          </feed>
+        `
+        const expected = {
+          title: 'Atom 0.3 Feed',
+          id: 'urn:uuid:test',
+          updated: '2024-01-01T00:00:00Z',
+          entries: [{
+            title: 'Post',
+            id: 'urn:uuid:1',
+            updated: '2024-01-01T00:00:00Z',
+            content: '<p>Hello <b>world</b></p>',
+          }],
+        }
+
+        expect(parse(value)).toEqual(expected)
+      })
+    })
+
+    describe('missing and empty elements', () => {
+      it('RW-N07: should parse entry with no title', () => {
+        const value = `
+          <?xml version="1.0" encoding="UTF-8"?>
+          <feed xmlns="http://www.w3.org/2005/Atom">
+            <title>Test</title>
+            <id>urn:uuid:test</id>
+            <updated>2024-01-01T00:00:00Z</updated>
+            <entry>
+              <id>urn:uuid:1</id>
+              <updated>2024-01-01T00:00:00Z</updated>
+              <content>Content without title</content>
+            </entry>
+          </feed>
+        `
+        const expected = {
+          title: 'Test',
+          id: 'urn:uuid:test',
+          updated: '2024-01-01T00:00:00Z',
+          entries: [{
+            id: 'urn:uuid:1',
+            updated: '2024-01-01T00:00:00Z',
+            content: 'Content without title',
+          }],
+        }
+
+        expect(parse(value)).toEqual(expected)
+      })
+
+      it('RW-N01: should parse feed with no entries', () => {
+        const value = `
+          <?xml version="1.0" encoding="UTF-8"?>
+          <feed xmlns="http://www.w3.org/2005/Atom">
+            <title>Empty Feed</title>
+            <id>urn:uuid:test</id>
+            <updated>2024-01-01T00:00:00Z</updated>
+          </feed>
+        `
+        const expected = {
+          title: 'Empty Feed',
+          id: 'urn:uuid:test',
+          updated: '2024-01-01T00:00:00Z',
+        }
+
+        expect(parse(value)).toEqual(expected)
+      })
+
+      it('RW-N03: should handle empty summary', () => {
+        const value = `
+          <?xml version="1.0" encoding="UTF-8"?>
+          <feed xmlns="http://www.w3.org/2005/Atom">
+            <title>Test</title>
+            <id>urn:uuid:test</id>
+            <updated>2024-01-01T00:00:00Z</updated>
+            <entry>
+              <title>Post</title>
+              <id>urn:uuid:1</id>
+              <updated>2024-01-01T00:00:00Z</updated>
+              <summary/>
+            </entry>
+          </feed>
+        `
+        const expected = {
+          title: 'Test',
+          id: 'urn:uuid:test',
+          updated: '2024-01-01T00:00:00Z',
+          entries: [{
+            title: 'Post',
+            id: 'urn:uuid:1',
+            updated: '2024-01-01T00:00:00Z',
+          }],
+        }
+
+        expect(parse(value)).toEqual(expected)
+      })
+
+      it('RW-N11: should handle whitespace-only title', () => {
+        const value = `
+          <?xml version="1.0" encoding="UTF-8"?>
+          <feed xmlns="http://www.w3.org/2005/Atom">
+            <title>Test</title>
+            <id>urn:uuid:test</id>
+            <updated>2024-01-01T00:00:00Z</updated>
+            <entry>
+              <title>   </title>
+              <id>urn:uuid:1</id>
+              <updated>2024-01-01T00:00:00Z</updated>
+              <content>Has content but empty title</content>
+            </entry>
+          </feed>
+        `
+        const expected = {
+          title: 'Test',
+          id: 'urn:uuid:test',
+          updated: '2024-01-01T00:00:00Z',
+          entries: [{
+            id: 'urn:uuid:1',
+            updated: '2024-01-01T00:00:00Z',
+            content: 'Has content but empty title',
+          }],
+        }
+
+        expect(parse(value)).toEqual(expected)
+      })
+
+      it('RW-N15: should throw for empty feed container', () => {
+        const value = `
+          <?xml version="1.0" encoding="UTF-8"?>
+          <feed xmlns="http://www.w3.org/2005/Atom">
+          </feed>
+        `
+
+        expect(() => parse(value)).toThrow()
+      })
+
+      it('RW-N21: should parse entry with published but no updated', () => {
+        const value = `
+          <?xml version="1.0" encoding="UTF-8"?>
+          <feed xmlns="http://www.w3.org/2005/Atom">
+            <title>Test</title>
+            <id>urn:uuid:test</id>
+            <updated>2024-01-01T00:00:00Z</updated>
+            <entry>
+              <title>Post</title>
+              <id>urn:uuid:1</id>
+              <published>2024-01-15T10:30:00Z</published>
+            </entry>
+          </feed>
+        `
+        const expected = {
+          title: 'Test',
+          id: 'urn:uuid:test',
+          updated: '2024-01-01T00:00:00Z',
+          entries: [{
+            title: 'Post',
+            id: 'urn:uuid:1',
+            published: '2024-01-15T10:30:00Z',
+          }],
+        }
+
+        expect(parse(value)).toEqual(expected)
+      })
+
+      it('RW-N23: should parse entry with no id', () => {
+        const value = `
+          <?xml version="1.0" encoding="UTF-8"?>
+          <feed xmlns="http://www.w3.org/2005/Atom">
+            <title>Test</title>
+            <id>urn:uuid:test</id>
+            <updated>2024-01-01T00:00:00Z</updated>
+            <entry>
+              <title>Post</title>
+              <content>Some content here</content>
+            </entry>
+          </feed>
+        `
+        const expected = {
+          title: 'Test',
+          id: 'urn:uuid:test',
+          updated: '2024-01-01T00:00:00Z',
+          entries: [{
+            title: 'Post',
+            content: 'Some content here',
+          }],
+        }
+
+        expect(parse(value)).toEqual(expected)
+      })
+    })
+
+    describe('date handling', () => {
+      it('RW-T02: should preserve published and updated dates as strings', () => {
+        const value = `
+          <?xml version="1.0" encoding="UTF-8"?>
+          <feed xmlns="http://www.w3.org/2005/Atom">
+            <title>Test</title>
+            <id>urn:uuid:test</id>
+            <updated>2024-06-15T14:30:00+02:00</updated>
+            <entry>
+              <title>Post</title>
+              <id>urn:uuid:1</id>
+              <published>2024-06-15T12:00:00Z</published>
+              <updated>2024-06-15T14:30:00+02:00</updated>
+            </entry>
+          </feed>
+        `
+        const expected = {
+          title: 'Test',
+          id: 'urn:uuid:test',
+          updated: '2024-06-15T14:30:00+02:00',
+          entries: [{
+            title: 'Post',
+            id: 'urn:uuid:1',
+            published: '2024-06-15T12:00:00Z',
+            updated: '2024-06-15T14:30:00+02:00',
+          }],
+        }
+
+        expect(parse(value)).toEqual(expected)
+      })
+
+      it('RW-T12: should parse entry with both published and updated dates', () => {
+        const value = `
+          <?xml version="1.0" encoding="UTF-8"?>
+          <feed xmlns="http://www.w3.org/2005/Atom">
+            <title>Test</title>
+            <id>urn:uuid:test</id>
+            <updated>2024-01-01T00:00:00Z</updated>
+            <entry>
+              <title>Post</title>
+              <id>urn:uuid:1</id>
+              <published>2024-01-01T00:00:00Z</published>
+              <updated>2024-06-15T12:00:00Z</updated>
+            </entry>
+          </feed>
+        `
+        const expected = {
+          title: 'Test',
+          id: 'urn:uuid:test',
+          updated: '2024-01-01T00:00:00Z',
+          entries: [{
+            title: 'Post',
+            id: 'urn:uuid:1',
+            published: '2024-01-01T00:00:00Z',
+            updated: '2024-06-15T12:00:00Z',
+          }],
+        }
+
+        expect(parse(value)).toEqual(expected)
+      })
+    })
+
+    describe('cdata handling', () => {
+      it('RW-C02: should handle CDATA in title', () => {
+        const value = `
+          <?xml version="1.0" encoding="UTF-8"?>
+          <feed xmlns="http://www.w3.org/2005/Atom">
+            <title><![CDATA[Test & Blog]]></title>
+            <id>urn:uuid:test</id>
+            <updated>2024-01-01T00:00:00Z</updated>
+          </feed>
+        `
+        const expected = {
+          title: 'Test & Blog',
+          id: 'urn:uuid:test',
+          updated: '2024-01-01T00:00:00Z',
+        }
+
+        expect(parse(value)).toEqual(expected)
+      })
+    })
+
+    describe('malformed XML resilience', () => {
+      it('RW-E10: should handle BOM at start of feed', () => {
+        const value = `\uFEFF<?xml version="1.0" encoding="UTF-8"?>
+          <feed xmlns="http://www.w3.org/2005/Atom">
+            <title>BOM Feed</title>
+            <id>urn:uuid:test</id>
+            <updated>2024-01-01T00:00:00Z</updated>
+          </feed>
+        `
+        const expected = {
+          title: 'BOM Feed',
+          id: 'urn:uuid:test',
+          updated: '2024-01-01T00:00:00Z',
+        }
+
+        expect(parse(value)).toEqual(expected)
+      })
+
+      it('RW-E12: should handle unescaped ampersand in entry title via CDATA', () => {
+        const value = `
+          <?xml version="1.0" encoding="UTF-8"?>
+          <feed xmlns="http://www.w3.org/2005/Atom">
+            <title>Test</title>
+            <id>urn:uuid:test</id>
+            <updated>2024-01-01T00:00:00Z</updated>
+            <entry>
+              <title><![CDATA[Tom & Jerry]]></title>
+              <id>urn:uuid:1</id>
+              <updated>2024-01-01T00:00:00Z</updated>
+            </entry>
+          </feed>
+        `
+        const expected = {
+          title: 'Test',
+          id: 'urn:uuid:test',
+          updated: '2024-01-01T00:00:00Z',
+          entries: [{
+            title: 'Tom & Jerry',
+            id: 'urn:uuid:1',
+            updated: '2024-01-01T00:00:00Z',
+          }],
+        }
+
+        expect(parse(value)).toEqual(expected)
+      })
+
+      it('RW-E06: should decode &nbsp; entity in content', () => {
+        const value = `
+          <?xml version="1.0" encoding="UTF-8"?>
+          <feed xmlns="http://www.w3.org/2005/Atom">
+            <title>Test</title>
+            <id>urn:uuid:test</id>
+            <updated>2024-01-01T00:00:00Z</updated>
+            <entry>
+              <title>Post</title>
+              <id>urn:uuid:1</id>
+              <updated>2024-01-01T00:00:00Z</updated>
+              <content>Hello&nbsp;World</content>
+            </entry>
+          </feed>
+        `
+        const expected = {
+          title: 'Test',
+          id: 'urn:uuid:test',
+          updated: '2024-01-01T00:00:00Z',
+          entries: [{
+            title: 'Post',
+            id: 'urn:uuid:1',
+            updated: '2024-01-01T00:00:00Z',
+            content: 'Hello\u00A0World',
+          }],
+        }
+
+        expect(parse(value)).toEqual(expected)
+      })
+
+      it('RW-X01: should partially parse truncated XML without throwing', () => {
+        const value = `
+          <?xml version="1.0" encoding="UTF-8"?>
+          <feed xmlns="http://www.w3.org/2005/Atom">
+            <title>Test</title>
+            <id>urn:uuid:test</id>
+            <updated>2024-01-01T00:00:00Z</updated>
+            <entry>
+              <title>Post</title>
+        `
+
+        expect(() => parse(value)).not.toThrow()
+      })
+
+      it('RW-E17: should throw on unescaped less-than in content', () => {
+        const value = `
+          <?xml version="1.0" encoding="UTF-8"?>
+          <feed xmlns="http://www.w3.org/2005/Atom">
+            <title>Test</title>
+            <id>urn:uuid:test</id>
+            <updated>2024-01-01T00:00:00Z</updated>
+            <entry>
+              <title>Post</title>
+              <id>urn:uuid:1</id>
+              <updated>2024-01-01T00:00:00Z</updated>
+              <content>5 < 10</content>
+            </entry>
+          </feed>
+        `
+
+        expect(() => parse(value)).toThrow()
+      })
+
+      it('RW-X08: should strip XML comments from element content', () => {
+        const value = `
+          <?xml version="1.0" encoding="UTF-8"?>
+          <feed xmlns="http://www.w3.org/2005/Atom">
+            <title>Test<!-- hidden --> Feed</title>
+            <id>urn:uuid:test</id>
+            <updated>2024-01-01T00:00:00Z</updated>
+            <entry>
+              <title>Post<!-- comment --> Title</title>
+              <id>urn:uuid:1</id>
+              <updated>2024-01-01T00:00:00Z</updated>
+            </entry>
+          </feed>
+        `
+        const expected = {
+          title: 'Test Feed',
+          id: 'urn:uuid:test',
+          updated: '2024-01-01T00:00:00Z',
+          entries: [{
+            title: 'Post Title',
+            id: 'urn:uuid:1',
+            updated: '2024-01-01T00:00:00Z',
+          }],
+        }
+
+        expect(parse(value)).toEqual(expected)
+      })
+
+      it('RW-X09: should parse entries appearing before feed metadata', () => {
+        const value = `
+          <?xml version="1.0" encoding="UTF-8"?>
+          <feed xmlns="http://www.w3.org/2005/Atom">
+            <entry>
+              <title>Post</title>
+              <id>urn:uuid:1</id>
+              <updated>2024-01-01T00:00:00Z</updated>
+            </entry>
+            <title>Test</title>
+            <id>urn:uuid:test</id>
+            <updated>2024-01-15T00:00:00Z</updated>
+          </feed>
+        `
+        const expected = {
+          title: 'Test',
+          id: 'urn:uuid:test',
+          updated: '2024-01-15T00:00:00Z',
+          entries: [{
+            title: 'Post',
+            id: 'urn:uuid:1',
+            updated: '2024-01-01T00:00:00Z',
+          }],
+        }
+
+        expect(parse(value)).toEqual(expected)
+      })
+    })
+
+    describe('stop node edge cases', () => {
+      it('RW-D12: should preserve HTML tags in CDATA content', () => {
+        const value = `
+          <?xml version="1.0" encoding="UTF-8"?>
+          <feed xmlns="http://www.w3.org/2005/Atom">
+            <title>Test</title>
+            <id>urn:uuid:test</id>
+            <updated>2024-01-01T00:00:00Z</updated>
+            <entry>
+              <title>Post</title>
+              <id>urn:uuid:1</id>
+              <updated>2024-01-01T00:00:00Z</updated>
+              <content><![CDATA[<div><img src="test.jpg" /><p>Text with <a href="http://example.com">link</a> and <br/> break</p></div>]]></content>
+            </entry>
+          </feed>
+        `
+        const expected = {
+          title: 'Test',
+          id: 'urn:uuid:test',
+          updated: '2024-01-01T00:00:00Z',
+          entries: [{
+            title: 'Post',
+            id: 'urn:uuid:1',
+            updated: '2024-01-01T00:00:00Z',
+            content: '<div><img src="test.jpg" /><p>Text with <a href="http://example.com">link</a> and <br/> break</p></div>',
+          }],
+        }
+
+        expect(parse(value)).toEqual(expected)
+      })
+
+      it('RW-D04: should preserve escaped HTML in summary', () => {
+        const value = `
+          <?xml version="1.0" encoding="UTF-8"?>
+          <feed xmlns="http://www.w3.org/2005/Atom">
+            <title>Test</title>
+            <id>urn:uuid:test</id>
+            <updated>2024-01-01T00:00:00Z</updated>
+            <entry>
+              <title>Post</title>
+              <id>urn:uuid:1</id>
+              <updated>2024-01-01T00:00:00Z</updated>
+              <summary>&lt;p&gt;Escaped paragraph&lt;/p&gt;</summary>
+            </entry>
+          </feed>
+        `
+        const expected = {
+          title: 'Test',
+          id: 'urn:uuid:test',
+          updated: '2024-01-01T00:00:00Z',
+          entries: [{
+            title: 'Post',
+            id: 'urn:uuid:1',
+            updated: '2024-01-01T00:00:00Z',
+            summary: '<p>Escaped paragraph</p>',
+          }],
+        }
+
+        expect(parse(value)).toEqual(expected)
+      })
+    })
+
+    describe('partial and unusual structures', () => {
+      it('RW-N02: should handle entry with only id and updated', () => {
+        const value = `
+          <?xml version="1.0" encoding="UTF-8"?>
+          <feed xmlns="http://www.w3.org/2005/Atom">
+            <title>Test</title>
+            <id>urn:uuid:test</id>
+            <updated>2024-01-01T00:00:00Z</updated>
+            <entry>
+              <id>urn:uuid:1</id>
+              <updated>2024-01-01T00:00:00Z</updated>
+            </entry>
+          </feed>
+        `
+        const expected = {
+          title: 'Test',
+          id: 'urn:uuid:test',
+          updated: '2024-01-01T00:00:00Z',
+          entries: [{
+            id: 'urn:uuid:1',
+            updated: '2024-01-01T00:00:00Z',
+          }],
+        }
+
+        expect(parse(value)).toEqual(expected)
+      })
+
+      it('RW-A08: should handle generator with uri and version attributes', () => {
+        const value = `
+          <?xml version="1.0" encoding="UTF-8"?>
+          <feed xmlns="http://www.w3.org/2005/Atom">
+            <title>Test</title>
+            <id>urn:uuid:test</id>
+            <updated>2024-01-01T00:00:00Z</updated>
+            <generator uri="https://example.com/gen" version="2.0">MyGenerator</generator>
+          </feed>
+        `
+        const expected = {
+          title: 'Test',
+          id: 'urn:uuid:test',
+          updated: '2024-01-01T00:00:00Z',
+          generator: {
+            text: 'MyGenerator',
+            uri: 'https://example.com/gen',
+            version: '2.0',
+          },
+        }
+
+        expect(parse(value)).toEqual(expected)
+      })
+
+      it('RW-A07: should handle category with term, scheme, and label', () => {
+        const value = `
+          <?xml version="1.0" encoding="UTF-8"?>
+          <feed xmlns="http://www.w3.org/2005/Atom">
+            <title>Test</title>
+            <id>urn:uuid:test</id>
+            <updated>2024-01-01T00:00:00Z</updated>
+            <entry>
+              <title>Post</title>
+              <id>urn:uuid:1</id>
+              <updated>2024-01-01T00:00:00Z</updated>
+              <category term="tech" scheme="https://example.com/categories" label="Technology"/>
+              <category term="programming"/>
+            </entry>
+          </feed>
+        `
+        const expected = {
+          title: 'Test',
+          id: 'urn:uuid:test',
+          updated: '2024-01-01T00:00:00Z',
+          entries: [{
+            title: 'Post',
+            id: 'urn:uuid:1',
+            updated: '2024-01-01T00:00:00Z',
+            categories: [
+              { term: 'tech', scheme: 'https://example.com/categories', label: 'Technology' },
+              { term: 'programming' },
+            ],
+          }],
+        }
+
+        expect(parse(value)).toEqual(expected)
+      })
+
+      it('RW-NS11: should handle entry source element', () => {
+        const value = `
+          <?xml version="1.0" encoding="UTF-8"?>
+          <feed xmlns="http://www.w3.org/2005/Atom">
+            <title>Aggregator</title>
+            <id>urn:uuid:aggregator</id>
+            <updated>2024-01-01T00:00:00Z</updated>
+            <entry>
+              <title>Reposted Article</title>
+              <id>urn:uuid:1</id>
+              <updated>2024-01-01T00:00:00Z</updated>
+              <source>
+                <title>Original Blog</title>
+                <id>urn:uuid:original</id>
+                <link href="https://original.example.com" rel="alternate"/>
+              </source>
+            </entry>
+          </feed>
+        `
+        const expected = {
+          title: 'Aggregator',
+          id: 'urn:uuid:aggregator',
+          updated: '2024-01-01T00:00:00Z',
+          entries: [{
+            title: 'Reposted Article',
+            id: 'urn:uuid:1',
+            updated: '2024-01-01T00:00:00Z',
+            source: {
+              title: 'Original Blog',
+              id: 'urn:uuid:original',
+              links: [{ href: 'https://original.example.com', rel: 'alternate' }],
+            },
+          }],
+        }
+
+        expect(parse(value)).toEqual(expected)
+      })
+
+      it('RW-Q10: should not confuse entry title with source title', () => {
+        const value = `
+          <?xml version="1.0" encoding="UTF-8"?>
+          <feed xmlns="http://www.w3.org/2005/Atom">
+            <title>Aggregator</title>
+            <id>urn:uuid:aggregator</id>
+            <updated>2024-01-01T00:00:00Z</updated>
+            <entry>
+              <title>Article Title</title>
+              <id>urn:uuid:1</id>
+              <updated>2024-01-01T00:00:00Z</updated>
+              <source>
+                <title>Blog Name</title>
+                <id>urn:uuid:blog</id>
+              </source>
+            </entry>
+          </feed>
+        `
+        const expected = {
+          title: 'Aggregator',
+          id: 'urn:uuid:aggregator',
+          updated: '2024-01-01T00:00:00Z',
+          entries: [{
+            title: 'Article Title',
+            id: 'urn:uuid:1',
+            updated: '2024-01-01T00:00:00Z',
+            source: {
+              title: 'Blog Name',
+              id: 'urn:uuid:blog',
+            },
+          }],
+        }
+
+        expect(parse(value)).toEqual(expected)
+      })
+
+      it('RW-A11: should parse feed with xml:lang attribute (attribute not captured)', () => {
+        const value = `
+          <?xml version="1.0" encoding="UTF-8"?>
+          <feed xmlns="http://www.w3.org/2005/Atom" xml:lang="en-US">
+            <title>English Feed</title>
+            <id>urn:uuid:test</id>
+            <updated>2024-01-01T00:00:00Z</updated>
+            <entry>
+              <title>Post</title>
+              <id>urn:uuid:1</id>
+              <updated>2024-01-01T00:00:00Z</updated>
+            </entry>
+          </feed>
+        `
+        const expected = {
+          title: 'English Feed',
+          id: 'urn:uuid:test',
+          updated: '2024-01-01T00:00:00Z',
+          entries: [{
+            title: 'Post',
+            id: 'urn:uuid:1',
+            updated: '2024-01-01T00:00:00Z',
+          }],
+        }
+
+        expect(parse(value)).toEqual(expected)
+      })
+
+      it('RW-L06: should handle link with no rel attribute defaulting to just href', () => {
+        const value = `
+          <?xml version="1.0" encoding="UTF-8"?>
+          <feed xmlns="http://www.w3.org/2005/Atom">
+            <title>Test</title>
+            <id>urn:uuid:test</id>
+            <updated>2024-01-01T00:00:00Z</updated>
+            <link href="https://example.com/"/>
+            <entry>
+              <title>Post</title>
+              <id>urn:uuid:1</id>
+              <updated>2024-01-01T00:00:00Z</updated>
+              <link href="https://example.com/post/1"/>
+            </entry>
+          </feed>
+        `
+        const expected = {
+          title: 'Test',
+          id: 'urn:uuid:test',
+          updated: '2024-01-01T00:00:00Z',
+          links: [{ href: 'https://example.com/' }],
+          entries: [{
+            title: 'Post',
+            id: 'urn:uuid:1',
+            updated: '2024-01-01T00:00:00Z',
+            links: [{ href: 'https://example.com/post/1' }],
+          }],
+        }
+
+        expect(parse(value)).toEqual(expected)
+      })
+
+      it('RW-Q06: should handle rights element', () => {
+        const value = `
+          <?xml version="1.0" encoding="UTF-8"?>
+          <feed xmlns="http://www.w3.org/2005/Atom">
+            <title>Test</title>
+            <id>urn:uuid:test</id>
+            <updated>2024-01-01T00:00:00Z</updated>
+            <rights>&copy; 2024 Example Corp</rights>
+          </feed>
+        `
+        const expected = {
+          title: 'Test',
+          id: 'urn:uuid:test',
+          updated: '2024-01-01T00:00:00Z',
+          rights: '\u00A9 2024 Example Corp',
+        }
+
+        expect(parse(value)).toEqual(expected)
+      })
+
+      it('RW-D14: should decode double-escaped entities only once', () => {
+        const value = `
+          <?xml version="1.0" encoding="UTF-8"?>
+          <feed xmlns="http://www.w3.org/2005/Atom">
+            <title>Test</title>
+            <id>urn:uuid:test</id>
+            <updated>2024-01-01T00:00:00Z</updated>
+            <entry>
+              <title>CSS, &amp;lt;pre&amp;gt;, and more</title>
+              <id>urn:uuid:1</id>
+              <updated>2024-01-01T00:00:00Z</updated>
+            </entry>
+          </feed>
+        `
+        const expected = {
+          title: 'Test',
+          id: 'urn:uuid:test',
+          updated: '2024-01-01T00:00:00Z',
+          entries: [{
+            title: 'CSS, &lt;pre&gt;, and more',
+            id: 'urn:uuid:1',
+            updated: '2024-01-01T00:00:00Z',
+          }],
+        }
+
+        expect(parse(value)).toEqual(expected)
+      })
+
+      it('RW-D15: should decode entity-encoded HTML in content', () => {
+        const value = `
+          <?xml version="1.0" encoding="UTF-8"?>
+          <feed xmlns="http://www.w3.org/2005/Atom">
+            <title>Test</title>
+            <id>urn:uuid:test</id>
+            <updated>2024-01-01T00:00:00Z</updated>
+            <entry>
+              <title>Post</title>
+              <id>urn:uuid:1</id>
+              <updated>2024-01-01T00:00:00Z</updated>
+              <content type="html">&lt;p&gt;Hello &lt;strong&gt;world&lt;/strong&gt;&lt;/p&gt;</content>
+            </entry>
+          </feed>
+        `
+        const expected = {
+          title: 'Test',
+          id: 'urn:uuid:test',
+          updated: '2024-01-01T00:00:00Z',
+          entries: [{
+            title: 'Post',
+            id: 'urn:uuid:1',
+            updated: '2024-01-01T00:00:00Z',
+            content: '<p>Hello <strong>world</strong></p>',
+          }],
+        }
+
+        expect(parse(value)).toEqual(expected)
+      })
+
+      it('RW-D16: should parse content and summary independently regardless of document order', () => {
+        const value = `
+          <?xml version="1.0" encoding="UTF-8"?>
+          <feed xmlns="http://www.w3.org/2005/Atom">
+            <title>Test</title>
+            <id>urn:uuid:test</id>
+            <updated>2024-01-01T00:00:00Z</updated>
+            <entry>
+              <title>Post</title>
+              <id>urn:uuid:1</id>
+              <updated>2024-01-01T00:00:00Z</updated>
+              <content type="html">Full article content here</content>
+              <summary>Brief summary</summary>
+            </entry>
+          </feed>
+        `
+        const expected = {
+          title: 'Test',
+          id: 'urn:uuid:test',
+          updated: '2024-01-01T00:00:00Z',
+          entries: [{
+            title: 'Post',
+            id: 'urn:uuid:1',
+            updated: '2024-01-01T00:00:00Z',
+            content: 'Full article content here',
+            summary: 'Brief summary',
+          }],
+        }
+
+        expect(parse(value)).toEqual(expected)
+      })
+
+      it('RW-L13: should decode XML entities in link href attribute', () => {
+        const value = `
+          <?xml version="1.0" encoding="UTF-8"?>
+          <feed xmlns="http://www.w3.org/2005/Atom">
+            <title>Test</title>
+            <id>urn:uuid:test</id>
+            <updated>2024-01-01T00:00:00Z</updated>
+            <entry>
+              <title>Post</title>
+              <id>urn:uuid:1</id>
+              <updated>2024-01-01T00:00:00Z</updated>
+              <link href="https://example.com/search?q=test&amp;sort=new" rel="alternate"/>
+            </entry>
+          </feed>
+        `
+        const expected = {
+          title: 'Test',
+          id: 'urn:uuid:test',
+          updated: '2024-01-01T00:00:00Z',
+          entries: [{
+            title: 'Post',
+            id: 'urn:uuid:1',
+            updated: '2024-01-01T00:00:00Z',
+            links: [{ href: 'https://example.com/search?q=test&sort=new', rel: 'alternate' }],
+          }],
+        }
+
+        expect(parse(value)).toEqual(expected)
+      })
+
+      it('RW-L15: should omit href from link when it is empty', () => {
+        const value = `
+          <?xml version="1.0" encoding="UTF-8"?>
+          <feed xmlns="http://www.w3.org/2005/Atom">
+            <title>Test</title>
+            <id>urn:uuid:test</id>
+            <updated>2024-01-01T00:00:00Z</updated>
+            <entry>
+              <title>Post</title>
+              <id>urn:uuid:1</id>
+              <updated>2024-01-01T00:00:00Z</updated>
+              <link href="" rel="alternate" type="text/html"/>
+            </entry>
+          </feed>
+        `
+        const expected = {
+          title: 'Test',
+          id: 'urn:uuid:test',
+          updated: '2024-01-01T00:00:00Z',
+          entries: [{
+            title: 'Post',
+            id: 'urn:uuid:1',
+            updated: '2024-01-01T00:00:00Z',
+            links: [{ rel: 'alternate', type: 'text/html' }],
+          }],
+        }
+
+        expect(parse(value)).toEqual(expected)
+      })
+
+      it('RW-L16: should capture all links without filtering by rel', () => {
+        const value = `
+          <?xml version="1.0" encoding="UTF-8"?>
+          <feed xmlns="http://www.w3.org/2005/Atom">
+            <title>Test</title>
+            <id>urn:uuid:test</id>
+            <updated>2024-01-01T00:00:00Z</updated>
+            <entry>
+              <title>Post</title>
+              <id>urn:uuid:1</id>
+              <updated>2024-01-01T00:00:00Z</updated>
+              <link rel="self" href="https://example.com/feed/1"/>
+              <link rel="alternate" href="https://example.com/post/1" type="text/html"/>
+            </entry>
+          </feed>
+        `
+        const expected = {
+          title: 'Test',
+          id: 'urn:uuid:test',
+          updated: '2024-01-01T00:00:00Z',
+          entries: [{
+            title: 'Post',
+            id: 'urn:uuid:1',
+            updated: '2024-01-01T00:00:00Z',
+            links: [
+              { href: 'https://example.com/feed/1', rel: 'self' },
+              { href: 'https://example.com/post/1', rel: 'alternate', type: 'text/html' },
+            ],
+          }],
+        }
+
+        expect(parse(value)).toEqual(expected)
+      })
+
+      it('RW-N20: should omit self-closing subtitle with type attribute only', () => {
+        const value = `
+          <?xml version="1.0" encoding="UTF-8"?>
+          <feed xmlns="http://www.w3.org/2005/Atom">
+            <title>Test</title>
+            <id>urn:uuid:test</id>
+            <updated>2024-01-01T00:00:00Z</updated>
+            <subtitle type="text"/>
+          </feed>
+        `
+        const expected = {
+          title: 'Test',
+          id: 'urn:uuid:test',
+          updated: '2024-01-01T00:00:00Z',
+        }
+
+        expect(parse(value)).toEqual(expected)
+      })
+
+      it('RW-A12: should omit author when name element is self-closing', () => {
+        const value = `
+          <?xml version="1.0" encoding="UTF-8"?>
+          <feed xmlns="http://www.w3.org/2005/Atom">
+            <title>Test</title>
+            <id>urn:uuid:test</id>
+            <updated>2024-01-01T00:00:00Z</updated>
+            <entry>
+              <title>Post</title>
+              <id>urn:uuid:1</id>
+              <updated>2024-01-01T00:00:00Z</updated>
+              <author><name/></author>
+            </entry>
+          </feed>
+        `
+        const expected = {
+          title: 'Test',
+          id: 'urn:uuid:test',
+          updated: '2024-01-01T00:00:00Z',
+          entries: [{
+            title: 'Post',
+            id: 'urn:uuid:1',
+            updated: '2024-01-01T00:00:00Z',
+          }],
+        }
+
+        expect(parse(value)).toEqual(expected)
+      })
+
+      it('RW-NS20: should handle xmlns with spaces around equals sign', () => {
+        const value = `<feed xmlns = "http://www.w3.org/2005/Atom"><title>Test</title><id>urn:uuid:test</id><updated>2024-01-01T00:00:00Z</updated></feed>`
+        const expected = {
+          title: 'Test',
+          id: 'urn:uuid:test',
+          updated: '2024-01-01T00:00:00Z',
+        }
+
+        expect(parse(value)).toEqual(expected)
+      })
+
+      it('RW-NS21: should preserve HTML5 summary element inside XHTML content without confusing it with Atom summary', () => {
+        const value = `
+          <?xml version="1.0" encoding="UTF-8"?>
+          <feed xmlns="http://www.w3.org/2005/Atom">
+            <title>Test</title>
+            <id>urn:uuid:test</id>
+            <updated>2024-01-01T00:00:00Z</updated>
+            <entry>
+              <title>Post</title>
+              <id>urn:uuid:1</id>
+              <updated>2024-01-01T00:00:00Z</updated>
+              <content type="xhtml"><div xmlns="http://www.w3.org/1999/xhtml"><details><summary>Click to expand</summary><p>Details here</p></details></div></content>
+            </entry>
+          </feed>
+        `
+        const expected = {
+          title: 'Test',
+          id: 'urn:uuid:test',
+          updated: '2024-01-01T00:00:00Z',
+          entries: [{
+            title: 'Post',
+            id: 'urn:uuid:1',
+            updated: '2024-01-01T00:00:00Z',
+            content: '<div xmlns="http://www.w3.org/1999/xhtml"><details><summary>Click to expand</summary><p>Details here</p></details></div>',
+          }],
+        }
+
+        expect(parse(value)).toEqual(expected)
+      })
+
+      it('RW-NS22: should preserve raw XML inside content with XML media type', () => {
+        const value = `
+          <?xml version="1.0" encoding="UTF-8"?>
+          <feed xmlns="http://www.w3.org/2005/Atom">
+            <title>Test</title>
+            <id>urn:uuid:test</id>
+            <updated>2024-01-01T00:00:00Z</updated>
+            <entry>
+              <title>Post</title>
+              <id>urn:uuid:1</id>
+              <updated>2024-01-01T00:00:00Z</updated>
+              <content type="application/mathml+xml"><math xmlns="http://www.w3.org/1998/Math/MathML"><mi>x</mi></math></content>
+            </entry>
+          </feed>
+        `
+        const expected = {
+          title: 'Test',
+          id: 'urn:uuid:test',
+          updated: '2024-01-01T00:00:00Z',
+          entries: [{
+            title: 'Post',
+            id: 'urn:uuid:1',
+            updated: '2024-01-01T00:00:00Z',
+            content: '<math xmlns="http://www.w3.org/1998/Math/MathML"><mi>x</mi></math>',
+          }],
+        }
+
+        expect(parse(value)).toEqual(expected)
+      })
+
+      it('RW-NS23: should parse feed with non-standard a10: prefix for Atom namespace', () => {
+        const value = `<a10:feed xmlns:a10="http://www.w3.org/2005/Atom"><a10:title>Test</a10:title><a10:id>urn:uuid:test</a10:id><a10:updated>2024-01-01T00:00:00Z</a10:updated></a10:feed>`
+        const expected = {
+          title: 'Test',
+          id: 'urn:uuid:test',
+          updated: '2024-01-01T00:00:00Z',
+        }
+
+        expect(parse(value)).toEqual(expected)
+      })
+
+      it('RW-T11: should trim whitespace from date values', () => {
+        const value = `
+          <?xml version="1.0" encoding="UTF-8"?>
+          <feed xmlns="http://www.w3.org/2005/Atom">
+            <title>Test</title>
+            <id>urn:uuid:test</id>
+            <updated>2024-01-01T00:00:00Z</updated>
+            <entry>
+              <title>Post</title>
+              <id>urn:uuid:1</id>
+              <updated> 2024-01-15T10:30:00Z </updated>
+            </entry>
+          </feed>
+        `
+        const expected = {
+          title: 'Test',
+          id: 'urn:uuid:test',
+          updated: '2024-01-01T00:00:00Z',
+          entries: [{
+            title: 'Post',
+            id: 'urn:uuid:1',
+            updated: '2024-01-15T10:30:00Z',
+          }],
+        }
+
+        expect(parse(value)).toEqual(expected)
+      })
+
+      it('RW-X16: should parse Atom 0.3 feed with legacy namespace and element names', () => {
+        const value = `<feed xmlns="http://purl.org/atom/ns#"><title>Atom 0.3 Feed</title><id>urn:uuid:test</id><modified>2024-01-01T00:00:00Z</modified><tagline>A legacy feed</tagline></feed>`
+        const expected = {
+          title: 'Atom 0.3 Feed',
+          id: 'urn:uuid:test',
+          updated: '2024-01-01T00:00:00Z',
+          subtitle: 'A legacy feed',
+        }
+
+        expect(parse(value)).toEqual(expected)
+      })
+    })
   })
 
   describe('xml comment stripping', () => {

--- a/src/feeds/atom/parse/index.test.ts
+++ b/src/feeds/atom/parse/index.test.ts
@@ -1181,7 +1181,7 @@ describe('parse', () => {
     })
   })
 
-  // Catalogue: plans/real_world_test_suite.md
+  // Edge cases and quirks observed in feeds found in the wild.
   describe('real world feeds', () => {
     describe('character encoding', () => {
       it('RW-E01: should decode HTML numeric character references in entry title', () => {
@@ -1202,11 +1202,13 @@ describe('parse', () => {
           title: 'Test',
           id: 'urn:uuid:test',
           updated: '2024-01-01T00:00:00Z',
-          entries: [{
-            title: 'Caf\u00e9 Culture',
-            id: 'urn:uuid:1',
-            updated: '2024-01-01T00:00:00Z',
-          }],
+          entries: [
+            {
+              title: 'Caf\u00e9 Culture',
+              id: 'urn:uuid:1',
+              updated: '2024-01-01T00:00:00Z',
+            },
+          ],
         }
 
         expect(parse(value)).toEqual(expected)
@@ -1231,12 +1233,14 @@ describe('parse', () => {
           title: 'Test',
           id: 'urn:uuid:test',
           updated: '2024-01-01T00:00:00Z',
-          entries: [{
-            title: 'Post',
-            id: 'urn:uuid:1',
-            updated: '2024-01-01T00:00:00Z',
-            summary: 'First \u2013 Second',
-          }],
+          entries: [
+            {
+              title: 'Post',
+              id: 'urn:uuid:1',
+              updated: '2024-01-01T00:00:00Z',
+              summary: 'First \u2013 Second',
+            },
+          ],
         }
 
         expect(parse(value)).toEqual(expected)
@@ -1260,11 +1264,13 @@ describe('parse', () => {
           title: 'Test',
           id: 'urn:uuid:test',
           updated: '2024-01-01T00:00:00Z',
-          entries: [{
-            title: 'Tom &amp; Jerry',
-            id: 'urn:uuid:1',
-            updated: '2024-01-01T00:00:00Z',
-          }],
+          entries: [
+            {
+              title: 'Tom &amp; Jerry',
+              id: 'urn:uuid:1',
+              updated: '2024-01-01T00:00:00Z',
+            },
+          ],
         }
 
         expect(parse(value)).toEqual(expected)
@@ -1291,12 +1297,14 @@ describe('parse', () => {
           title: 'Test',
           id: 'urn:uuid:test',
           updated: '2024-01-01T00:00:00Z',
-          entries: [{
-            title: 'Post',
-            id: 'urn:uuid:1',
-            updated: '2024-01-01T00:00:00Z',
-            content: '<p>Full <strong>HTML</strong> content</p>',
-          }],
+          entries: [
+            {
+              title: 'Post',
+              id: 'urn:uuid:1',
+              updated: '2024-01-01T00:00:00Z',
+              content: '<p>Full <strong>HTML</strong> content</p>',
+            },
+          ],
         }
 
         expect(parse(value)).toEqual(expected)
@@ -1322,13 +1330,15 @@ describe('parse', () => {
           title: 'Test',
           id: 'urn:uuid:test',
           updated: '2024-01-01T00:00:00Z',
-          entries: [{
-            title: 'Post',
-            id: 'urn:uuid:1',
-            updated: '2024-01-01T00:00:00Z',
-            summary: 'A brief summary',
-            content: 'Full content here',
-          }],
+          entries: [
+            {
+              title: 'Post',
+              id: 'urn:uuid:1',
+              updated: '2024-01-01T00:00:00Z',
+              summary: 'A brief summary',
+              content: 'Full content here',
+            },
+          ],
         }
 
         expect(parse(value)).toEqual(expected)
@@ -1353,11 +1363,13 @@ describe('parse', () => {
           title: 'Test',
           id: 'urn:uuid:test',
           updated: '2024-01-01T00:00:00Z',
-          entries: [{
-            title: 'Post',
-            id: 'urn:uuid:1',
-            updated: '2024-01-01T00:00:00Z',
-          }],
+          entries: [
+            {
+              title: 'Post',
+              id: 'urn:uuid:1',
+              updated: '2024-01-01T00:00:00Z',
+            },
+          ],
         }
 
         expect(parse(value)).toEqual(expected)
@@ -1382,12 +1394,15 @@ describe('parse', () => {
           title: 'Test',
           id: 'urn:uuid:test',
           updated: '2024-01-01T00:00:00Z',
-          entries: [{
-            title: 'Post',
-            id: 'urn:uuid:1',
-            updated: '2024-01-01T00:00:00Z',
-            content: '<div xmlns="http://www.w3.org/1999/xhtml"><p>Hello <em>world</em></p></div>',
-          }],
+          entries: [
+            {
+              title: 'Post',
+              id: 'urn:uuid:1',
+              updated: '2024-01-01T00:00:00Z',
+              content:
+                '<div xmlns="http://www.w3.org/1999/xhtml"><p>Hello <em>world</em></p></div>',
+            },
+          ],
         }
 
         expect(parse(value)).toEqual(expected)
@@ -1412,11 +1427,13 @@ describe('parse', () => {
           title: 'Test',
           id: 'urn:uuid:test',
           updated: '2024-01-01T00:00:00Z',
-          entries: [{
-            title: 'Post',
-            id: 'urn:uuid:1',
-            updated: '2024-01-01T00:00:00Z',
-          }],
+          entries: [
+            {
+              title: 'Post',
+              id: 'urn:uuid:1',
+              updated: '2024-01-01T00:00:00Z',
+            },
+          ],
         }
 
         expect(parse(value)).toEqual(expected)
@@ -1441,12 +1458,15 @@ describe('parse', () => {
           title: 'Test',
           id: 'urn:uuid:test',
           updated: '2024-01-01T00:00:00Z',
-          entries: [{
-            title: 'Post',
-            id: 'urn:uuid:1',
-            updated: '2024-01-01T00:00:00Z',
-            content: '<div xmlns="http://www.w3.org/1999/xhtml"><div class="article"><p>Text</p></div></div>',
-          }],
+          entries: [
+            {
+              title: 'Post',
+              id: 'urn:uuid:1',
+              updated: '2024-01-01T00:00:00Z',
+              content:
+                '<div xmlns="http://www.w3.org/1999/xhtml"><div class="article"><p>Text</p></div></div>',
+            },
+          ],
         }
 
         expect(parse(value)).toEqual(expected)
@@ -1471,12 +1491,14 @@ describe('parse', () => {
           title: 'Test',
           id: 'urn:uuid:test',
           updated: '2024-01-01T00:00:00Z',
-          entries: [{
-            title: 'Post',
-            id: 'urn:uuid:1',
-            updated: '2024-01-01T00:00:00Z',
-            content: 'iVBORw0KGgo=',
-          }],
+          entries: [
+            {
+              title: 'Post',
+              id: 'urn:uuid:1',
+              updated: '2024-01-01T00:00:00Z',
+              content: 'iVBORw0KGgo=',
+            },
+          ],
         }
 
         expect(parse(value)).toEqual(expected)
@@ -1519,12 +1541,14 @@ describe('parse', () => {
           title: 'Test',
           id: 'urn:uuid:test',
           updated: '2024-01-01T00:00:00Z',
-          entries: [{
-            title: 'Post',
-            id: 'urn:uuid:1',
-            updated: '2024-01-01T00:00:00Z',
-            content: '<p>No wrapper</p>',
-          }],
+          entries: [
+            {
+              title: 'Post',
+              id: 'urn:uuid:1',
+              updated: '2024-01-01T00:00:00Z',
+              content: '<p>No wrapper</p>',
+            },
+          ],
         }
 
         expect(parse(value)).toEqual(expected)
@@ -1558,15 +1582,17 @@ describe('parse', () => {
             { href: 'https://example.com/', rel: 'alternate' },
             { href: 'https://example.com/feed.xml', rel: 'self', type: 'application/atom+xml' },
           ],
-          entries: [{
-            title: 'Post',
-            id: 'urn:uuid:1',
-            updated: '2024-01-01T00:00:00Z',
-            links: [
-              { href: 'https://example.com/post/1', rel: 'alternate' },
-              { href: 'https://example.com/post/1/comments', rel: 'replies' },
-            ],
-          }],
+          entries: [
+            {
+              title: 'Post',
+              id: 'urn:uuid:1',
+              updated: '2024-01-01T00:00:00Z',
+              links: [
+                { href: 'https://example.com/post/1', rel: 'alternate' },
+                { href: 'https://example.com/post/1/comments', rel: 'replies' },
+              ],
+            },
+          ],
         }
 
         expect(parse(value)).toEqual(expected)
@@ -1592,15 +1618,17 @@ describe('parse', () => {
           title: 'Test',
           id: 'urn:uuid:test',
           updated: '2024-01-01T00:00:00Z',
-          entries: [{
-            title: 'Post',
-            id: 'urn:uuid:1',
-            updated: '2024-01-01T00:00:00Z',
-            links: [
-              { href: 'https://example.com/en/post', rel: 'alternate', hreflang: 'en' },
-              { href: 'https://example.com/fr/post', rel: 'alternate', hreflang: 'fr' },
-            ],
-          }],
+          entries: [
+            {
+              title: 'Post',
+              id: 'urn:uuid:1',
+              updated: '2024-01-01T00:00:00Z',
+              links: [
+                { href: 'https://example.com/en/post', rel: 'alternate', hreflang: 'en' },
+                { href: 'https://example.com/fr/post', rel: 'alternate', hreflang: 'fr' },
+              ],
+            },
+          ],
         }
 
         expect(parse(value)).toEqual(expected)
@@ -1625,12 +1653,14 @@ describe('parse', () => {
           title: 'Test',
           id: 'urn:uuid:test',
           updated: '2024-01-01T00:00:00Z',
-          entries: [{
-            title: 'Post',
-            id: 'urn:uuid:1',
-            updated: '2024-01-01T00:00:00Z',
-            links: [{ href: '/blog/post-1', rel: 'alternate' }],
-          }],
+          entries: [
+            {
+              title: 'Post',
+              id: 'urn:uuid:1',
+              updated: '2024-01-01T00:00:00Z',
+              links: [{ href: '/blog/post-1', rel: 'alternate' }],
+            },
+          ],
         }
 
         expect(parse(value)).toEqual(expected)
@@ -1657,12 +1687,14 @@ describe('parse', () => {
           id: 'urn:uuid:test',
           updated: '2024-01-01T00:00:00Z',
           links: [{ rel: 'alternate', type: 'text/html' }],
-          entries: [{
-            title: 'Post',
-            id: 'urn:uuid:1',
-            updated: '2024-01-01T00:00:00Z',
-            links: [{ rel: 'alternate' }],
-          }],
+          entries: [
+            {
+              title: 'Post',
+              id: 'urn:uuid:1',
+              updated: '2024-01-01T00:00:00Z',
+              links: [{ rel: 'alternate' }],
+            },
+          ],
         }
 
         expect(parse(value)).toEqual(expected)
@@ -1688,15 +1720,17 @@ describe('parse', () => {
           title: 'Test',
           id: 'urn:uuid:test',
           updated: '2024-01-01T00:00:00Z',
-          entries: [{
-            title: 'Post',
-            id: 'urn:uuid:1',
-            updated: '2024-01-01T00:00:00Z',
-            links: [
-              { href: 'https://example.com/post', rel: 'alternate' },
-              { href: 'https://example.com/post/comments', rel: 'replies' },
-            ],
-          }],
+          entries: [
+            {
+              title: 'Post',
+              id: 'urn:uuid:1',
+              updated: '2024-01-01T00:00:00Z',
+              links: [
+                { href: 'https://example.com/post', rel: 'alternate' },
+                { href: 'https://example.com/post/comments', rel: 'replies' },
+              ],
+            },
+          ],
         }
 
         expect(parse(value)).toEqual(expected)
@@ -1722,15 +1756,17 @@ describe('parse', () => {
           title: 'Test',
           id: 'urn:uuid:test',
           updated: '2024-01-01T00:00:00Z',
-          entries: [{
-            title: 'Post',
-            id: 'urn:uuid:1',
-            updated: '2024-01-01T00:00:00Z',
-            links: [
-              { href: 'https://example.com/image.jpg', rel: 'enclosure', type: 'image/jpeg' },
-              { href: 'https://example.com/post', rel: 'alternate' },
-            ],
-          }],
+          entries: [
+            {
+              title: 'Post',
+              id: 'urn:uuid:1',
+              updated: '2024-01-01T00:00:00Z',
+              links: [
+                { href: 'https://example.com/image.jpg', rel: 'enclosure', type: 'image/jpeg' },
+                { href: 'https://example.com/post', rel: 'alternate' },
+              ],
+            },
+          ],
         }
 
         expect(parse(value)).toEqual(expected)
@@ -1764,15 +1800,17 @@ describe('parse', () => {
           title: 'Test',
           id: 'urn:uuid:test',
           updated: '2024-01-01T00:00:00Z',
-          entries: [{
-            title: 'Co-authored Post',
-            id: 'urn:uuid:1',
-            updated: '2024-01-01T00:00:00Z',
-            authors: [
-              { name: 'Alice', email: 'alice@example.com' },
-              { name: 'Bob', uri: 'https://bob.example.com' },
-            ],
-          }],
+          entries: [
+            {
+              title: 'Co-authored Post',
+              id: 'urn:uuid:1',
+              updated: '2024-01-01T00:00:00Z',
+              authors: [
+                { name: 'Alice', email: 'alice@example.com' },
+                { name: 'Bob', uri: 'https://bob.example.com' },
+              ],
+            },
+          ],
         }
 
         expect(parse(value)).toEqual(expected)
@@ -1796,11 +1834,13 @@ describe('parse', () => {
           title: 'Test',
           id: 'urn:uuid:test',
           updated: '2024-01-01T00:00:00Z',
-          authors: [{
-            name: 'Feed Author',
-            uri: 'https://author.example.com',
-            email: 'author@example.com',
-          }],
+          authors: [
+            {
+              name: 'Feed Author',
+              uri: 'https://author.example.com',
+              email: 'author@example.com',
+            },
+          ],
         }
 
         expect(parse(value)).toEqual(expected)
@@ -1827,13 +1867,15 @@ describe('parse', () => {
           title: 'Test',
           id: 'urn:uuid:test',
           updated: '2024-01-01T00:00:00Z',
-          entries: [{
-            title: 'Post',
-            id: 'urn:uuid:1',
-            updated: '2024-01-01T00:00:00Z',
-            authors: [{ name: 'Main Author' }],
-            contributors: [{ name: 'Editor' }, { name: 'Reviewer' }],
-          }],
+          entries: [
+            {
+              title: 'Post',
+              id: 'urn:uuid:1',
+              updated: '2024-01-01T00:00:00Z',
+              authors: [{ name: 'Main Author' }],
+              contributors: [{ name: 'Editor' }, { name: 'Reviewer' }],
+            },
+          ],
         }
 
         expect(parse(value)).toEqual(expected)
@@ -1860,12 +1902,14 @@ describe('parse', () => {
           title: 'Test',
           id: 'urn:uuid:test',
           updated: '2024-01-01T00:00:00Z',
-          entries: [{
-            title: 'Post',
-            id: 'urn:uuid:1',
-            updated: '2024-01-01T00:00:00Z',
-            authors: [{ email: 'author@example.com' }],
-          }],
+          entries: [
+            {
+              title: 'Post',
+              id: 'urn:uuid:1',
+              updated: '2024-01-01T00:00:00Z',
+              authors: [{ email: 'author@example.com' }],
+            },
+          ],
         }
 
         expect(parse(value)).toEqual(expected)
@@ -1892,12 +1936,14 @@ describe('parse', () => {
           title: 'Test',
           id: 'urn:uuid:test',
           updated: '2024-01-01T00:00:00Z',
-          entries: [{
-            title: 'Post',
-            id: 'urn:uuid:1',
-            updated: '2024-01-01T00:00:00Z',
-            authors: [{ uri: 'https://author.example.com' }],
-          }],
+          entries: [
+            {
+              title: 'Post',
+              id: 'urn:uuid:1',
+              updated: '2024-01-01T00:00:00Z',
+              authors: [{ uri: 'https://author.example.com' }],
+            },
+          ],
         }
 
         expect(parse(value)).toEqual(expected)
@@ -1925,15 +1971,19 @@ describe('parse', () => {
           title: 'Test',
           id: 'urn:uuid:test',
           updated: '2024-01-01T00:00:00Z',
-          entries: [{
-            title: 'Post',
-            id: 'urn:uuid:1',
-            updated: '2024-01-01T00:00:00Z',
-            contributors: [{
-              email: 'jane@example.com',
-              uri: 'https://jane.example.com',
-            }],
-          }],
+          entries: [
+            {
+              title: 'Post',
+              id: 'urn:uuid:1',
+              updated: '2024-01-01T00:00:00Z',
+              contributors: [
+                {
+                  email: 'jane@example.com',
+                  uri: 'https://jane.example.com',
+                },
+              ],
+            },
+          ],
         }
 
         expect(parse(value)).toEqual(expected)
@@ -1972,8 +2022,12 @@ describe('parse', () => {
         expect(result.entries?.[0]?.yt?.videoId).toBe('dQw4w9WgXcQ')
         expect(result.entries?.[0]?.yt?.channelId).toBe('UCxxxxxxxx')
         expect(result.entries?.[0]?.media?.groups?.[0]?.title?.value).toBe('Video Title')
-        expect(result.entries?.[0]?.media?.groups?.[0]?.description?.value).toBe('Video description')
-        expect(result.entries?.[0]?.media?.groups?.[0]?.thumbnails?.[0]?.url).toBe('https://img.youtube.com/thumb.jpg')
+        expect(result.entries?.[0]?.media?.groups?.[0]?.description?.value).toBe(
+          'Video description',
+        )
+        expect(result.entries?.[0]?.media?.groups?.[0]?.thumbnails?.[0]?.url).toBe(
+          'https://img.youtube.com/thumb.jpg',
+        )
       })
 
       it('RW-NS05: should parse feed with media:content on entry', () => {
@@ -1997,7 +2051,9 @@ describe('parse', () => {
 
         expect(result.entries?.[0]?.media?.contents?.[0]?.url).toBe('https://example.com/image.jpg')
         expect(result.entries?.[0]?.media?.contents?.[0]?.type).toBe('image/jpeg')
-        expect(result.entries?.[0]?.media?.thumbnails?.[0]?.url).toBe('https://example.com/thumb.jpg')
+        expect(result.entries?.[0]?.media?.thumbnails?.[0]?.url).toBe(
+          'https://example.com/thumb.jpg',
+        )
       })
 
       it('RW-NS01: should handle non-standard prefix for known namespace URI', () => {
@@ -2020,15 +2076,17 @@ describe('parse', () => {
           title: 'Test',
           id: 'urn:uuid:test',
           updated: '2024-01-01T00:00:00Z',
-          entries: [{
-            title: 'Post',
-            id: 'urn:uuid:1',
-            updated: '2024-01-01T00:00:00Z',
-            dc: {
-              creators: ['Author Name'],
-              creator: 'Author Name',
+          entries: [
+            {
+              title: 'Post',
+              id: 'urn:uuid:1',
+              updated: '2024-01-01T00:00:00Z',
+              dc: {
+                creators: ['Author Name'],
+                creator: 'Author Name',
+              },
             },
-          }],
+          ],
         }
 
         expect(parse(value)).toEqual(expected)
@@ -2081,12 +2139,14 @@ describe('parse', () => {
           title: 'Atom 0.3 Feed',
           id: 'urn:uuid:test',
           updated: '2024-01-01T00:00:00Z',
-          entries: [{
-            title: 'Post',
-            id: 'urn:uuid:1',
-            updated: '2024-01-01T00:00:00Z',
-            content: '<p>Hello <b>world</b></p>',
-          }],
+          entries: [
+            {
+              title: 'Post',
+              id: 'urn:uuid:1',
+              updated: '2024-01-01T00:00:00Z',
+              content: '<p>Hello <b>world</b></p>',
+            },
+          ],
         }
 
         expect(parse(value)).toEqual(expected)
@@ -2112,11 +2172,13 @@ describe('parse', () => {
           title: 'Test',
           id: 'urn:uuid:test',
           updated: '2024-01-01T00:00:00Z',
-          entries: [{
-            id: 'urn:uuid:1',
-            updated: '2024-01-01T00:00:00Z',
-            content: 'Content without title',
-          }],
+          entries: [
+            {
+              id: 'urn:uuid:1',
+              updated: '2024-01-01T00:00:00Z',
+              content: 'Content without title',
+            },
+          ],
         }
 
         expect(parse(value)).toEqual(expected)
@@ -2159,11 +2221,13 @@ describe('parse', () => {
           title: 'Test',
           id: 'urn:uuid:test',
           updated: '2024-01-01T00:00:00Z',
-          entries: [{
-            title: 'Post',
-            id: 'urn:uuid:1',
-            updated: '2024-01-01T00:00:00Z',
-          }],
+          entries: [
+            {
+              title: 'Post',
+              id: 'urn:uuid:1',
+              updated: '2024-01-01T00:00:00Z',
+            },
+          ],
         }
 
         expect(parse(value)).toEqual(expected)
@@ -2188,11 +2252,13 @@ describe('parse', () => {
           title: 'Test',
           id: 'urn:uuid:test',
           updated: '2024-01-01T00:00:00Z',
-          entries: [{
-            id: 'urn:uuid:1',
-            updated: '2024-01-01T00:00:00Z',
-            content: 'Has content but empty title',
-          }],
+          entries: [
+            {
+              id: 'urn:uuid:1',
+              updated: '2024-01-01T00:00:00Z',
+              content: 'Has content but empty title',
+            },
+          ],
         }
 
         expect(parse(value)).toEqual(expected)
@@ -2226,11 +2292,13 @@ describe('parse', () => {
           title: 'Test',
           id: 'urn:uuid:test',
           updated: '2024-01-01T00:00:00Z',
-          entries: [{
-            title: 'Post',
-            id: 'urn:uuid:1',
-            published: '2024-01-15T10:30:00Z',
-          }],
+          entries: [
+            {
+              title: 'Post',
+              id: 'urn:uuid:1',
+              published: '2024-01-15T10:30:00Z',
+            },
+          ],
         }
 
         expect(parse(value)).toEqual(expected)
@@ -2253,10 +2321,12 @@ describe('parse', () => {
           title: 'Test',
           id: 'urn:uuid:test',
           updated: '2024-01-01T00:00:00Z',
-          entries: [{
-            title: 'Post',
-            content: 'Some content here',
-          }],
+          entries: [
+            {
+              title: 'Post',
+              content: 'Some content here',
+            },
+          ],
         }
 
         expect(parse(value)).toEqual(expected)
@@ -2283,12 +2353,14 @@ describe('parse', () => {
           title: 'Test',
           id: 'urn:uuid:test',
           updated: '2024-06-15T14:30:00+02:00',
-          entries: [{
-            title: 'Post',
-            id: 'urn:uuid:1',
-            published: '2024-06-15T12:00:00Z',
-            updated: '2024-06-15T14:30:00+02:00',
-          }],
+          entries: [
+            {
+              title: 'Post',
+              id: 'urn:uuid:1',
+              published: '2024-06-15T12:00:00Z',
+              updated: '2024-06-15T14:30:00+02:00',
+            },
+          ],
         }
 
         expect(parse(value)).toEqual(expected)
@@ -2313,12 +2385,14 @@ describe('parse', () => {
           title: 'Test',
           id: 'urn:uuid:test',
           updated: '2024-01-01T00:00:00Z',
-          entries: [{
-            title: 'Post',
-            id: 'urn:uuid:1',
-            published: '2024-01-01T00:00:00Z',
-            updated: '2024-06-15T12:00:00Z',
-          }],
+          entries: [
+            {
+              title: 'Post',
+              id: 'urn:uuid:1',
+              published: '2024-01-01T00:00:00Z',
+              updated: '2024-06-15T12:00:00Z',
+            },
+          ],
         }
 
         expect(parse(value)).toEqual(expected)
@@ -2381,11 +2455,13 @@ describe('parse', () => {
           title: 'Test',
           id: 'urn:uuid:test',
           updated: '2024-01-01T00:00:00Z',
-          entries: [{
-            title: 'Tom & Jerry',
-            id: 'urn:uuid:1',
-            updated: '2024-01-01T00:00:00Z',
-          }],
+          entries: [
+            {
+              title: 'Tom & Jerry',
+              id: 'urn:uuid:1',
+              updated: '2024-01-01T00:00:00Z',
+            },
+          ],
         }
 
         expect(parse(value)).toEqual(expected)
@@ -2410,12 +2486,14 @@ describe('parse', () => {
           title: 'Test',
           id: 'urn:uuid:test',
           updated: '2024-01-01T00:00:00Z',
-          entries: [{
-            title: 'Post',
-            id: 'urn:uuid:1',
-            updated: '2024-01-01T00:00:00Z',
-            content: 'Hello\u00A0World',
-          }],
+          entries: [
+            {
+              title: 'Post',
+              id: 'urn:uuid:1',
+              updated: '2024-01-01T00:00:00Z',
+              content: 'Hello\u00A0World',
+            },
+          ],
         }
 
         expect(parse(value)).toEqual(expected)
@@ -2472,11 +2550,13 @@ describe('parse', () => {
           title: 'Test Feed',
           id: 'urn:uuid:test',
           updated: '2024-01-01T00:00:00Z',
-          entries: [{
-            title: 'Post Title',
-            id: 'urn:uuid:1',
-            updated: '2024-01-01T00:00:00Z',
-          }],
+          entries: [
+            {
+              title: 'Post Title',
+              id: 'urn:uuid:1',
+              updated: '2024-01-01T00:00:00Z',
+            },
+          ],
         }
 
         expect(parse(value)).toEqual(expected)
@@ -2500,11 +2580,13 @@ describe('parse', () => {
           title: 'Test',
           id: 'urn:uuid:test',
           updated: '2024-01-15T00:00:00Z',
-          entries: [{
-            title: 'Post',
-            id: 'urn:uuid:1',
-            updated: '2024-01-01T00:00:00Z',
-          }],
+          entries: [
+            {
+              title: 'Post',
+              id: 'urn:uuid:1',
+              updated: '2024-01-01T00:00:00Z',
+            },
+          ],
         }
 
         expect(parse(value)).toEqual(expected)
@@ -2531,12 +2613,15 @@ describe('parse', () => {
           title: 'Test',
           id: 'urn:uuid:test',
           updated: '2024-01-01T00:00:00Z',
-          entries: [{
-            title: 'Post',
-            id: 'urn:uuid:1',
-            updated: '2024-01-01T00:00:00Z',
-            content: '<div><img src="test.jpg" /><p>Text with <a href="http://example.com">link</a> and <br/> break</p></div>',
-          }],
+          entries: [
+            {
+              title: 'Post',
+              id: 'urn:uuid:1',
+              updated: '2024-01-01T00:00:00Z',
+              content:
+                '<div><img src="test.jpg" /><p>Text with <a href="http://example.com">link</a> and <br/> break</p></div>',
+            },
+          ],
         }
 
         expect(parse(value)).toEqual(expected)
@@ -2561,12 +2646,14 @@ describe('parse', () => {
           title: 'Test',
           id: 'urn:uuid:test',
           updated: '2024-01-01T00:00:00Z',
-          entries: [{
-            title: 'Post',
-            id: 'urn:uuid:1',
-            updated: '2024-01-01T00:00:00Z',
-            summary: '<p>Escaped paragraph</p>',
-          }],
+          entries: [
+            {
+              title: 'Post',
+              id: 'urn:uuid:1',
+              updated: '2024-01-01T00:00:00Z',
+              summary: '<p>Escaped paragraph</p>',
+            },
+          ],
         }
 
         expect(parse(value)).toEqual(expected)
@@ -2591,10 +2678,12 @@ describe('parse', () => {
           title: 'Test',
           id: 'urn:uuid:test',
           updated: '2024-01-01T00:00:00Z',
-          entries: [{
-            id: 'urn:uuid:1',
-            updated: '2024-01-01T00:00:00Z',
-          }],
+          entries: [
+            {
+              id: 'urn:uuid:1',
+              updated: '2024-01-01T00:00:00Z',
+            },
+          ],
         }
 
         expect(parse(value)).toEqual(expected)
@@ -2644,15 +2733,17 @@ describe('parse', () => {
           title: 'Test',
           id: 'urn:uuid:test',
           updated: '2024-01-01T00:00:00Z',
-          entries: [{
-            title: 'Post',
-            id: 'urn:uuid:1',
-            updated: '2024-01-01T00:00:00Z',
-            categories: [
-              { term: 'tech', scheme: 'https://example.com/categories', label: 'Technology' },
-              { term: 'programming' },
-            ],
-          }],
+          entries: [
+            {
+              title: 'Post',
+              id: 'urn:uuid:1',
+              updated: '2024-01-01T00:00:00Z',
+              categories: [
+                { term: 'tech', scheme: 'https://example.com/categories', label: 'Technology' },
+                { term: 'programming' },
+              ],
+            },
+          ],
         }
 
         expect(parse(value)).toEqual(expected)
@@ -2681,16 +2772,18 @@ describe('parse', () => {
           title: 'Aggregator',
           id: 'urn:uuid:aggregator',
           updated: '2024-01-01T00:00:00Z',
-          entries: [{
-            title: 'Reposted Article',
-            id: 'urn:uuid:1',
-            updated: '2024-01-01T00:00:00Z',
-            source: {
-              title: 'Original Blog',
-              id: 'urn:uuid:original',
-              links: [{ href: 'https://original.example.com', rel: 'alternate' }],
+          entries: [
+            {
+              title: 'Reposted Article',
+              id: 'urn:uuid:1',
+              updated: '2024-01-01T00:00:00Z',
+              source: {
+                title: 'Original Blog',
+                id: 'urn:uuid:original',
+                links: [{ href: 'https://original.example.com', rel: 'alternate' }],
+              },
             },
-          }],
+          ],
         }
 
         expect(parse(value)).toEqual(expected)
@@ -2718,15 +2811,17 @@ describe('parse', () => {
           title: 'Aggregator',
           id: 'urn:uuid:aggregator',
           updated: '2024-01-01T00:00:00Z',
-          entries: [{
-            title: 'Article Title',
-            id: 'urn:uuid:1',
-            updated: '2024-01-01T00:00:00Z',
-            source: {
-              title: 'Blog Name',
-              id: 'urn:uuid:blog',
+          entries: [
+            {
+              title: 'Article Title',
+              id: 'urn:uuid:1',
+              updated: '2024-01-01T00:00:00Z',
+              source: {
+                title: 'Blog Name',
+                id: 'urn:uuid:blog',
+              },
             },
-          }],
+          ],
         }
 
         expect(parse(value)).toEqual(expected)
@@ -2750,11 +2845,13 @@ describe('parse', () => {
           title: 'English Feed',
           id: 'urn:uuid:test',
           updated: '2024-01-01T00:00:00Z',
-          entries: [{
-            title: 'Post',
-            id: 'urn:uuid:1',
-            updated: '2024-01-01T00:00:00Z',
-          }],
+          entries: [
+            {
+              title: 'Post',
+              id: 'urn:uuid:1',
+              updated: '2024-01-01T00:00:00Z',
+            },
+          ],
         }
 
         expect(parse(value)).toEqual(expected)
@@ -2781,12 +2878,14 @@ describe('parse', () => {
           id: 'urn:uuid:test',
           updated: '2024-01-01T00:00:00Z',
           links: [{ href: 'https://example.com/' }],
-          entries: [{
-            title: 'Post',
-            id: 'urn:uuid:1',
-            updated: '2024-01-01T00:00:00Z',
-            links: [{ href: 'https://example.com/post/1' }],
-          }],
+          entries: [
+            {
+              title: 'Post',
+              id: 'urn:uuid:1',
+              updated: '2024-01-01T00:00:00Z',
+              links: [{ href: 'https://example.com/post/1' }],
+            },
+          ],
         }
 
         expect(parse(value)).toEqual(expected)
@@ -2830,11 +2929,13 @@ describe('parse', () => {
           title: 'Test',
           id: 'urn:uuid:test',
           updated: '2024-01-01T00:00:00Z',
-          entries: [{
-            title: 'CSS, &lt;pre&gt;, and more',
-            id: 'urn:uuid:1',
-            updated: '2024-01-01T00:00:00Z',
-          }],
+          entries: [
+            {
+              title: 'CSS, &lt;pre&gt;, and more',
+              id: 'urn:uuid:1',
+              updated: '2024-01-01T00:00:00Z',
+            },
+          ],
         }
 
         expect(parse(value)).toEqual(expected)
@@ -2859,12 +2960,14 @@ describe('parse', () => {
           title: 'Test',
           id: 'urn:uuid:test',
           updated: '2024-01-01T00:00:00Z',
-          entries: [{
-            title: 'Post',
-            id: 'urn:uuid:1',
-            updated: '2024-01-01T00:00:00Z',
-            content: '<p>Hello <strong>world</strong></p>',
-          }],
+          entries: [
+            {
+              title: 'Post',
+              id: 'urn:uuid:1',
+              updated: '2024-01-01T00:00:00Z',
+              content: '<p>Hello <strong>world</strong></p>',
+            },
+          ],
         }
 
         expect(parse(value)).toEqual(expected)
@@ -2890,13 +2993,15 @@ describe('parse', () => {
           title: 'Test',
           id: 'urn:uuid:test',
           updated: '2024-01-01T00:00:00Z',
-          entries: [{
-            title: 'Post',
-            id: 'urn:uuid:1',
-            updated: '2024-01-01T00:00:00Z',
-            content: 'Full article content here',
-            summary: 'Brief summary',
-          }],
+          entries: [
+            {
+              title: 'Post',
+              id: 'urn:uuid:1',
+              updated: '2024-01-01T00:00:00Z',
+              content: 'Full article content here',
+              summary: 'Brief summary',
+            },
+          ],
         }
 
         expect(parse(value)).toEqual(expected)
@@ -2921,12 +3026,14 @@ describe('parse', () => {
           title: 'Test',
           id: 'urn:uuid:test',
           updated: '2024-01-01T00:00:00Z',
-          entries: [{
-            title: 'Post',
-            id: 'urn:uuid:1',
-            updated: '2024-01-01T00:00:00Z',
-            links: [{ href: 'https://example.com/search?q=test&sort=new', rel: 'alternate' }],
-          }],
+          entries: [
+            {
+              title: 'Post',
+              id: 'urn:uuid:1',
+              updated: '2024-01-01T00:00:00Z',
+              links: [{ href: 'https://example.com/search?q=test&sort=new', rel: 'alternate' }],
+            },
+          ],
         }
 
         expect(parse(value)).toEqual(expected)
@@ -2951,12 +3058,14 @@ describe('parse', () => {
           title: 'Test',
           id: 'urn:uuid:test',
           updated: '2024-01-01T00:00:00Z',
-          entries: [{
-            title: 'Post',
-            id: 'urn:uuid:1',
-            updated: '2024-01-01T00:00:00Z',
-            links: [{ rel: 'alternate', type: 'text/html' }],
-          }],
+          entries: [
+            {
+              title: 'Post',
+              id: 'urn:uuid:1',
+              updated: '2024-01-01T00:00:00Z',
+              links: [{ rel: 'alternate', type: 'text/html' }],
+            },
+          ],
         }
 
         expect(parse(value)).toEqual(expected)
@@ -2982,15 +3091,17 @@ describe('parse', () => {
           title: 'Test',
           id: 'urn:uuid:test',
           updated: '2024-01-01T00:00:00Z',
-          entries: [{
-            title: 'Post',
-            id: 'urn:uuid:1',
-            updated: '2024-01-01T00:00:00Z',
-            links: [
-              { href: 'https://example.com/feed/1', rel: 'self' },
-              { href: 'https://example.com/post/1', rel: 'alternate', type: 'text/html' },
-            ],
-          }],
+          entries: [
+            {
+              title: 'Post',
+              id: 'urn:uuid:1',
+              updated: '2024-01-01T00:00:00Z',
+              links: [
+                { href: 'https://example.com/feed/1', rel: 'self' },
+                { href: 'https://example.com/post/1', rel: 'alternate', type: 'text/html' },
+              ],
+            },
+          ],
         }
 
         expect(parse(value)).toEqual(expected)
@@ -3034,11 +3145,13 @@ describe('parse', () => {
           title: 'Test',
           id: 'urn:uuid:test',
           updated: '2024-01-01T00:00:00Z',
-          entries: [{
-            title: 'Post',
-            id: 'urn:uuid:1',
-            updated: '2024-01-01T00:00:00Z',
-          }],
+          entries: [
+            {
+              title: 'Post',
+              id: 'urn:uuid:1',
+              updated: '2024-01-01T00:00:00Z',
+            },
+          ],
         }
 
         expect(parse(value)).toEqual(expected)
@@ -3074,12 +3187,15 @@ describe('parse', () => {
           title: 'Test',
           id: 'urn:uuid:test',
           updated: '2024-01-01T00:00:00Z',
-          entries: [{
-            title: 'Post',
-            id: 'urn:uuid:1',
-            updated: '2024-01-01T00:00:00Z',
-            content: '<div xmlns="http://www.w3.org/1999/xhtml"><details><summary>Click to expand</summary><p>Details here</p></details></div>',
-          }],
+          entries: [
+            {
+              title: 'Post',
+              id: 'urn:uuid:1',
+              updated: '2024-01-01T00:00:00Z',
+              content:
+                '<div xmlns="http://www.w3.org/1999/xhtml"><details><summary>Click to expand</summary><p>Details here</p></details></div>',
+            },
+          ],
         }
 
         expect(parse(value)).toEqual(expected)
@@ -3104,12 +3220,14 @@ describe('parse', () => {
           title: 'Test',
           id: 'urn:uuid:test',
           updated: '2024-01-01T00:00:00Z',
-          entries: [{
-            title: 'Post',
-            id: 'urn:uuid:1',
-            updated: '2024-01-01T00:00:00Z',
-            content: '<math xmlns="http://www.w3.org/1998/Math/MathML"><mi>x</mi></math>',
-          }],
+          entries: [
+            {
+              title: 'Post',
+              id: 'urn:uuid:1',
+              updated: '2024-01-01T00:00:00Z',
+              content: '<math xmlns="http://www.w3.org/1998/Math/MathML"><mi>x</mi></math>',
+            },
+          ],
         }
 
         expect(parse(value)).toEqual(expected)
@@ -3144,11 +3262,13 @@ describe('parse', () => {
           title: 'Test',
           id: 'urn:uuid:test',
           updated: '2024-01-01T00:00:00Z',
-          entries: [{
-            title: 'Post',
-            id: 'urn:uuid:1',
-            updated: '2024-01-15T10:30:00Z',
-          }],
+          entries: [
+            {
+              title: 'Post',
+              id: 'urn:uuid:1',
+              updated: '2024-01-15T10:30:00Z',
+            },
+          ],
         }
 
         expect(parse(value)).toEqual(expected)

--- a/src/feeds/json/parse/index.test.ts
+++ b/src/feeds/json/parse/index.test.ts
@@ -330,7 +330,697 @@ describe('parse', () => {
     })
   })
 
+  // Catalogue: plans/real_world_test_suite.md
   describe('real world feeds', () => {
-    // TODO: Add real world feeds with problematic edge cases.
+    describe('author handling', () => {
+      it('RW-J01: should handle v1 singular author object', () => {
+        const value = {
+          version: 'https://jsonfeed.org/version/1',
+          title: 'Blog',
+          author: { name: 'John Doe', url: 'https://example.com' },
+          items: [{ id: '1', content_text: 'Hello' }],
+        }
+        const expected = {
+          title: 'Blog',
+          authors: [{ name: 'John Doe', url: 'https://example.com' }],
+          items: [{ id: '1', content_text: 'Hello' }],
+        }
+
+        expect(parse(value)).toEqual(expected)
+      })
+
+      it('RW-J01: should prefer v1.1 authors array over v1 author object', () => {
+        const value = {
+          version: 'https://jsonfeed.org/version/1.1',
+          title: 'Blog',
+          authors: [{ name: 'Alice' }, { name: 'Bob' }],
+          author: { name: 'Ignored' },
+          items: [{ id: '1', content_text: 'Hello' }],
+        }
+        const expected = {
+          title: 'Blog',
+          authors: [{ name: 'Alice' }, { name: 'Bob' }],
+          items: [{ id: '1', content_text: 'Hello' }],
+        }
+
+        expect(parse(value)).toEqual(expected)
+      })
+
+      it('RW-J01: should handle author on item level', () => {
+        const value = {
+          version: 'https://jsonfeed.org/version/1.1',
+          title: 'Blog',
+          items: [{
+            id: '1',
+            content_text: 'Hello',
+            authors: [{
+              name: 'Alice',
+              url: 'https://alice.example.com',
+              avatar: 'https://alice.example.com/avatar.jpg',
+            }],
+          }],
+        }
+        const expected = {
+          title: 'Blog',
+          items: [{
+            id: '1',
+            content_text: 'Hello',
+            authors: [{
+              name: 'Alice',
+              url: 'https://alice.example.com',
+              avatar: 'https://alice.example.com/avatar.jpg',
+            }],
+          }],
+        }
+
+        expect(parse(value)).toEqual(expected)
+      })
+    })
+
+    describe('content handling', () => {
+      it('RW-J06: should parse content_html with raw HTML', () => {
+        const value = {
+          version: 'https://jsonfeed.org/version/1.1',
+          title: 'Blog',
+          items: [{
+            id: '1',
+            content_html: '<p>Hello <strong>world</strong></p>',
+          }],
+        }
+        const expected = {
+          title: 'Blog',
+          items: [{
+            id: '1',
+            content_html: '<p>Hello <strong>world</strong></p>',
+          }],
+        }
+
+        expect(parse(value)).toEqual(expected)
+      })
+
+      it('RW-J06: should parse both content_text and content_html', () => {
+        const value = {
+          version: 'https://jsonfeed.org/version/1.1',
+          title: 'Blog',
+          items: [{
+            id: '1',
+            content_text: 'Hello world',
+            content_html: '<p>Hello world</p>',
+          }],
+        }
+        const expected = {
+          title: 'Blog',
+          items: [{
+            id: '1',
+            content_text: 'Hello world',
+            content_html: '<p>Hello world</p>',
+          }],
+        }
+
+        expect(parse(value)).toEqual(expected)
+      })
+
+      it('RW-J06: should handle item with only content_text', () => {
+        const value = {
+          version: 'https://jsonfeed.org/version/1.1',
+          title: 'Blog',
+          items: [{
+            id: '1',
+            content_text: 'Plain text content',
+          }],
+        }
+        const expected = {
+          title: 'Blog',
+          items: [{
+            id: '1',
+            content_text: 'Plain text content',
+          }],
+        }
+
+        expect(parse(value)).toEqual(expected)
+      })
+    })
+
+    describe('attachments', () => {
+      it('RW-M08: should parse attachments with all fields', () => {
+        const value = {
+          version: 'https://jsonfeed.org/version/1.1',
+          title: 'Podcast',
+          items: [{
+            id: '1',
+            content_text: 'Episode notes',
+            attachments: [{
+              url: 'https://example.com/episode.mp3',
+              mime_type: 'audio/mpeg',
+              title: 'Episode 1',
+              size_in_bytes: 12345678,
+              duration_in_seconds: 3600,
+            }],
+          }],
+        }
+        const expected = {
+          title: 'Podcast',
+          items: [{
+            id: '1',
+            content_text: 'Episode notes',
+            attachments: [{
+              url: 'https://example.com/episode.mp3',
+              mime_type: 'audio/mpeg',
+              title: 'Episode 1',
+              size_in_bytes: 12345678,
+              duration_in_seconds: 3600,
+            }],
+          }],
+        }
+
+        expect(parse(value)).toEqual(expected)
+      })
+
+      it('RW-M08: should parse multiple attachments', () => {
+        const value = {
+          version: 'https://jsonfeed.org/version/1.1',
+          title: 'Podcast',
+          items: [{
+            id: '1',
+            content_text: 'Episode',
+            attachments: [
+              { url: 'https://example.com/ep.mp3', mime_type: 'audio/mpeg' },
+              { url: 'https://example.com/ep.ogg', mime_type: 'audio/ogg' },
+            ],
+          }],
+        }
+        const expected = {
+          title: 'Podcast',
+          items: [{
+            id: '1',
+            content_text: 'Episode',
+            attachments: [
+              { url: 'https://example.com/ep.mp3', mime_type: 'audio/mpeg' },
+              { url: 'https://example.com/ep.ogg', mime_type: 'audio/ogg' },
+            ],
+          }],
+        }
+
+        expect(parse(value)).toEqual(expected)
+      })
+    })
+
+    describe('tags', () => {
+      it('RW-J07: should parse tags as array of strings', () => {
+        const value = {
+          version: 'https://jsonfeed.org/version/1.1',
+          title: 'Blog',
+          items: [{
+            id: '1',
+            content_text: 'Hello',
+            tags: ['javascript', 'typescript', 'nodejs'],
+          }],
+        }
+        const expected = {
+          title: 'Blog',
+          items: [{
+            id: '1',
+            content_text: 'Hello',
+            tags: ['javascript', 'typescript', 'nodejs'],
+          }],
+        }
+
+        expect(parse(value)).toEqual(expected)
+      })
+    })
+
+    describe('missing and empty elements', () => {
+      it('RW-N13: should ignore unknown custom fields', () => {
+        const value = {
+          version: 'https://jsonfeed.org/version/1.1',
+          title: 'Blog',
+          custom_extension: { foo: 'bar' },
+          items: [{
+            id: '1',
+            content_text: 'Hello',
+            _custom: 'value',
+          }],
+        }
+        const expected = {
+          title: 'Blog',
+          items: [{
+            id: '1',
+            content_text: 'Hello',
+          }],
+        }
+
+        expect(parse(value)).toEqual(expected)
+      })
+
+      it('RW-N04: should handle null values in fields', () => {
+        const value = {
+          version: 'https://jsonfeed.org/version/1.1',
+          title: 'Blog',
+          description: null,
+          items: [{
+            id: '1',
+            content_text: 'Hello',
+            title: null,
+            summary: null,
+          }],
+        }
+        const expected = {
+          title: 'Blog',
+          items: [{
+            id: '1',
+            content_text: 'Hello',
+          }],
+        }
+
+        expect(parse(value)).toEqual(expected)
+      })
+
+      it('RW-N05: should handle empty string values', () => {
+        const value = {
+          version: 'https://jsonfeed.org/version/1.1',
+          title: 'Blog',
+          description: '',
+          items: [{
+            id: '1',
+            content_text: 'Hello',
+            title: '',
+          }],
+        }
+        const expected = {
+          title: 'Blog',
+          items: [{
+            id: '1',
+            content_text: 'Hello',
+          }],
+        }
+
+        expect(parse(value)).toEqual(expected)
+      })
+
+      it('RW-J03: should handle item with numeric id', () => {
+        const value = {
+          version: 'https://jsonfeed.org/version/1.1',
+          title: 'Blog',
+          items: [{
+            id: 42,
+            content_text: 'Hello',
+          }],
+        }
+        const expected = {
+          title: 'Blog',
+          items: [{
+            id: '42',
+            content_text: 'Hello',
+          }],
+        }
+
+        expect(parse(value)).toEqual(expected)
+      })
+    })
+
+    describe('feed metadata', () => {
+      it('RW-Q08: should parse feed with all metadata fields', () => {
+        const value = {
+          version: 'https://jsonfeed.org/version/1.1',
+          title: 'My Blog',
+          home_page_url: 'https://example.com',
+          feed_url: 'https://example.com/feed.json',
+          description: 'A blog about stuff',
+          icon: 'https://example.com/icon.png',
+          favicon: 'https://example.com/favicon.ico',
+          language: 'en-US',
+          expired: false,
+          items: [{ id: '1', content_text: 'Hello' }],
+        }
+        const expected = {
+          title: 'My Blog',
+          home_page_url: 'https://example.com',
+          feed_url: 'https://example.com/feed.json',
+          description: 'A blog about stuff',
+          icon: 'https://example.com/icon.png',
+          favicon: 'https://example.com/favicon.ico',
+          language: 'en-US',
+          expired: false,
+          items: [{ id: '1', content_text: 'Hello' }],
+        }
+
+        expect(parse(value)).toEqual(expected)
+      })
+
+      it('RW-Q08: should parse hubs for WebSub support', () => {
+        const value = {
+          version: 'https://jsonfeed.org/version/1.1',
+          title: 'Blog',
+          hubs: [{ type: 'WebSub', url: 'https://hub.example.com' }],
+          items: [{ id: '1', content_text: 'Hello' }],
+        }
+        const expected = {
+          title: 'Blog',
+          hubs: [{ type: 'WebSub', url: 'https://hub.example.com' }],
+          items: [{ id: '1', content_text: 'Hello' }],
+        }
+
+        expect(parse(value)).toEqual(expected)
+      })
+    })
+
+    describe('type coercion edge cases', () => {
+      it('RW-J05: should drop boolean id (not coerced to string)', () => {
+        const value = {
+          version: 'https://jsonfeed.org/version/1.1',
+          title: 'Blog',
+          items: [{
+            id: true,
+            content_text: 'Hello',
+          }],
+        }
+        const expected = {
+          title: 'Blog',
+          items: [{
+            content_text: 'Hello',
+          }],
+        }
+
+        expect(parse(value)).toEqual(expected)
+      })
+
+      it('RW-J04: should handle numeric zero as id', () => {
+        const value = {
+          version: 'https://jsonfeed.org/version/1.1',
+          title: 'Blog',
+          items: [{
+            id: 0,
+            content_text: 'Hello',
+          }],
+        }
+        const expected = {
+          title: 'Blog',
+          items: [{
+            id: '0',
+            content_text: 'Hello',
+          }],
+        }
+
+        expect(parse(value)).toEqual(expected)
+      })
+
+      it('RW-J09: should handle expired as true', () => {
+        const value = {
+          version: 'https://jsonfeed.org/version/1.1',
+          title: 'Archived Blog',
+          expired: true,
+          items: [{ id: '1', content_text: 'Old post' }],
+        }
+        const expected = {
+          title: 'Archived Blog',
+          expired: true,
+          items: [{ id: '1', content_text: 'Old post' }],
+        }
+
+        expect(parse(value)).toEqual(expected)
+      })
+    })
+
+    describe('case insensitivity', () => {
+      it('RW-J08: should handle uppercase property names', () => {
+        const value = {
+          version: 'https://jsonfeed.org/version/1.1',
+          Title: 'Blog',
+          DESCRIPTION: 'A test blog',
+          items: [{
+            ID: '1',
+            Content_Text: 'Hello',
+          }],
+        }
+        const expected = {
+          title: 'Blog',
+          description: 'A test blog',
+          items: [{
+            id: '1',
+            content_text: 'Hello',
+          }],
+        }
+
+        expect(parse(value)).toEqual(expected)
+      })
+
+      it('RW-J08: should handle mixed case in nested objects', () => {
+        const value = {
+          version: 'https://jsonfeed.org/version/1.1',
+          title: 'Blog',
+          Authors: [{ Name: 'Alice', URL: 'https://alice.com' }],
+          items: [{ id: '1', content_text: 'Hello' }],
+        }
+        const expected = {
+          title: 'Blog',
+          authors: [{ name: 'Alice', url: 'https://alice.com' }],
+          items: [{ id: '1', content_text: 'Hello' }],
+        }
+
+        expect(parse(value)).toEqual(expected)
+      })
+    })
+
+    describe('unusual but valid structures', () => {
+      it('RW-J02: should handle author as plain string (non-spec but common)', () => {
+        const value = {
+          version: 'https://jsonfeed.org/version/1',
+          title: 'Blog',
+          author: 'John Doe',
+          items: [{ id: '1', content_text: 'Hello' }],
+        }
+        const expected = {
+          title: 'Blog',
+          authors: [{ name: 'John Doe' }],
+          items: [{ id: '1', content_text: 'Hello' }],
+        }
+
+        expect(parse(value)).toEqual(expected)
+      })
+
+      it('RW-N09: should handle empty items array', () => {
+        const value = {
+          version: 'https://jsonfeed.org/version/1.1',
+          title: 'Empty Blog',
+          items: [],
+        }
+        const expected = {
+          title: 'Empty Blog',
+        }
+
+        expect(parse(value)).toEqual(expected)
+      })
+
+      it('RW-N10: should handle items with only empty objects', () => {
+        const value = {
+          version: 'https://jsonfeed.org/version/1.1',
+          title: 'Blog',
+          items: [{}],
+        }
+        const expected = {
+          title: 'Blog',
+        }
+
+        expect(parse(value)).toEqual(expected)
+      })
+
+      it('RW-A10: should handle attachment with no mime_type', () => {
+        const value = {
+          version: 'https://jsonfeed.org/version/1.1',
+          title: 'Podcast',
+          items: [{
+            id: '1',
+            content_text: 'Episode',
+            attachments: [{ url: 'https://example.com/file.mp3' }],
+          }],
+        }
+        const expected = {
+          title: 'Podcast',
+          items: [{
+            id: '1',
+            content_text: 'Episode',
+            attachments: [{ url: 'https://example.com/file.mp3' }],
+          }],
+        }
+
+        expect(parse(value)).toEqual(expected)
+      })
+
+      it('RW-T04: should handle item with date_published and date_modified', () => {
+        const value = {
+          version: 'https://jsonfeed.org/version/1.1',
+          title: 'Blog',
+          items: [{
+            id: '1',
+            content_text: 'Hello',
+            date_published: '2024-01-15T12:00:00Z',
+            date_modified: '2024-01-16T14:30:00+02:00',
+          }],
+        }
+        const expected = {
+          title: 'Blog',
+          items: [{
+            id: '1',
+            content_text: 'Hello',
+            date_published: '2024-01-15T12:00:00Z',
+            date_modified: '2024-01-16T14:30:00+02:00',
+          }],
+        }
+
+        expect(parse(value)).toEqual(expected)
+      })
+
+      it('RW-N11: should handle whitespace-only title', () => {
+        const value = {
+          version: 'https://jsonfeed.org/version/1.1',
+          title: '   ',
+          items: [{ id: '1', content_text: 'Hello' }],
+        }
+        const expected = {
+          items: [{ id: '1', content_text: 'Hello' }],
+        }
+
+        expect(parse(value)).toEqual(expected)
+      })
+
+      it('RW-J07: should handle tags with empty strings filtered out', () => {
+        const value = {
+          version: 'https://jsonfeed.org/version/1.1',
+          title: 'Blog',
+          items: [{
+            id: '1',
+            content_text: 'Hello',
+            tags: ['javascript', '', 'typescript', '   '],
+          }],
+        }
+        const expected = {
+          title: 'Blog',
+          items: [{
+            id: '1',
+            content_text: 'Hello',
+            tags: ['javascript', 'typescript'],
+          }],
+        }
+
+        expect(parse(value)).toEqual(expected)
+      })
+
+      it('RW-J10: should handle authors as plain object instead of array', () => {
+        const value = {
+          version: 'https://jsonfeed.org/version/1.1',
+          title: 'Test Blog',
+          items: [{
+            id: '1',
+            content_text: 'Hello',
+            authors: { name: 'John Doe' },
+          }],
+        }
+        const expected = {
+          title: 'Test Blog',
+          items: [{
+            id: '1',
+            content_text: 'Hello',
+            authors: [{ name: 'John Doe' }],
+          }],
+        }
+
+        expect(parse(value)).toEqual(expected)
+      })
+
+      it('RW-J11: should handle items as single object instead of array', () => {
+        const value = {
+          version: 'https://jsonfeed.org/version/1.1',
+          title: 'Blog',
+          items: {
+            id: '1',
+            content_text: 'Solo post',
+            url: 'https://example.com/post/1',
+          },
+        }
+        const expected = {
+          title: 'Blog',
+          items: [{
+            id: '1',
+            content_text: 'Solo post',
+            url: 'https://example.com/post/1',
+          }],
+        }
+
+        expect(parse(value)).toEqual(expected)
+      })
+
+      it('RW-N25: should drop author with all empty string fields', () => {
+        const value = {
+          version: 'https://jsonfeed.org/version/1.1',
+          title: 'Test',
+          items: [{
+            id: '1',
+            content_text: 'Post',
+            authors: [{ name: '', url: '', avatar: '' }],
+          }],
+        }
+        const expected = {
+          title: 'Test',
+          items: [{
+            id: '1',
+            content_text: 'Post',
+          }],
+        }
+
+        expect(parse(value)).toEqual(expected)
+      })
+
+      it('RW-J12: should parse summary as separate field without content', () => {
+        const value = {
+          version: 'https://jsonfeed.org/version/1.1',
+          title: 'Test',
+          items: [{
+            id: '1',
+            summary: 'This is a summary',
+          }],
+        }
+        const expected = {
+          title: 'Test',
+          items: [{
+            id: '1',
+            summary: 'This is a summary',
+          }],
+        }
+
+        expect(parse(value)).toEqual(expected)
+      })
+
+      it('RW-J13: should coerce string size_in_bytes and duration_in_seconds to numbers', () => {
+        const value = {
+          version: 'https://jsonfeed.org/version/1.1',
+          title: 'Test',
+          items: [{
+            id: '1',
+            content_text: 'Episode',
+            attachments: [{
+              url: 'https://example.com/episode.mp3',
+              mime_type: 'audio/mpeg',
+              size_in_bytes: '12345678',
+              duration_in_seconds: '3661',
+            }],
+          }],
+        }
+        const expected = {
+          title: 'Test',
+          items: [{
+            id: '1',
+            content_text: 'Episode',
+            attachments: [{
+              url: 'https://example.com/episode.mp3',
+              mime_type: 'audio/mpeg',
+              size_in_bytes: 12345678,
+              duration_in_seconds: 3661,
+            }],
+          }],
+        }
+
+        expect(parse(value)).toEqual(expected)
+      })
+    })
   })
 })

--- a/src/feeds/json/parse/index.test.ts
+++ b/src/feeds/json/parse/index.test.ts
@@ -330,7 +330,7 @@ describe('parse', () => {
     })
   })
 
-  // Catalogue: plans/real_world_test_suite.md
+  // Edge cases and quirks observed in feeds found in the wild.
   describe('real world feeds', () => {
     describe('author handling', () => {
       it('RW-J01: should handle v1 singular author object', () => {
@@ -370,27 +370,35 @@ describe('parse', () => {
         const value = {
           version: 'https://jsonfeed.org/version/1.1',
           title: 'Blog',
-          items: [{
-            id: '1',
-            content_text: 'Hello',
-            authors: [{
-              name: 'Alice',
-              url: 'https://alice.example.com',
-              avatar: 'https://alice.example.com/avatar.jpg',
-            }],
-          }],
+          items: [
+            {
+              id: '1',
+              content_text: 'Hello',
+              authors: [
+                {
+                  name: 'Alice',
+                  url: 'https://alice.example.com',
+                  avatar: 'https://alice.example.com/avatar.jpg',
+                },
+              ],
+            },
+          ],
         }
         const expected = {
           title: 'Blog',
-          items: [{
-            id: '1',
-            content_text: 'Hello',
-            authors: [{
-              name: 'Alice',
-              url: 'https://alice.example.com',
-              avatar: 'https://alice.example.com/avatar.jpg',
-            }],
-          }],
+          items: [
+            {
+              id: '1',
+              content_text: 'Hello',
+              authors: [
+                {
+                  name: 'Alice',
+                  url: 'https://alice.example.com',
+                  avatar: 'https://alice.example.com/avatar.jpg',
+                },
+              ],
+            },
+          ],
         }
 
         expect(parse(value)).toEqual(expected)
@@ -402,17 +410,21 @@ describe('parse', () => {
         const value = {
           version: 'https://jsonfeed.org/version/1.1',
           title: 'Blog',
-          items: [{
-            id: '1',
-            content_html: '<p>Hello <strong>world</strong></p>',
-          }],
+          items: [
+            {
+              id: '1',
+              content_html: '<p>Hello <strong>world</strong></p>',
+            },
+          ],
         }
         const expected = {
           title: 'Blog',
-          items: [{
-            id: '1',
-            content_html: '<p>Hello <strong>world</strong></p>',
-          }],
+          items: [
+            {
+              id: '1',
+              content_html: '<p>Hello <strong>world</strong></p>',
+            },
+          ],
         }
 
         expect(parse(value)).toEqual(expected)
@@ -422,19 +434,23 @@ describe('parse', () => {
         const value = {
           version: 'https://jsonfeed.org/version/1.1',
           title: 'Blog',
-          items: [{
-            id: '1',
-            content_text: 'Hello world',
-            content_html: '<p>Hello world</p>',
-          }],
+          items: [
+            {
+              id: '1',
+              content_text: 'Hello world',
+              content_html: '<p>Hello world</p>',
+            },
+          ],
         }
         const expected = {
           title: 'Blog',
-          items: [{
-            id: '1',
-            content_text: 'Hello world',
-            content_html: '<p>Hello world</p>',
-          }],
+          items: [
+            {
+              id: '1',
+              content_text: 'Hello world',
+              content_html: '<p>Hello world</p>',
+            },
+          ],
         }
 
         expect(parse(value)).toEqual(expected)
@@ -444,17 +460,21 @@ describe('parse', () => {
         const value = {
           version: 'https://jsonfeed.org/version/1.1',
           title: 'Blog',
-          items: [{
-            id: '1',
-            content_text: 'Plain text content',
-          }],
+          items: [
+            {
+              id: '1',
+              content_text: 'Plain text content',
+            },
+          ],
         }
         const expected = {
           title: 'Blog',
-          items: [{
-            id: '1',
-            content_text: 'Plain text content',
-          }],
+          items: [
+            {
+              id: '1',
+              content_text: 'Plain text content',
+            },
+          ],
         }
 
         expect(parse(value)).toEqual(expected)
@@ -466,31 +486,39 @@ describe('parse', () => {
         const value = {
           version: 'https://jsonfeed.org/version/1.1',
           title: 'Podcast',
-          items: [{
-            id: '1',
-            content_text: 'Episode notes',
-            attachments: [{
-              url: 'https://example.com/episode.mp3',
-              mime_type: 'audio/mpeg',
-              title: 'Episode 1',
-              size_in_bytes: 12345678,
-              duration_in_seconds: 3600,
-            }],
-          }],
+          items: [
+            {
+              id: '1',
+              content_text: 'Episode notes',
+              attachments: [
+                {
+                  url: 'https://example.com/episode.mp3',
+                  mime_type: 'audio/mpeg',
+                  title: 'Episode 1',
+                  size_in_bytes: 12345678,
+                  duration_in_seconds: 3600,
+                },
+              ],
+            },
+          ],
         }
         const expected = {
           title: 'Podcast',
-          items: [{
-            id: '1',
-            content_text: 'Episode notes',
-            attachments: [{
-              url: 'https://example.com/episode.mp3',
-              mime_type: 'audio/mpeg',
-              title: 'Episode 1',
-              size_in_bytes: 12345678,
-              duration_in_seconds: 3600,
-            }],
-          }],
+          items: [
+            {
+              id: '1',
+              content_text: 'Episode notes',
+              attachments: [
+                {
+                  url: 'https://example.com/episode.mp3',
+                  mime_type: 'audio/mpeg',
+                  title: 'Episode 1',
+                  size_in_bytes: 12345678,
+                  duration_in_seconds: 3600,
+                },
+              ],
+            },
+          ],
         }
 
         expect(parse(value)).toEqual(expected)
@@ -500,25 +528,29 @@ describe('parse', () => {
         const value = {
           version: 'https://jsonfeed.org/version/1.1',
           title: 'Podcast',
-          items: [{
-            id: '1',
-            content_text: 'Episode',
-            attachments: [
-              { url: 'https://example.com/ep.mp3', mime_type: 'audio/mpeg' },
-              { url: 'https://example.com/ep.ogg', mime_type: 'audio/ogg' },
-            ],
-          }],
+          items: [
+            {
+              id: '1',
+              content_text: 'Episode',
+              attachments: [
+                { url: 'https://example.com/ep.mp3', mime_type: 'audio/mpeg' },
+                { url: 'https://example.com/ep.ogg', mime_type: 'audio/ogg' },
+              ],
+            },
+          ],
         }
         const expected = {
           title: 'Podcast',
-          items: [{
-            id: '1',
-            content_text: 'Episode',
-            attachments: [
-              { url: 'https://example.com/ep.mp3', mime_type: 'audio/mpeg' },
-              { url: 'https://example.com/ep.ogg', mime_type: 'audio/ogg' },
-            ],
-          }],
+          items: [
+            {
+              id: '1',
+              content_text: 'Episode',
+              attachments: [
+                { url: 'https://example.com/ep.mp3', mime_type: 'audio/mpeg' },
+                { url: 'https://example.com/ep.ogg', mime_type: 'audio/ogg' },
+              ],
+            },
+          ],
         }
 
         expect(parse(value)).toEqual(expected)
@@ -530,19 +562,23 @@ describe('parse', () => {
         const value = {
           version: 'https://jsonfeed.org/version/1.1',
           title: 'Blog',
-          items: [{
-            id: '1',
-            content_text: 'Hello',
-            tags: ['javascript', 'typescript', 'nodejs'],
-          }],
+          items: [
+            {
+              id: '1',
+              content_text: 'Hello',
+              tags: ['javascript', 'typescript', 'nodejs'],
+            },
+          ],
         }
         const expected = {
           title: 'Blog',
-          items: [{
-            id: '1',
-            content_text: 'Hello',
-            tags: ['javascript', 'typescript', 'nodejs'],
-          }],
+          items: [
+            {
+              id: '1',
+              content_text: 'Hello',
+              tags: ['javascript', 'typescript', 'nodejs'],
+            },
+          ],
         }
 
         expect(parse(value)).toEqual(expected)
@@ -555,18 +591,22 @@ describe('parse', () => {
           version: 'https://jsonfeed.org/version/1.1',
           title: 'Blog',
           custom_extension: { foo: 'bar' },
-          items: [{
-            id: '1',
-            content_text: 'Hello',
-            _custom: 'value',
-          }],
+          items: [
+            {
+              id: '1',
+              content_text: 'Hello',
+              _custom: 'value',
+            },
+          ],
         }
         const expected = {
           title: 'Blog',
-          items: [{
-            id: '1',
-            content_text: 'Hello',
-          }],
+          items: [
+            {
+              id: '1',
+              content_text: 'Hello',
+            },
+          ],
         }
 
         expect(parse(value)).toEqual(expected)
@@ -577,19 +617,23 @@ describe('parse', () => {
           version: 'https://jsonfeed.org/version/1.1',
           title: 'Blog',
           description: null,
-          items: [{
-            id: '1',
-            content_text: 'Hello',
-            title: null,
-            summary: null,
-          }],
+          items: [
+            {
+              id: '1',
+              content_text: 'Hello',
+              title: null,
+              summary: null,
+            },
+          ],
         }
         const expected = {
           title: 'Blog',
-          items: [{
-            id: '1',
-            content_text: 'Hello',
-          }],
+          items: [
+            {
+              id: '1',
+              content_text: 'Hello',
+            },
+          ],
         }
 
         expect(parse(value)).toEqual(expected)
@@ -600,18 +644,22 @@ describe('parse', () => {
           version: 'https://jsonfeed.org/version/1.1',
           title: 'Blog',
           description: '',
-          items: [{
-            id: '1',
-            content_text: 'Hello',
-            title: '',
-          }],
+          items: [
+            {
+              id: '1',
+              content_text: 'Hello',
+              title: '',
+            },
+          ],
         }
         const expected = {
           title: 'Blog',
-          items: [{
-            id: '1',
-            content_text: 'Hello',
-          }],
+          items: [
+            {
+              id: '1',
+              content_text: 'Hello',
+            },
+          ],
         }
 
         expect(parse(value)).toEqual(expected)
@@ -621,17 +669,21 @@ describe('parse', () => {
         const value = {
           version: 'https://jsonfeed.org/version/1.1',
           title: 'Blog',
-          items: [{
-            id: 42,
-            content_text: 'Hello',
-          }],
+          items: [
+            {
+              id: 42,
+              content_text: 'Hello',
+            },
+          ],
         }
         const expected = {
           title: 'Blog',
-          items: [{
-            id: '42',
-            content_text: 'Hello',
-          }],
+          items: [
+            {
+              id: '42',
+              content_text: 'Hello',
+            },
+          ],
         }
 
         expect(parse(value)).toEqual(expected)
@@ -689,16 +741,20 @@ describe('parse', () => {
         const value = {
           version: 'https://jsonfeed.org/version/1.1',
           title: 'Blog',
-          items: [{
-            id: true,
-            content_text: 'Hello',
-          }],
+          items: [
+            {
+              id: true,
+              content_text: 'Hello',
+            },
+          ],
         }
         const expected = {
           title: 'Blog',
-          items: [{
-            content_text: 'Hello',
-          }],
+          items: [
+            {
+              content_text: 'Hello',
+            },
+          ],
         }
 
         expect(parse(value)).toEqual(expected)
@@ -708,17 +764,21 @@ describe('parse', () => {
         const value = {
           version: 'https://jsonfeed.org/version/1.1',
           title: 'Blog',
-          items: [{
-            id: 0,
-            content_text: 'Hello',
-          }],
+          items: [
+            {
+              id: 0,
+              content_text: 'Hello',
+            },
+          ],
         }
         const expected = {
           title: 'Blog',
-          items: [{
-            id: '0',
-            content_text: 'Hello',
-          }],
+          items: [
+            {
+              id: '0',
+              content_text: 'Hello',
+            },
+          ],
         }
 
         expect(parse(value)).toEqual(expected)
@@ -747,18 +807,22 @@ describe('parse', () => {
           version: 'https://jsonfeed.org/version/1.1',
           Title: 'Blog',
           DESCRIPTION: 'A test blog',
-          items: [{
-            ID: '1',
-            Content_Text: 'Hello',
-          }],
+          items: [
+            {
+              ID: '1',
+              Content_Text: 'Hello',
+            },
+          ],
         }
         const expected = {
           title: 'Blog',
           description: 'A test blog',
-          items: [{
-            id: '1',
-            content_text: 'Hello',
-          }],
+          items: [
+            {
+              id: '1',
+              content_text: 'Hello',
+            },
+          ],
         }
 
         expect(parse(value)).toEqual(expected)
@@ -828,19 +892,23 @@ describe('parse', () => {
         const value = {
           version: 'https://jsonfeed.org/version/1.1',
           title: 'Podcast',
-          items: [{
-            id: '1',
-            content_text: 'Episode',
-            attachments: [{ url: 'https://example.com/file.mp3' }],
-          }],
+          items: [
+            {
+              id: '1',
+              content_text: 'Episode',
+              attachments: [{ url: 'https://example.com/file.mp3' }],
+            },
+          ],
         }
         const expected = {
           title: 'Podcast',
-          items: [{
-            id: '1',
-            content_text: 'Episode',
-            attachments: [{ url: 'https://example.com/file.mp3' }],
-          }],
+          items: [
+            {
+              id: '1',
+              content_text: 'Episode',
+              attachments: [{ url: 'https://example.com/file.mp3' }],
+            },
+          ],
         }
 
         expect(parse(value)).toEqual(expected)
@@ -850,21 +918,25 @@ describe('parse', () => {
         const value = {
           version: 'https://jsonfeed.org/version/1.1',
           title: 'Blog',
-          items: [{
-            id: '1',
-            content_text: 'Hello',
-            date_published: '2024-01-15T12:00:00Z',
-            date_modified: '2024-01-16T14:30:00+02:00',
-          }],
+          items: [
+            {
+              id: '1',
+              content_text: 'Hello',
+              date_published: '2024-01-15T12:00:00Z',
+              date_modified: '2024-01-16T14:30:00+02:00',
+            },
+          ],
         }
         const expected = {
           title: 'Blog',
-          items: [{
-            id: '1',
-            content_text: 'Hello',
-            date_published: '2024-01-15T12:00:00Z',
-            date_modified: '2024-01-16T14:30:00+02:00',
-          }],
+          items: [
+            {
+              id: '1',
+              content_text: 'Hello',
+              date_published: '2024-01-15T12:00:00Z',
+              date_modified: '2024-01-16T14:30:00+02:00',
+            },
+          ],
         }
 
         expect(parse(value)).toEqual(expected)
@@ -887,19 +959,23 @@ describe('parse', () => {
         const value = {
           version: 'https://jsonfeed.org/version/1.1',
           title: 'Blog',
-          items: [{
-            id: '1',
-            content_text: 'Hello',
-            tags: ['javascript', '', 'typescript', '   '],
-          }],
+          items: [
+            {
+              id: '1',
+              content_text: 'Hello',
+              tags: ['javascript', '', 'typescript', '   '],
+            },
+          ],
         }
         const expected = {
           title: 'Blog',
-          items: [{
-            id: '1',
-            content_text: 'Hello',
-            tags: ['javascript', 'typescript'],
-          }],
+          items: [
+            {
+              id: '1',
+              content_text: 'Hello',
+              tags: ['javascript', 'typescript'],
+            },
+          ],
         }
 
         expect(parse(value)).toEqual(expected)
@@ -909,19 +985,23 @@ describe('parse', () => {
         const value = {
           version: 'https://jsonfeed.org/version/1.1',
           title: 'Test Blog',
-          items: [{
-            id: '1',
-            content_text: 'Hello',
-            authors: { name: 'John Doe' },
-          }],
+          items: [
+            {
+              id: '1',
+              content_text: 'Hello',
+              authors: { name: 'John Doe' },
+            },
+          ],
         }
         const expected = {
           title: 'Test Blog',
-          items: [{
-            id: '1',
-            content_text: 'Hello',
-            authors: [{ name: 'John Doe' }],
-          }],
+          items: [
+            {
+              id: '1',
+              content_text: 'Hello',
+              authors: [{ name: 'John Doe' }],
+            },
+          ],
         }
 
         expect(parse(value)).toEqual(expected)
@@ -939,11 +1019,13 @@ describe('parse', () => {
         }
         const expected = {
           title: 'Blog',
-          items: [{
-            id: '1',
-            content_text: 'Solo post',
-            url: 'https://example.com/post/1',
-          }],
+          items: [
+            {
+              id: '1',
+              content_text: 'Solo post',
+              url: 'https://example.com/post/1',
+            },
+          ],
         }
 
         expect(parse(value)).toEqual(expected)
@@ -953,18 +1035,22 @@ describe('parse', () => {
         const value = {
           version: 'https://jsonfeed.org/version/1.1',
           title: 'Test',
-          items: [{
-            id: '1',
-            content_text: 'Post',
-            authors: [{ name: '', url: '', avatar: '' }],
-          }],
+          items: [
+            {
+              id: '1',
+              content_text: 'Post',
+              authors: [{ name: '', url: '', avatar: '' }],
+            },
+          ],
         }
         const expected = {
           title: 'Test',
-          items: [{
-            id: '1',
-            content_text: 'Post',
-          }],
+          items: [
+            {
+              id: '1',
+              content_text: 'Post',
+            },
+          ],
         }
 
         expect(parse(value)).toEqual(expected)
@@ -974,17 +1060,21 @@ describe('parse', () => {
         const value = {
           version: 'https://jsonfeed.org/version/1.1',
           title: 'Test',
-          items: [{
-            id: '1',
-            summary: 'This is a summary',
-          }],
+          items: [
+            {
+              id: '1',
+              summary: 'This is a summary',
+            },
+          ],
         }
         const expected = {
           title: 'Test',
-          items: [{
-            id: '1',
-            summary: 'This is a summary',
-          }],
+          items: [
+            {
+              id: '1',
+              summary: 'This is a summary',
+            },
+          ],
         }
 
         expect(parse(value)).toEqual(expected)
@@ -994,29 +1084,37 @@ describe('parse', () => {
         const value = {
           version: 'https://jsonfeed.org/version/1.1',
           title: 'Test',
-          items: [{
-            id: '1',
-            content_text: 'Episode',
-            attachments: [{
-              url: 'https://example.com/episode.mp3',
-              mime_type: 'audio/mpeg',
-              size_in_bytes: '12345678',
-              duration_in_seconds: '3661',
-            }],
-          }],
+          items: [
+            {
+              id: '1',
+              content_text: 'Episode',
+              attachments: [
+                {
+                  url: 'https://example.com/episode.mp3',
+                  mime_type: 'audio/mpeg',
+                  size_in_bytes: '12345678',
+                  duration_in_seconds: '3661',
+                },
+              ],
+            },
+          ],
         }
         const expected = {
           title: 'Test',
-          items: [{
-            id: '1',
-            content_text: 'Episode',
-            attachments: [{
-              url: 'https://example.com/episode.mp3',
-              mime_type: 'audio/mpeg',
-              size_in_bytes: 12345678,
-              duration_in_seconds: 3661,
-            }],
-          }],
+          items: [
+            {
+              id: '1',
+              content_text: 'Episode',
+              attachments: [
+                {
+                  url: 'https://example.com/episode.mp3',
+                  mime_type: 'audio/mpeg',
+                  size_in_bytes: 12345678,
+                  duration_in_seconds: 3661,
+                },
+              ],
+            },
+          ],
         }
 
         expect(parse(value)).toEqual(expected)

--- a/src/feeds/rdf/parse/index.test.ts
+++ b/src/feeds/rdf/parse/index.test.ts
@@ -1541,7 +1541,7 @@ describe('parse', () => {
     })
   })
 
-  // Catalogue: plans/real_world_test_suite.md
+  // Edge cases and quirks observed in feeds found in the wild.
   describe('real world feeds', () => {
     describe('character encoding', () => {
       it('RW-E01: should decode HTML numeric character references', () => {
@@ -1582,10 +1582,12 @@ describe('parse', () => {
           title: 'Test',
           link: 'http://example.com',
           description: 'Test',
-          items: [{
-            title: 'News \u2013 Update',
-            rdf: { about: 'http://example.com/1' },
-          }],
+          items: [
+            {
+              title: 'News \u2013 Update',
+              rdf: { about: 'http://example.com/1' },
+            },
+          ],
         }
 
         expect(parse(value)).toEqual(expected)
@@ -1612,11 +1614,13 @@ describe('parse', () => {
           title: 'Test',
           link: 'http://example.com',
           description: 'Test',
-          items: [{
-            title: 'Item',
-            description: '<p>HTML with <strong>bold</strong></p>',
-            rdf: { about: 'http://example.com/1' },
-          }],
+          items: [
+            {
+              title: 'Item',
+              description: '<p>HTML with <strong>bold</strong></p>',
+              rdf: { about: 'http://example.com/1' },
+            },
+          ],
         }
 
         expect(parse(value)).toEqual(expected)
@@ -1666,16 +1670,18 @@ describe('parse', () => {
           title: 'Test',
           link: 'http://example.com',
           description: 'Test',
-          items: [{
-            title: 'Post',
-            dc: {
-              creators: ['Author'],
-              creator: 'Author',
-              dates: ['2024-01-15'],
-              date: '2024-01-15',
+          items: [
+            {
+              title: 'Post',
+              dc: {
+                creators: ['Author'],
+                creator: 'Author',
+                dates: ['2024-01-15'],
+                date: '2024-01-15',
+              },
+              rdf: { about: 'http://example.com/1' },
             },
-            rdf: { about: 'http://example.com/1' },
-          }],
+          ],
         }
 
         expect(parse(value)).toEqual(expected)
@@ -1702,11 +1708,13 @@ describe('parse', () => {
           title: 'Test',
           link: 'http://example.com',
           description: 'Test',
-          items: [{
-            title: 'Title Only',
-            link: 'http://example.com/1',
-            rdf: { about: 'http://example.com/1' },
-          }],
+          items: [
+            {
+              title: 'Title Only',
+              link: 'http://example.com/1',
+              rdf: { about: 'http://example.com/1' },
+            },
+          ],
         }
 
         expect(parse(value)).toEqual(expected)
@@ -1776,14 +1784,16 @@ describe('parse', () => {
           title: 'Test',
           link: 'http://example.com',
           description: 'Test',
-          items: [{
-            title: 'Post',
-            dc: {
-              subjects: ['Technology', 'Science', 'Open Source'],
-              subject: 'Technology',
+          items: [
+            {
+              title: 'Post',
+              dc: {
+                subjects: ['Technology', 'Science', 'Open Source'],
+                subject: 'Technology',
+              },
+              rdf: { about: 'http://example.com/1' },
             },
-            rdf: { about: 'http://example.com/1' },
-          }],
+          ],
         }
 
         expect(parse(value)).toEqual(expected)
@@ -1812,13 +1822,16 @@ describe('parse', () => {
           title: 'Test',
           link: 'http://example.com',
           description: 'Test',
-          items: [{
-            title: 'Post',
-            content: {
-              encoded: '<div class="post"><h1>Title</h1><p>Text with <a href="https://example.com">link</a></p></div>',
+          items: [
+            {
+              title: 'Post',
+              content: {
+                encoded:
+                  '<div class="post"><h1>Title</h1><p>Text with <a href="https://example.com">link</a></p></div>',
+              },
+              rdf: { about: 'http://example.com/1' },
             },
-            rdf: { about: 'http://example.com/1' },
-          }],
+          ],
         }
 
         expect(parse(value)).toEqual(expected)
@@ -1863,10 +1876,12 @@ describe('parse', () => {
           title: 'Test',
           link: 'http://example.com',
           description: 'Test',
-          items: [{
-            title: 'Hello\u00A0World',
-            rdf: { about: 'http://example.com/1' },
-          }],
+          items: [
+            {
+              title: 'Hello\u00A0World',
+              rdf: { about: 'http://example.com/1' },
+            },
+          ],
         }
 
         expect(parse(value)).toEqual(expected)
@@ -1906,10 +1921,12 @@ describe('parse', () => {
           title: 'Test',
           link: 'http://example.com',
           description: 'Test',
-          items: [{
-            title: 'Tom &amp; Jerry',
-            rdf: { about: 'http://example.com/1' },
-          }],
+          items: [
+            {
+              title: 'Tom &amp; Jerry',
+              rdf: { about: 'http://example.com/1' },
+            },
+          ],
         }
 
         expect(parse(value)).toEqual(expected)
@@ -1965,9 +1982,21 @@ describe('parse', () => {
           link: 'http://example.com',
           description: 'Test',
           items: [
-            { title: 'First', link: 'http://example.com/1', rdf: { about: 'http://example.com/1' } },
-            { title: 'Second', link: 'http://example.com/2', rdf: { about: 'http://example.com/2' } },
-            { title: 'Third', link: 'http://example.com/3', rdf: { about: 'http://example.com/3' } },
+            {
+              title: 'First',
+              link: 'http://example.com/1',
+              rdf: { about: 'http://example.com/1' },
+            },
+            {
+              title: 'Second',
+              link: 'http://example.com/2',
+              rdf: { about: 'http://example.com/2' },
+            },
+            {
+              title: 'Third',
+              link: 'http://example.com/3',
+              rdf: { about: 'http://example.com/3' },
+            },
           ],
         }
 
@@ -1994,11 +2023,13 @@ describe('parse', () => {
           title: 'Prefixed Feed',
           link: 'http://example.com',
           description: 'A feed using prefixed RSS elements',
-          items: [{
-            title: 'Prefixed Item',
-            link: 'http://example.com/1',
-            rdf: { about: 'http://example.com/1' },
-          }],
+          items: [
+            {
+              title: 'Prefixed Item',
+              link: 'http://example.com/1',
+              rdf: { about: 'http://example.com/1' },
+            },
+          ],
         }
 
         expect(parse(value)).toEqual(expected)
@@ -2023,10 +2054,12 @@ describe('parse', () => {
           title: 'Test',
           link: 'http://example.com',
           description: 'Test',
-          items: [{
-            title: 'No About',
-            link: 'http://example.com/1',
-          }],
+          items: [
+            {
+              title: 'No About',
+              link: 'http://example.com/1',
+            },
+          ],
         }
 
         expect(parse(value)).toEqual(expected)

--- a/src/feeds/rdf/parse/index.test.ts
+++ b/src/feeds/rdf/parse/index.test.ts
@@ -1541,8 +1541,537 @@ describe('parse', () => {
     })
   })
 
+  // Catalogue: plans/real_world_test_suite.md
   describe('real world feeds', () => {
-    // TODO: Add real world feeds with problematic edge cases.
+    describe('character encoding', () => {
+      it('RW-E01: should decode HTML numeric character references', () => {
+        const value = `
+          <?xml version="1.0" encoding="UTF-8"?>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns="http://purl.org/rss/1.0/">
+            <channel>
+              <title>Caf&#233; Blog</title>
+              <link>http://example.com</link>
+              <description>Test</description>
+            </channel>
+          </rdf:RDF>
+        `
+        const expected = {
+          title: 'Caf\u00e9 Blog',
+          link: 'http://example.com',
+          description: 'Test',
+        }
+
+        expect(parse(value)).toEqual(expected)
+      })
+
+      it('RW-E03: should decode named HTML entities in item title', () => {
+        const value = `
+          <?xml version="1.0" encoding="UTF-8"?>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns="http://purl.org/rss/1.0/">
+            <channel>
+              <title>Test</title>
+              <link>http://example.com</link>
+              <description>Test</description>
+            </channel>
+            <item rdf:about="http://example.com/1">
+              <title>News &ndash; Update</title>
+            </item>
+          </rdf:RDF>
+        `
+        const expected = {
+          title: 'Test',
+          link: 'http://example.com',
+          description: 'Test',
+          items: [{
+            title: 'News \u2013 Update',
+            rdf: { about: 'http://example.com/1' },
+          }],
+        }
+
+        expect(parse(value)).toEqual(expected)
+      })
+    })
+
+    describe('cdata handling', () => {
+      it('RW-C09: should handle CDATA in item description', () => {
+        const value = `
+          <?xml version="1.0" encoding="UTF-8"?>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns="http://purl.org/rss/1.0/">
+            <channel>
+              <title>Test</title>
+              <link>http://example.com</link>
+              <description>Test</description>
+            </channel>
+            <item rdf:about="http://example.com/1">
+              <title>Item</title>
+              <description><![CDATA[<p>HTML with <strong>bold</strong></p>]]></description>
+            </item>
+          </rdf:RDF>
+        `
+        const expected = {
+          title: 'Test',
+          link: 'http://example.com',
+          description: 'Test',
+          items: [{
+            title: 'Item',
+            description: '<p>HTML with <strong>bold</strong></p>',
+            rdf: { about: 'http://example.com/1' },
+          }],
+        }
+
+        expect(parse(value)).toEqual(expected)
+      })
+
+      it('RW-C02: should handle CDATA in channel title', () => {
+        const value = `
+          <?xml version="1.0" encoding="UTF-8"?>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns="http://purl.org/rss/1.0/">
+            <channel>
+              <title><![CDATA[Test & Blog]]></title>
+              <link>http://example.com</link>
+              <description>Test</description>
+            </channel>
+          </rdf:RDF>
+        `
+        const expected = {
+          title: 'Test & Blog',
+          link: 'http://example.com',
+          description: 'Test',
+        }
+
+        expect(parse(value)).toEqual(expected)
+      })
+    })
+
+    describe('namespace edge cases', () => {
+      it('RW-NS01: should handle non-standard prefix for dc namespace', () => {
+        const value = `
+          <?xml version="1.0" encoding="UTF-8"?>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+                   xmlns="http://purl.org/rss/1.0/"
+                   xmlns:dublin="http://purl.org/dc/elements/1.1/">
+            <channel>
+              <title>Test</title>
+              <link>http://example.com</link>
+              <description>Test</description>
+            </channel>
+            <item rdf:about="http://example.com/1">
+              <title>Post</title>
+              <dublin:creator>Author</dublin:creator>
+              <dublin:date>2024-01-15</dublin:date>
+            </item>
+          </rdf:RDF>
+        `
+        const expected = {
+          title: 'Test',
+          link: 'http://example.com',
+          description: 'Test',
+          items: [{
+            title: 'Post',
+            dc: {
+              creators: ['Author'],
+              creator: 'Author',
+              dates: ['2024-01-15'],
+              date: '2024-01-15',
+            },
+            rdf: { about: 'http://example.com/1' },
+          }],
+        }
+
+        expect(parse(value)).toEqual(expected)
+      })
+    })
+
+    describe('missing and empty elements', () => {
+      it('RW-N08: should parse item with no description', () => {
+        const value = `
+          <?xml version="1.0" encoding="UTF-8"?>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns="http://purl.org/rss/1.0/">
+            <channel>
+              <title>Test</title>
+              <link>http://example.com</link>
+              <description>Test</description>
+            </channel>
+            <item rdf:about="http://example.com/1">
+              <title>Title Only</title>
+              <link>http://example.com/1</link>
+            </item>
+          </rdf:RDF>
+        `
+        const expected = {
+          title: 'Test',
+          link: 'http://example.com',
+          description: 'Test',
+          items: [{
+            title: 'Title Only',
+            link: 'http://example.com/1',
+            rdf: { about: 'http://example.com/1' },
+          }],
+        }
+
+        expect(parse(value)).toEqual(expected)
+      })
+
+      it('RW-N01: should parse feed with no items', () => {
+        const value = `
+          <?xml version="1.0" encoding="UTF-8"?>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns="http://purl.org/rss/1.0/">
+            <channel>
+              <title>Empty</title>
+              <link>http://example.com</link>
+              <description>No items</description>
+            </channel>
+          </rdf:RDF>
+        `
+        const expected = {
+          title: 'Empty',
+          link: 'http://example.com',
+          description: 'No items',
+        }
+
+        expect(parse(value)).toEqual(expected)
+      })
+
+      it('RW-N03: should handle empty self-closing description', () => {
+        const value = `
+          <?xml version="1.0" encoding="UTF-8"?>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns="http://purl.org/rss/1.0/">
+            <channel>
+              <title>Test</title>
+              <link>http://example.com</link>
+              <description/>
+            </channel>
+          </rdf:RDF>
+        `
+        const expected = {
+          title: 'Test',
+          link: 'http://example.com',
+        }
+
+        expect(parse(value)).toEqual(expected)
+      })
+    })
+
+    describe('multiple elements', () => {
+      it('RW-M04: should parse multiple dc:subject as categories', () => {
+        const value = `
+          <?xml version="1.0" encoding="UTF-8"?>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+                   xmlns="http://purl.org/rss/1.0/"
+                   xmlns:dc="http://purl.org/dc/elements/1.1/">
+            <channel>
+              <title>Test</title>
+              <link>http://example.com</link>
+              <description>Test</description>
+            </channel>
+            <item rdf:about="http://example.com/1">
+              <title>Post</title>
+              <dc:subject>Technology</dc:subject>
+              <dc:subject>Science</dc:subject>
+              <dc:subject>Open Source</dc:subject>
+            </item>
+          </rdf:RDF>
+        `
+        const expected = {
+          title: 'Test',
+          link: 'http://example.com',
+          description: 'Test',
+          items: [{
+            title: 'Post',
+            dc: {
+              subjects: ['Technology', 'Science', 'Open Source'],
+              subject: 'Technology',
+            },
+            rdf: { about: 'http://example.com/1' },
+          }],
+        }
+
+        expect(parse(value)).toEqual(expected)
+      })
+    })
+
+    describe('content:encoded', () => {
+      it('RW-NS09: should parse content:encoded with complex HTML in CDATA', () => {
+        const value = `
+          <?xml version="1.0" encoding="UTF-8"?>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+                   xmlns="http://purl.org/rss/1.0/"
+                   xmlns:content="http://purl.org/rss/1.0/modules/content/">
+            <channel>
+              <title>Test</title>
+              <link>http://example.com</link>
+              <description>Test</description>
+            </channel>
+            <item rdf:about="http://example.com/1">
+              <title>Post</title>
+              <content:encoded><![CDATA[<div class="post"><h1>Title</h1><p>Text with <a href="https://example.com">link</a></p></div>]]></content:encoded>
+            </item>
+          </rdf:RDF>
+        `
+        const expected = {
+          title: 'Test',
+          link: 'http://example.com',
+          description: 'Test',
+          items: [{
+            title: 'Post',
+            content: {
+              encoded: '<div class="post"><h1>Title</h1><p>Text with <a href="https://example.com">link</a></p></div>',
+            },
+            rdf: { about: 'http://example.com/1' },
+          }],
+        }
+
+        expect(parse(value)).toEqual(expected)
+      })
+    })
+
+    describe('malformed XML resilience', () => {
+      it('RW-E10: should handle BOM at start of feed', () => {
+        const value = `\uFEFF<?xml version="1.0" encoding="UTF-8"?>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns="http://purl.org/rss/1.0/">
+            <channel>
+              <title>BOM Feed</title>
+              <link>http://example.com</link>
+              <description>Test</description>
+            </channel>
+          </rdf:RDF>
+        `
+        const expected = {
+          title: 'BOM Feed',
+          link: 'http://example.com',
+          description: 'Test',
+        }
+
+        expect(parse(value)).toEqual(expected)
+      })
+
+      it('RW-E06: should decode &nbsp; entity in item title', () => {
+        const value = `
+          <?xml version="1.0" encoding="UTF-8"?>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns="http://purl.org/rss/1.0/">
+            <channel>
+              <title>Test</title>
+              <link>http://example.com</link>
+              <description>Test</description>
+            </channel>
+            <item rdf:about="http://example.com/1">
+              <title>Hello&nbsp;World</title>
+            </item>
+          </rdf:RDF>
+        `
+        const expected = {
+          title: 'Test',
+          link: 'http://example.com',
+          description: 'Test',
+          items: [{
+            title: 'Hello\u00A0World',
+            rdf: { about: 'http://example.com/1' },
+          }],
+        }
+
+        expect(parse(value)).toEqual(expected)
+      })
+
+      it('RW-X01: should partially parse truncated XML without throwing', () => {
+        const value = `
+          <?xml version="1.0" encoding="UTF-8"?>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns="http://purl.org/rss/1.0/">
+            <channel>
+              <title>Test</title>
+        `
+        const expected = {
+          title: 'Test',
+        }
+
+        expect(parse(value)).toEqual(expected)
+      })
+    })
+
+    describe('double-encoded and special entities', () => {
+      it('RW-E04: should single-decode double-encoded entities', () => {
+        const value = `
+          <?xml version="1.0" encoding="UTF-8"?>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns="http://purl.org/rss/1.0/">
+            <channel>
+              <title>Test</title>
+              <link>http://example.com</link>
+              <description>Test</description>
+            </channel>
+            <item rdf:about="http://example.com/1">
+              <title>Tom &amp;amp; Jerry</title>
+            </item>
+          </rdf:RDF>
+        `
+        const expected = {
+          title: 'Test',
+          link: 'http://example.com',
+          description: 'Test',
+          items: [{
+            title: 'Tom &amp; Jerry',
+            rdf: { about: 'http://example.com/1' },
+          }],
+        }
+
+        expect(parse(value)).toEqual(expected)
+      })
+
+      it('RW-E07: should decode &copy; entity', () => {
+        const value = `
+          <?xml version="1.0" encoding="UTF-8"?>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns="http://purl.org/rss/1.0/">
+            <channel>
+              <title>&copy; 2024 Example</title>
+              <link>http://example.com</link>
+              <description>Test</description>
+            </channel>
+          </rdf:RDF>
+        `
+        const expected = {
+          title: '\u00A9 2024 Example',
+          link: 'http://example.com',
+          description: 'Test',
+        }
+
+        expect(parse(value)).toEqual(expected)
+      })
+    })
+
+    describe('multiple items and rdf:about', () => {
+      it('RW-M07: should parse multiple items preserving rdf:about on each', () => {
+        const value = `
+          <?xml version="1.0" encoding="UTF-8"?>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns="http://purl.org/rss/1.0/">
+            <channel>
+              <title>Test</title>
+              <link>http://example.com</link>
+              <description>Test</description>
+            </channel>
+            <item rdf:about="http://example.com/1">
+              <title>First</title>
+              <link>http://example.com/1</link>
+            </item>
+            <item rdf:about="http://example.com/2">
+              <title>Second</title>
+              <link>http://example.com/2</link>
+            </item>
+            <item rdf:about="http://example.com/3">
+              <title>Third</title>
+              <link>http://example.com/3</link>
+            </item>
+          </rdf:RDF>
+        `
+        const expected = {
+          title: 'Test',
+          link: 'http://example.com',
+          description: 'Test',
+          items: [
+            { title: 'First', link: 'http://example.com/1', rdf: { about: 'http://example.com/1' } },
+            { title: 'Second', link: 'http://example.com/2', rdf: { about: 'http://example.com/2' } },
+            { title: 'Third', link: 'http://example.com/3', rdf: { about: 'http://example.com/3' } },
+          ],
+        }
+
+        expect(parse(value)).toEqual(expected)
+      })
+
+      it('RW-NS13: should handle prefixed core elements in RDF feed', () => {
+        const value = `
+          <?xml version="1.0" encoding="UTF-8"?>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+                   xmlns:rss="http://purl.org/rss/1.0/">
+            <rss:channel>
+              <rss:title>Prefixed Feed</rss:title>
+              <rss:link>http://example.com</rss:link>
+              <rss:description>A feed using prefixed RSS elements</rss:description>
+            </rss:channel>
+            <rss:item rdf:about="http://example.com/1">
+              <rss:title>Prefixed Item</rss:title>
+              <rss:link>http://example.com/1</rss:link>
+            </rss:item>
+          </rdf:RDF>
+        `
+        const expected = {
+          title: 'Prefixed Feed',
+          link: 'http://example.com',
+          description: 'A feed using prefixed RSS elements',
+          items: [{
+            title: 'Prefixed Item',
+            link: 'http://example.com/1',
+            rdf: { about: 'http://example.com/1' },
+          }],
+        }
+
+        expect(parse(value)).toEqual(expected)
+      })
+
+      it('RW-N12: should handle item with no rdf:about', () => {
+        const value = `
+          <?xml version="1.0" encoding="UTF-8"?>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns="http://purl.org/rss/1.0/">
+            <channel>
+              <title>Test</title>
+              <link>http://example.com</link>
+              <description>Test</description>
+            </channel>
+            <item>
+              <title>No About</title>
+              <link>http://example.com/1</link>
+            </item>
+          </rdf:RDF>
+        `
+        const expected = {
+          title: 'Test',
+          link: 'http://example.com',
+          description: 'Test',
+          items: [{
+            title: 'No About',
+            link: 'http://example.com/1',
+          }],
+        }
+
+        expect(parse(value)).toEqual(expected)
+      })
+
+      it('RW-X15: should parse items as top-level siblings outside channel', () => {
+        const value = `
+          <?xml version="1.0" encoding="UTF-8"?>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns="http://purl.org/rss/1.0/">
+            <channel>
+              <title>Test Channel</title>
+              <link>http://example.com</link>
+              <description>A test channel</description>
+            </channel>
+            <item rdf:about="http://example.com/1">
+              <title>First Item</title>
+              <link>http://example.com/1</link>
+            </item>
+            <item rdf:about="http://example.com/2">
+              <title>Second Item</title>
+              <link>http://example.com/2</link>
+            </item>
+          </rdf:RDF>
+        `
+        const expected = {
+          title: 'Test Channel',
+          link: 'http://example.com',
+          description: 'A test channel',
+          items: [
+            {
+              title: 'First Item',
+              link: 'http://example.com/1',
+              rdf: { about: 'http://example.com/1' },
+            },
+            {
+              title: 'Second Item',
+              link: 'http://example.com/2',
+              rdf: { about: 'http://example.com/2' },
+            },
+          ],
+        }
+
+        expect(parse(value)).toEqual(expected)
+      })
+    })
   })
 
   describe('xml comment stripping', () => {

--- a/src/feeds/rss/parse/index.test.ts
+++ b/src/feeds/rss/parse/index.test.ts
@@ -870,8 +870,9 @@ describe('parse', () => {
     })
   })
 
+  // Catalogue: plans/real_world_test_suite.md
   describe('real world feeds', () => {
-    it('should preserve HTML entities inside CDATA in content:encoded', () => {
+    it('RW-C01: should preserve HTML entities inside CDATA in content:encoded', () => {
       const value = `
         <?xml version="1.0" encoding="UTF-8"?>
         <rss version="2.0" xmlns:content="http://purl.org/rss/1.0/modules/content/">
@@ -906,7 +907,7 @@ describe('parse', () => {
     })
 
     describe('author', () => {
-      it('should parse item author as plain text', () => {
+      it('RW-M03: should parse item author as plain text', () => {
         const value = `
           <?xml version="1.0" encoding="UTF-8"?>
           <rss version="2.0">
@@ -936,7 +937,7 @@ describe('parse', () => {
         expect(parse(value)).toEqual(expected)
       })
 
-      it('should parse item author with nested name element', () => {
+      it('RW-M03: should parse item author with nested name element', () => {
         const value = `
           <?xml version="1.0" encoding="UTF-8"?>
           <rss version="2.0">
@@ -964,6 +965,2906 @@ describe('parse', () => {
         }
 
         expect(parse(value)).toEqual(expected)
+      })
+    })
+
+    describe('character encoding', () => {
+      it('RW-E01: should decode HTML numeric character references in text', () => {
+        const value = `
+          <?xml version="1.0" encoding="UTF-8"?>
+          <rss version="2.0">
+            <channel>
+              <title>Test</title>
+              <link>https://example.com</link>
+              <description>Test</description>
+              <item>
+                <title>Caf&#233; Culture</title>
+              </item>
+            </channel>
+          </rss>
+        `
+        const expected = {
+          title: 'Test',
+          link: 'https://example.com',
+          description: 'Test',
+          items: [{ title: 'Café Culture' }],
+        }
+
+        expect(parse(value)).toEqual(expected)
+      })
+
+      it('RW-E02: should decode hex numeric character references', () => {
+        const value = `
+          <?xml version="1.0" encoding="UTF-8"?>
+          <rss version="2.0">
+            <channel>
+              <title>Test</title>
+              <link>https://example.com</link>
+              <description>Test</description>
+              <item>
+                <title>Caf&#xE9; Culture</title>
+              </item>
+            </channel>
+          </rss>
+        `
+        const expected = {
+          title: 'Test',
+          link: 'https://example.com',
+          description: 'Test',
+          items: [{ title: 'Café Culture' }],
+        }
+
+        expect(parse(value)).toEqual(expected)
+      })
+
+      it('RW-E03: should decode named HTML entities in text', () => {
+        const value = `
+          <?xml version="1.0" encoding="UTF-8"?>
+          <rss version="2.0">
+            <channel>
+              <title>Test</title>
+              <link>https://example.com</link>
+              <description>Test</description>
+              <item>
+                <title>News &ndash; Update</title>
+              </item>
+            </channel>
+          </rss>
+        `
+        const expected = {
+          title: 'Test',
+          link: 'https://example.com',
+          description: 'Test',
+          items: [{ title: 'News \u2013 Update' }],
+        }
+
+        expect(parse(value)).toEqual(expected)
+      })
+
+      it('RW-E04: should single-decode double-encoded entities', () => {
+        const value = `
+          <?xml version="1.0" encoding="UTF-8"?>
+          <rss version="2.0">
+            <channel>
+              <title>Test</title>
+              <link>https://example.com</link>
+              <description>Test</description>
+              <item>
+                <title>Tom &amp;amp; Jerry</title>
+              </item>
+            </channel>
+          </rss>
+        `
+        const expected = {
+          title: 'Test',
+          link: 'https://example.com',
+          description: 'Test',
+          items: [{ title: 'Tom &amp; Jerry' }],
+        }
+
+        expect(parse(value)).toEqual(expected)
+      })
+
+      it('RW-E05: should decode multiple entity types in a single field', () => {
+        const value = `
+          <?xml version="1.0" encoding="UTF-8"?>
+          <rss version="2.0">
+            <channel>
+              <title>Test</title>
+              <link>https://example.com</link>
+              <description>Test</description>
+              <item>
+                <title>Price: &#36;5 &amp; &#x20AC;4</title>
+              </item>
+            </channel>
+          </rss>
+        `
+        const expected = {
+          title: 'Test',
+          link: 'https://example.com',
+          description: 'Test',
+          items: [{ title: 'Price: $5 & \u20AC4' }],
+        }
+
+        expect(parse(value)).toEqual(expected)
+      })
+    })
+
+    describe('cdata handling', () => {
+      it('RW-C05: should handle mixed CDATA and regular text in same element', () => {
+        const value = `
+          <?xml version="1.0" encoding="UTF-8"?>
+          <rss version="2.0">
+            <channel>
+              <title>Test</title>
+              <link>https://example.com</link>
+              <description>Test</description>
+              <item>
+                <title><![CDATA[Hello]]> &amp; World</title>
+              </item>
+            </channel>
+          </rss>
+        `
+        const expected = {
+          title: 'Test',
+          link: 'https://example.com',
+          description: 'Test',
+          items: [{ title: 'Hello & World' }],
+        }
+
+        expect(parse(value)).toEqual(expected)
+      })
+
+      it('RW-C02: should handle empty CDATA section', () => {
+        const value = `
+          <?xml version="1.0" encoding="UTF-8"?>
+          <rss version="2.0">
+            <channel>
+              <title>Test</title>
+              <link>https://example.com</link>
+              <description><![CDATA[]]></description>
+            </channel>
+          </rss>
+        `
+        const expected = {
+          title: 'Test',
+          link: 'https://example.com',
+        }
+
+        expect(parse(value)).toEqual(expected)
+      })
+
+      it('RW-C02: should handle CDATA in title element', () => {
+        const value = `
+          <?xml version="1.0" encoding="UTF-8"?>
+          <rss version="2.0">
+            <channel>
+              <title><![CDATA[Test & Blog]]></title>
+              <link>https://example.com</link>
+              <description>Test</description>
+            </channel>
+          </rss>
+        `
+        const expected = {
+          title: 'Test & Blog',
+          link: 'https://example.com',
+          description: 'Test',
+        }
+
+        expect(parse(value)).toEqual(expected)
+      })
+
+      it('RW-C12: should preserve HTML entities inside CDATA verbatim per XML spec', () => {
+        const value = `
+          <?xml version="1.0" encoding="UTF-8"?>
+          <rss version="2.0">
+            <channel>
+              <title>Test</title>
+              <link>https://example.com</link>
+              <description>Test</description>
+              <item>
+                <title><![CDATA[Jahresr&uuml;ckblick 2017]]></title>
+              </item>
+            </channel>
+          </rss>
+        `
+        const expected = {
+          title: 'Test',
+          link: 'https://example.com',
+          description: 'Test',
+          items: [{
+            title: 'Jahresr&uuml;ckblick 2017',
+          }],
+        }
+
+        expect(parse(value)).toEqual(expected)
+      })
+
+      it('RW-C11: should handle CDATA preceded by whitespace and newlines', () => {
+        const value = `
+          <?xml version="1.0" encoding="UTF-8"?>
+          <rss version="2.0">
+            <channel>
+              <title>Test</title>
+              <link>https://example.com</link>
+              <description>Test</description>
+              <item>
+                <title>Post</title>
+                <description>
+                  <![CDATA[<p>Actual content here</p>]]>
+                </description>
+              </item>
+            </channel>
+          </rss>
+        `
+        const expected = {
+          title: 'Test',
+          link: 'https://example.com',
+          description: 'Test',
+          items: [{
+            title: 'Post',
+            description: '<p>Actual content here</p>',
+          }],
+        }
+
+        expect(parse(value)).toEqual(expected)
+      })
+
+      it('RW-C01: should preserve entities inside CDATA without decoding', () => {
+        const value = `
+          <?xml version="1.0" encoding="UTF-8"?>
+          <rss version="2.0" xmlns:content="http://purl.org/rss/1.0/modules/content/">
+            <channel>
+              <title>Test</title>
+              <link>https://example.com</link>
+              <description>Test</description>
+              <item>
+                <title>Post</title>
+                <content:encoded><![CDATA[Use &amp; for ampersands]]></content:encoded>
+              </item>
+            </channel>
+          </rss>
+        `
+        const expected = {
+          title: 'Test',
+          link: 'https://example.com',
+          description: 'Test',
+          items: [{
+            title: 'Post',
+            content: { encoded: 'Use &amp; for ampersands' },
+          }],
+        }
+
+        expect(parse(value)).toEqual(expected)
+      })
+    })
+
+    describe('escaped cdata', () => {
+      it('RW-C10: should preserve entity-escaped CDATA markers as literal text', () => {
+        const value = `
+          <?xml version="1.0" encoding="UTF-8"?>
+          <rss version="2.0">
+            <channel>
+              <title>Test</title>
+              <link>https://example.com</link>
+              <description>Test</description>
+              <item>
+                <title>Post</title>
+                <description>&lt;![CDATA[Some escaped CDATA content]]&gt;</description>
+              </item>
+            </channel>
+          </rss>
+        `
+        const expected = {
+          title: 'Test',
+          link: 'https://example.com',
+          description: 'Test',
+          items: [{
+            title: 'Post',
+            description: '<![CDATA[Some escaped CDATA content]]>',
+          }],
+        }
+
+        expect(parse(value)).toEqual(expected)
+      })
+    })
+
+    describe('content and description', () => {
+      it('RW-D01: should parse both content:encoded and description independently', () => {
+        const value = `
+          <?xml version="1.0" encoding="UTF-8"?>
+          <rss version="2.0" xmlns:content="http://purl.org/rss/1.0/modules/content/">
+            <channel>
+              <title>Test</title>
+              <link>https://example.com</link>
+              <description>Test</description>
+              <item>
+                <title>Post</title>
+                <description>Short summary</description>
+                <content:encoded><![CDATA[<p>Full HTML content</p>]]></content:encoded>
+              </item>
+            </channel>
+          </rss>
+        `
+        const expected = {
+          title: 'Test',
+          link: 'https://example.com',
+          description: 'Test',
+          items: [{
+            title: 'Post',
+            description: 'Short summary',
+            content: { encoded: '<p>Full HTML content</p>' },
+          }],
+        }
+
+        expect(parse(value)).toEqual(expected)
+      })
+
+      it('RW-D02: should handle empty self-closing description tag', () => {
+        const value = `
+          <?xml version="1.0" encoding="UTF-8"?>
+          <rss version="2.0">
+            <channel>
+              <title>Test</title>
+              <link>https://example.com</link>
+              <description/>
+            </channel>
+          </rss>
+        `
+        const expected = {
+          title: 'Test',
+          link: 'https://example.com',
+        }
+
+        expect(parse(value)).toEqual(expected)
+      })
+
+      it('RW-D03: should handle whitespace-only description', () => {
+        const value = `
+          <?xml version="1.0" encoding="UTF-8"?>
+          <rss version="2.0">
+            <channel>
+              <title>Test</title>
+              <link>https://example.com</link>
+              <description>   </description>
+            </channel>
+          </rss>
+        `
+        const expected = {
+          title: 'Test',
+          link: 'https://example.com',
+        }
+
+        expect(parse(value)).toEqual(expected)
+      })
+
+      it('RW-D04: should decode escaped HTML in description', () => {
+        const value = `
+          <?xml version="1.0" encoding="UTF-8"?>
+          <rss version="2.0">
+            <channel>
+              <title>Test</title>
+              <link>https://example.com</link>
+              <description>Test</description>
+              <item>
+                <title>Post</title>
+                <description>&lt;p&gt;HTML content&lt;/p&gt;</description>
+              </item>
+            </channel>
+          </rss>
+        `
+        const expected = {
+          title: 'Test',
+          link: 'https://example.com',
+          description: 'Test',
+          items: [{
+            title: 'Post',
+            description: '<p>HTML content</p>',
+          }],
+        }
+
+        expect(parse(value)).toEqual(expected)
+      })
+    })
+
+    describe('link and URL handling', () => {
+      it('RW-L01: should preserve relative URLs as-is', () => {
+        const value = `
+          <?xml version="1.0" encoding="UTF-8"?>
+          <rss version="2.0">
+            <channel>
+              <title>Test</title>
+              <link>https://example.com</link>
+              <description>Test</description>
+              <item>
+                <title>Post</title>
+                <link>/blog/post-1</link>
+              </item>
+            </channel>
+          </rss>
+        `
+        const expected = {
+          title: 'Test',
+          link: 'https://example.com',
+          description: 'Test',
+          items: [{
+            title: 'Post',
+            link: '/blog/post-1',
+          }],
+        }
+
+        expect(parse(value)).toEqual(expected)
+      })
+
+      it('RW-L02: should handle URLs with encoded ampersands in query parameters', () => {
+        const value = `
+          <?xml version="1.0" encoding="UTF-8"?>
+          <rss version="2.0">
+            <channel>
+              <title>Test</title>
+              <link>https://example.com</link>
+              <description>Test</description>
+              <item>
+                <title>Post</title>
+                <link>https://example.com/search?q=hello&amp;lang=en</link>
+              </item>
+            </channel>
+          </rss>
+        `
+        const expected = {
+          title: 'Test',
+          link: 'https://example.com',
+          description: 'Test',
+          items: [{
+            title: 'Post',
+            link: 'https://example.com/search?q=hello&lang=en',
+          }],
+        }
+
+        expect(parse(value)).toEqual(expected)
+      })
+
+      it('RW-L03: should parse atom:link in RSS feed', () => {
+        const value = `
+          <?xml version="1.0" encoding="UTF-8"?>
+          <rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+            <channel>
+              <title>Test</title>
+              <link>https://example.com</link>
+              <description>Test</description>
+              <atom:link href="https://example.com/feed.xml" rel="self" type="application/rss+xml"/>
+            </channel>
+          </rss>
+        `
+        const expected = {
+          title: 'Test',
+          link: 'https://example.com',
+          description: 'Test',
+          atom: {
+            links: [{ href: 'https://example.com/feed.xml', rel: 'self', type: 'application/rss+xml' }],
+          },
+        }
+
+        expect(parse(value)).toEqual(expected)
+      })
+
+      it('RW-L12: should parse plain link when mixed with attribute-only link elements', () => {
+        const value = `
+          <?xml version="1.0" encoding="UTF-8"?>
+          <rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+            <channel>
+              <title>Test</title>
+              <link>https://example.com</link>
+              <link href="https://example.com/rss" rel="self" type="application/rss+xml"/>
+              <atom:link href="https://example.com/rss" rel="self" type="application/rss+xml"/>
+              <description>Test</description>
+              <item>
+                <title>Post</title>
+                <link>https://example.com/post/1</link>
+              </item>
+            </channel>
+          </rss>
+        `
+        const expected = {
+          title: 'Test',
+          link: 'https://example.com',
+          description: 'Test',
+          atom: {
+            links: [{ href: 'https://example.com/rss', rel: 'self', type: 'application/rss+xml' }],
+          },
+          items: [{
+            title: 'Post',
+            link: 'https://example.com/post/1',
+          }],
+        }
+
+        expect(parse(value)).toEqual(expected)
+      })
+    })
+
+    describe('multiple elements', () => {
+      it('RW-M01: should parse multiple enclosures', () => {
+        const value = `
+          <?xml version="1.0" encoding="UTF-8"?>
+          <rss version="2.0">
+            <channel>
+              <title>Test</title>
+              <link>https://example.com</link>
+              <description>Test</description>
+              <item>
+                <title>Episode 1</title>
+                <enclosure url="https://example.com/audio.mp3" type="audio/mpeg" length="12345"/>
+                <enclosure url="https://example.com/audio.ogg" type="audio/ogg" length="23456"/>
+              </item>
+            </channel>
+          </rss>
+        `
+        const expected = {
+          title: 'Test',
+          link: 'https://example.com',
+          description: 'Test',
+          items: [{
+            title: 'Episode 1',
+            enclosures: [
+              { url: 'https://example.com/audio.mp3', type: 'audio/mpeg', length: 12345 },
+              { url: 'https://example.com/audio.ogg', type: 'audio/ogg', length: 23456 },
+            ],
+          }],
+        }
+
+        expect(parse(value)).toEqual(expected)
+      })
+
+      it('RW-M02: should parse multiple categories with domains', () => {
+        const value = `
+          <?xml version="1.0" encoding="UTF-8"?>
+          <rss version="2.0">
+            <channel>
+              <title>Test</title>
+              <link>https://example.com</link>
+              <description>Test</description>
+              <item>
+                <title>Post</title>
+                <category>Technology</category>
+                <category domain="https://example.com/tags">JavaScript</category>
+                <category domain="https://example.com/tags">TypeScript</category>
+              </item>
+            </channel>
+          </rss>
+        `
+        const expected = {
+          title: 'Test',
+          link: 'https://example.com',
+          description: 'Test',
+          items: [{
+            title: 'Post',
+            categories: [
+              { name: 'Technology' },
+              { name: 'JavaScript', domain: 'https://example.com/tags' },
+              { name: 'TypeScript', domain: 'https://example.com/tags' },
+            ],
+          }],
+        }
+
+        expect(parse(value)).toEqual(expected)
+      })
+
+      it('RW-M03: should parse multiple authors', () => {
+        const value = `
+          <?xml version="1.0" encoding="UTF-8"?>
+          <rss version="2.0">
+            <channel>
+              <title>Test</title>
+              <link>https://example.com</link>
+              <description>Test</description>
+              <item>
+                <title>Post</title>
+                <author>alice@example.com (Alice)</author>
+                <author>bob@example.com (Bob)</author>
+              </item>
+            </channel>
+          </rss>
+        `
+        const expected = {
+          title: 'Test',
+          link: 'https://example.com',
+          description: 'Test',
+          items: [{
+            title: 'Post',
+            authors: ['alice@example.com (Alice)', 'bob@example.com (Bob)'],
+          }],
+        }
+
+        expect(parse(value)).toEqual(expected)
+      })
+    })
+
+    describe('missing and empty elements', () => {
+      it('RW-N01: should parse feed with no items', () => {
+        const value = `
+          <?xml version="1.0" encoding="UTF-8"?>
+          <rss version="2.0">
+            <channel>
+              <title>Empty Feed</title>
+              <link>https://example.com</link>
+              <description>No items here</description>
+            </channel>
+          </rss>
+        `
+        const expected = {
+          title: 'Empty Feed',
+          link: 'https://example.com',
+          description: 'No items here',
+        }
+
+        expect(parse(value)).toEqual(expected)
+      })
+
+      it('RW-N02: should parse item with only description', () => {
+        const value = `
+          <?xml version="1.0" encoding="UTF-8"?>
+          <rss version="2.0">
+            <channel>
+              <title>Test</title>
+              <link>https://example.com</link>
+              <description>Test</description>
+              <item>
+                <description>Just a description, no title or link</description>
+              </item>
+            </channel>
+          </rss>
+        `
+        const expected = {
+          title: 'Test',
+          link: 'https://example.com',
+          description: 'Test',
+          items: [{ description: 'Just a description, no title or link' }],
+        }
+
+        expect(parse(value)).toEqual(expected)
+      })
+
+      it('RW-N03: should handle self-closing empty tags gracefully', () => {
+        const value = `
+          <?xml version="1.0" encoding="UTF-8"?>
+          <rss version="2.0">
+            <channel>
+              <title>Test</title>
+              <link>https://example.com</link>
+              <description>Test</description>
+              <item>
+                <title>Post</title>
+                <author/>
+                <category/>
+              </item>
+            </channel>
+          </rss>
+        `
+        const expected = {
+          title: 'Test',
+          link: 'https://example.com',
+          description: 'Test',
+          items: [{ title: 'Post' }],
+        }
+
+        expect(parse(value)).toEqual(expected)
+      })
+
+      it('RW-N06: should parse feed with minimal channel info', () => {
+        const value = `
+          <?xml version="1.0" encoding="UTF-8"?>
+          <rss version="2.0">
+            <channel>
+              <title>Minimal</title>
+            </channel>
+          </rss>
+        `
+        const expected = {
+          title: 'Minimal',
+        }
+
+        expect(parse(value)).toEqual(expected)
+      })
+
+      it('RW-N14: should throw for empty channel container', () => {
+        const value = `
+          <?xml version="1.0" encoding="UTF-8"?>
+          <rss version="2.0">
+            <channel></channel>
+          </rss>
+        `
+
+        expect(() => parse(value)).toThrow()
+      })
+
+      it('RW-N16: should parse RSS feed with no channel title', () => {
+        const value = `
+          <?xml version="1.0" encoding="UTF-8"?>
+          <rss version="2.0">
+            <channel>
+              <link>https://example.com</link>
+              <description>A feed without a title</description>
+              <item>
+                <title>Post</title>
+              </item>
+            </channel>
+          </rss>
+        `
+        const expected = {
+          link: 'https://example.com',
+          description: 'A feed without a title',
+          items: [{ title: 'Post' }],
+        }
+
+        expect(parse(value)).toEqual(expected)
+      })
+
+      it('RW-N18: should treat empty guid element as absent', () => {
+        const value = `
+          <?xml version="1.0" encoding="UTF-8"?>
+          <rss version="2.0">
+            <channel>
+              <title>Test</title>
+              <link>https://example.com</link>
+              <description>Test</description>
+              <item>
+                <title>Post</title>
+                <guid></guid>
+              </item>
+            </channel>
+          </rss>
+        `
+        const expected = {
+          title: 'Test',
+          link: 'https://example.com',
+          description: 'Test',
+          items: [{ title: 'Post' }],
+        }
+
+        expect(parse(value)).toEqual(expected)
+      })
+    })
+
+    describe('attribute handling', () => {
+      it('RW-A01: should parse guid with isPermaLink false', () => {
+        const value = `
+          <?xml version="1.0" encoding="UTF-8"?>
+          <rss version="2.0">
+            <channel>
+              <title>Test</title>
+              <link>https://example.com</link>
+              <description>Test</description>
+              <item>
+                <title>Post</title>
+                <guid isPermaLink="false">unique-id-123</guid>
+              </item>
+            </channel>
+          </rss>
+        `
+        const expected = {
+          title: 'Test',
+          link: 'https://example.com',
+          description: 'Test',
+          items: [{
+            title: 'Post',
+            guid: { value: 'unique-id-123', isPermaLink: false },
+          }],
+        }
+
+        expect(parse(value)).toEqual(expected)
+      })
+
+      it('RW-A02: should parse guid with uppercase isPermaLink value', () => {
+        const value = `
+          <?xml version="1.0" encoding="UTF-8"?>
+          <rss version="2.0">
+            <channel>
+              <title>Test</title>
+              <link>https://example.com</link>
+              <description>Test</description>
+              <item>
+                <title>Post</title>
+                <guid isPermaLink="False">unique-id-456</guid>
+              </item>
+            </channel>
+          </rss>
+        `
+        const expected = {
+          title: 'Test',
+          link: 'https://example.com',
+          description: 'Test',
+          items: [{
+            title: 'Post',
+            guid: { value: 'unique-id-456', isPermaLink: false },
+          }],
+        }
+
+        expect(parse(value)).toEqual(expected)
+      })
+
+      it('RW-A03: should parse enclosure with all attributes', () => {
+        const value = `
+          <?xml version="1.0" encoding="UTF-8"?>
+          <rss version="2.0">
+            <channel>
+              <title>Test</title>
+              <link>https://example.com</link>
+              <description>Test</description>
+              <item>
+                <title>Episode</title>
+                <enclosure url="https://example.com/ep.mp3" length="12345678" type="audio/mpeg"/>
+              </item>
+            </channel>
+          </rss>
+        `
+        const expected = {
+          title: 'Test',
+          link: 'https://example.com',
+          description: 'Test',
+          items: [{
+            title: 'Episode',
+            enclosures: [{ url: 'https://example.com/ep.mp3', length: 12345678, type: 'audio/mpeg' }],
+          }],
+        }
+
+        expect(parse(value)).toEqual(expected)
+      })
+    })
+
+    describe('namespace edge cases', () => {
+      it('RW-NS01: should handle non-standard prefix for known namespace URI', () => {
+        const value = `
+          <?xml version="1.0" encoding="UTF-8"?>
+          <rss version="2.0" xmlns:mydc="http://purl.org/dc/elements/1.1/">
+            <channel>
+              <title>Test</title>
+              <link>https://example.com</link>
+              <description>Test</description>
+              <item>
+                <title>Post</title>
+                <mydc:creator>John Doe</mydc:creator>
+              </item>
+            </channel>
+          </rss>
+        `
+        const expected = {
+          title: 'Test',
+          link: 'https://example.com',
+          description: 'Test',
+          items: [{
+            title: 'Post',
+            dc: {
+              creators: ['John Doe'],
+              creator: 'John Doe',
+            },
+          }],
+        }
+
+        expect(parse(value)).toEqual(expected)
+      })
+
+      it('RW-NS02: should handle multiple namespaces with non-standard prefixes', () => {
+        const value = `
+          <?xml version="1.0" encoding="UTF-8"?>
+          <rss version="2.0"
+            xmlns:mydc="http://purl.org/dc/elements/1.1/"
+            xmlns:myatom="http://www.w3.org/2005/Atom"
+          >
+            <channel>
+              <title>Test</title>
+              <link>https://example.com</link>
+              <description>Test</description>
+              <myatom:link href="https://example.com/feed.xml" rel="self"/>
+              <item>
+                <title>Post</title>
+                <mydc:creator>Jane</mydc:creator>
+              </item>
+            </channel>
+          </rss>
+        `
+        const expected = {
+          title: 'Test',
+          link: 'https://example.com',
+          description: 'Test',
+          atom: {
+            links: [{ href: 'https://example.com/feed.xml', rel: 'self' }],
+          },
+          items: [{
+            title: 'Post',
+            dc: {
+              creators: ['Jane'],
+              creator: 'Jane',
+            },
+          }],
+        }
+
+        expect(parse(value)).toEqual(expected)
+      })
+
+      it('RW-NS03: should handle namespace URI without trailing slash variant', () => {
+        const value = `
+          <?xml version="1.0" encoding="UTF-8"?>
+          <rss version="2.0" xmlns:dc="http://purl.org/dc/elements/1.1">
+            <channel>
+              <title>Test</title>
+              <link>https://example.com</link>
+              <description>Test</description>
+              <item>
+                <title>Post</title>
+                <dc:creator>Author</dc:creator>
+              </item>
+            </channel>
+          </rss>
+        `
+        const expected = {
+          title: 'Test',
+          link: 'https://example.com',
+          description: 'Test',
+          items: [{
+            title: 'Post',
+            dc: {
+              creators: ['Author'],
+              creator: 'Author',
+            },
+          }],
+        }
+
+        expect(parse(value)).toEqual(expected)
+      })
+
+      it('RW-NS12: should handle namespace declared inline on item element', () => {
+        const value = `
+          <?xml version="1.0" encoding="UTF-8"?>
+          <rss version="2.0">
+            <channel>
+              <title>Test</title>
+              <link>https://example.com</link>
+              <description>Test</description>
+              <item xmlns:dc="http://purl.org/dc/elements/1.1/">
+                <title>Post</title>
+                <dc:creator>Inline Author</dc:creator>
+              </item>
+            </channel>
+          </rss>
+        `
+        const expected = {
+          title: 'Test',
+          link: 'https://example.com',
+          description: 'Test',
+          items: [{
+            title: 'Post',
+            dc: {
+              creators: ['Inline Author'],
+              creator: 'Inline Author',
+            },
+          }],
+        }
+
+        expect(parse(value)).toEqual(expected)
+      })
+    })
+
+    describe('feed-specific quirks', () => {
+      it('RW-Q02: should parse podcast feed with itunes namespace', () => {
+        const value = `
+          <?xml version="1.0" encoding="UTF-8"?>
+          <rss version="2.0" xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd">
+            <channel>
+              <title>My Podcast</title>
+              <link>https://example.com</link>
+              <description>A podcast</description>
+              <itunes:author>Host Name</itunes:author>
+              <itunes:explicit>false</itunes:explicit>
+              <item>
+                <title>Episode 1</title>
+                <enclosure url="https://example.com/ep1.mp3" type="audio/mpeg" length="12345"/>
+                <itunes:duration>01:23:45</itunes:duration>
+                <itunes:explicit>false</itunes:explicit>
+              </item>
+            </channel>
+          </rss>
+        `
+        const result = parse(value)
+
+        expect(result.title).toBe('My Podcast')
+        expect(result.itunes?.author).toBe('Host Name')
+        expect(result.itunes?.explicit).toBe(false)
+        expect(result.items?.[0]?.title).toBe('Episode 1')
+        expect(result.items?.[0]?.itunes?.duration).toBe(5025)
+        expect(result.items?.[0]?.itunes?.explicit).toBe(false)
+      })
+
+      it('RW-Q03: should parse feed with source element on item', () => {
+        const value = `
+          <?xml version="1.0" encoding="UTF-8"?>
+          <rss version="2.0">
+            <channel>
+              <title>Aggregator</title>
+              <link>https://example.com</link>
+              <description>Aggregated feed</description>
+              <item>
+                <title>Cross-posted Article</title>
+                <source url="https://original.com/feed.xml">Original Blog</source>
+              </item>
+            </channel>
+          </rss>
+        `
+        const expected = {
+          title: 'Aggregator',
+          link: 'https://example.com',
+          description: 'Aggregated feed',
+          items: [{
+            title: 'Cross-posted Article',
+            source: { title: 'Original Blog', url: 'https://original.com/feed.xml' },
+          }],
+        }
+
+        expect(parse(value)).toEqual(expected)
+      })
+
+      it('RW-Q04: should parse feed with comments URL on item', () => {
+        const value = `
+          <?xml version="1.0" encoding="UTF-8"?>
+          <rss version="2.0">
+            <channel>
+              <title>Test</title>
+              <link>https://example.com</link>
+              <description>Test</description>
+              <item>
+                <title>Post</title>
+                <comments>https://example.com/post/1#comments</comments>
+              </item>
+            </channel>
+          </rss>
+        `
+        const expected = {
+          title: 'Test',
+          link: 'https://example.com',
+          description: 'Test',
+          items: [{
+            title: 'Post',
+            comments: 'https://example.com/post/1#comments',
+          }],
+        }
+
+        expect(parse(value)).toEqual(expected)
+      })
+
+      it('RW-Q09: should preserve RFC 2822 author email format', () => {
+        const value = `
+          <?xml version="1.0" encoding="UTF-8"?>
+          <rss version="2.0">
+            <channel>
+              <title>Test</title>
+              <link>https://example.com</link>
+              <description>Test</description>
+              <item>
+                <title>Post</title>
+                <author>john@example.com (John Doe)</author>
+              </item>
+            </channel>
+          </rss>
+        `
+        const expected = {
+          title: 'Test',
+          link: 'https://example.com',
+          description: 'Test',
+          items: [{
+            title: 'Post',
+            authors: ['john@example.com (John Doe)'],
+          }],
+        }
+
+        expect(parse(value)).toEqual(expected)
+      })
+    })
+
+    describe('malformed XML resilience', () => {
+      it('RW-E10: should handle BOM at start of XML', () => {
+        const value = `\uFEFF<?xml version="1.0" encoding="UTF-8"?>
+          <rss version="2.0">
+            <channel>
+              <title>BOM Feed</title>
+              <link>https://example.com</link>
+              <description>Feed with BOM</description>
+            </channel>
+          </rss>
+        `
+        const expected = {
+          title: 'BOM Feed',
+          link: 'https://example.com',
+          description: 'Feed with BOM',
+        }
+
+        expect(parse(value)).toEqual(expected)
+      })
+
+      it('RW-E12: should handle unescaped ampersand in title', () => {
+        const value = `
+          <?xml version="1.0" encoding="UTF-8"?>
+          <rss version="2.0">
+            <channel>
+              <title>Tom & Jerry</title>
+              <link>https://example.com</link>
+              <description>Test</description>
+            </channel>
+          </rss>
+        `
+        const expected = {
+          title: 'Tom & Jerry',
+          link: 'https://example.com',
+          description: 'Test',
+        }
+
+        expect(parse(value)).toEqual(expected)
+      })
+
+      it('RW-E12: should handle unescaped ampersand in item description', () => {
+        const value = `
+          <?xml version="1.0" encoding="UTF-8"?>
+          <rss version="2.0">
+            <channel>
+              <title>Test</title>
+              <link>https://example.com</link>
+              <description>Test</description>
+              <item>
+                <title>Post</title>
+                <description>Fish & Chips are great</description>
+              </item>
+            </channel>
+          </rss>
+        `
+        const expected = {
+          title: 'Test',
+          link: 'https://example.com',
+          description: 'Test',
+          items: [{
+            title: 'Post',
+            description: 'Fish & Chips are great',
+          }],
+        }
+
+        expect(parse(value)).toEqual(expected)
+      })
+
+      it('RW-E06: should handle HTML entity &nbsp; in text', () => {
+        const value = `
+          <?xml version="1.0" encoding="UTF-8"?>
+          <rss version="2.0">
+            <channel>
+              <title>Test</title>
+              <link>https://example.com</link>
+              <description>Test</description>
+              <item>
+                <title>Hello&nbsp;World</title>
+              </item>
+            </channel>
+          </rss>
+        `
+        const expected = {
+          title: 'Test',
+          link: 'https://example.com',
+          description: 'Test',
+          items: [{ title: 'Hello\u00A0World' }],
+        }
+
+        expect(parse(value)).toEqual(expected)
+      })
+
+      it('RW-E07: should handle &copy; entity in text', () => {
+        const value = `
+          <?xml version="1.0" encoding="UTF-8"?>
+          <rss version="2.0">
+            <channel>
+              <title>Test</title>
+              <link>https://example.com</link>
+              <description>Test</description>
+              <item>
+                <title>&copy; 2024 Example Corp</title>
+              </item>
+            </channel>
+          </rss>
+        `
+        const expected = {
+          title: 'Test',
+          link: 'https://example.com',
+          description: 'Test',
+          items: [{ title: '\u00A9 2024 Example Corp' }],
+        }
+
+        expect(parse(value)).toEqual(expected)
+      })
+
+      it('RW-X01: should throw on truncated XML', () => {
+        const value = `
+          <?xml version="1.0" encoding="UTF-8"?>
+          <rss version="2.0">
+            <channel>
+              <title>Incomplete
+        `
+
+        expect(() => parse(value)).toThrow()
+      })
+
+      it('RW-E17: should throw on unescaped less-than in title', () => {
+        const value = `
+          <?xml version="1.0" encoding="UTF-8"?>
+          <rss version="2.0">
+            <channel>
+              <title>Test</title>
+              <link>https://example.com</link>
+              <description>Test</description>
+              <item>
+                <title>Price: $5 < $10</title>
+              </item>
+            </channel>
+          </rss>
+        `
+
+        expect(() => parse(value)).toThrow()
+      })
+
+      it('RW-E11: should handle control character U+0008 in content', () => {
+        const value = `
+          <?xml version="1.0" encoding="UTF-8"?>
+          <rss version="2.0">
+            <channel>
+              <title>Test</title>
+              <link>https://example.com</link>
+              <description>Test</description>
+              <item>
+                <title>Text with\u0008backspace</title>
+              </item>
+            </channel>
+          </rss>
+        `
+        const expected = {
+          title: 'Test',
+          link: 'https://example.com',
+          description: 'Test',
+          items: [{ title: 'Text with\u0008backspace' }],
+        }
+
+        expect(parse(value)).toEqual(expected)
+      })
+
+      it('RW-X04: should parse feed with DOCTYPE declaration', () => {
+        const value = `
+          <?xml version="1.0" encoding="UTF-8"?>
+          <!DOCTYPE rss SYSTEM "https://example.com/rss.dtd">
+          <rss version="2.0">
+            <channel>
+              <title>Test</title>
+              <link>https://example.com</link>
+              <description>Test</description>
+              <item>
+                <title>Post</title>
+              </item>
+            </channel>
+          </rss>
+        `
+        const expected = {
+          title: 'Test',
+          link: 'https://example.com',
+          description: 'Test',
+          items: [{ title: 'Post' }],
+        }
+
+        expect(parse(value)).toEqual(expected)
+      })
+
+      it('RW-X08: should strip XML comments from element content', () => {
+        const value = `
+          <?xml version="1.0" encoding="UTF-8"?>
+          <rss version="2.0">
+            <channel>
+              <title>Test<!-- hidden --> Feed</title>
+              <link>https://example.com</link>
+              <description>Test</description>
+              <item>
+                <title>Post<!-- comment --> Title</title>
+              </item>
+            </channel>
+          </rss>
+        `
+        const expected = {
+          title: 'Test Feed',
+          link: 'https://example.com',
+          description: 'Test',
+          items: [{ title: 'Post Title' }],
+        }
+
+        expect(parse(value)).toEqual(expected)
+      })
+
+      it('RW-X10: should use first channel when multiple channel elements exist', () => {
+        const value = `
+          <?xml version="1.0" encoding="UTF-8"?>
+          <rss version="2.0">
+            <channel>
+              <title>First Channel</title>
+              <link>https://first.example.com</link>
+              <description>First</description>
+              <item>
+                <title>First Post</title>
+              </item>
+            </channel>
+            <channel>
+              <title>Second Channel</title>
+              <link>https://second.example.com</link>
+              <description>Second</description>
+            </channel>
+          </rss>
+        `
+        const expected = {
+          title: 'First Channel',
+          link: 'https://first.example.com',
+          description: 'First',
+          items: [{ title: 'First Post' }],
+        }
+
+        expect(parse(value)).toEqual(expected)
+      })
+
+      it('RW-X11: should parse items placed outside channel element', () => {
+        const value = `
+          <?xml version="1.0" encoding="UTF-8"?>
+          <rss version="2.0">
+            <channel>
+              <title>Feed</title>
+              <link>https://example.com</link>
+              <description>Test</description>
+            </channel>
+            <item>
+              <title>Outside Item</title>
+              <link>https://example.com/outside</link>
+            </item>
+          </rss>
+        `
+        const expected = {
+          title: 'Feed',
+          link: 'https://example.com',
+          description: 'Test',
+          items: [{
+            title: 'Outside Item',
+            link: 'https://example.com/outside',
+          }],
+        }
+
+        expect(parse(value)).toEqual(expected)
+      })
+
+      it('RW-X12: should drop unquoted attribute values (fast-xml-parser limitation)', () => {
+        const value = `
+          <?xml version="1.0" encoding="UTF-8"?>
+          <rss version="2.0">
+            <channel>
+              <title>Test</title>
+              <link>https://example.com</link>
+              <description>Test</description>
+              <item>
+                <title>Post</title>
+                <enclosure url="https://example.com/file.mp3" length=12345 type="audio/mpeg"/>
+              </item>
+            </channel>
+          </rss>
+        `
+        const expected = {
+          title: 'Test',
+          link: 'https://example.com',
+          description: 'Test',
+          items: [{
+            title: 'Post',
+            enclosures: [{
+              url: 'https://example.com/file.mp3',
+              type: 'audio/mpeg',
+            }],
+          }],
+        }
+
+        expect(parse(value)).toEqual(expected)
+      })
+    })
+
+    describe('stop node edge cases', () => {
+      it('RW-D04: should preserve HTML tags in title as text', () => {
+        const value = `
+          <?xml version="1.0" encoding="UTF-8"?>
+          <rss version="2.0">
+            <channel>
+              <title>Test</title>
+              <link>https://example.com</link>
+              <description>Test</description>
+              <item>
+                <title><b>Bold</b> title</title>
+              </item>
+            </channel>
+          </rss>
+        `
+        const expected = {
+          title: 'Test',
+          link: 'https://example.com',
+          description: 'Test',
+          items: [{ title: '<b>Bold</b> title' }],
+        }
+
+        expect(parse(value)).toEqual(expected)
+      })
+
+      it('RW-C04: should handle CDATA with code containing angle brackets', () => {
+        const value = `
+          <?xml version="1.0" encoding="UTF-8"?>
+          <rss version="2.0" xmlns:content="http://purl.org/rss/1.0/modules/content/">
+            <channel>
+              <title>Test</title>
+              <link>https://example.com</link>
+              <description>Test</description>
+              <item>
+                <title>Code Example</title>
+                <content:encoded><![CDATA[<pre>for (i = 0; i < 10; i++) { console.log(i); }</pre>]]></content:encoded>
+              </item>
+            </channel>
+          </rss>
+        `
+        const expected = {
+          title: 'Test',
+          link: 'https://example.com',
+          description: 'Test',
+          items: [{
+            title: 'Code Example',
+            content: {
+              encoded: '<pre>for (i = 0; i < 10; i++) { console.log(i); }</pre>',
+            },
+          }],
+        }
+
+        expect(parse(value)).toEqual(expected)
+      })
+
+      it('RW-D04: should handle description with escaped HTML link', () => {
+        const value = `
+          <?xml version="1.0" encoding="UTF-8"?>
+          <rss version="2.0">
+            <channel>
+              <title>Test</title>
+              <link>https://example.com</link>
+              <description>Test</description>
+              <item>
+                <title>Post</title>
+                <description>Click &lt;a href=&quot;https://example.com&quot;&gt;here&lt;/a&gt; for more</description>
+              </item>
+            </channel>
+          </rss>
+        `
+        const expected = {
+          title: 'Test',
+          link: 'https://example.com',
+          description: 'Test',
+          items: [{
+            title: 'Post',
+            description: 'Click <a href="https://example.com">here</a> for more',
+          }],
+        }
+
+        expect(parse(value)).toEqual(expected)
+      })
+    })
+
+    describe('partial attributes', () => {
+      it('RW-A04: should handle enclosure with missing url attribute', () => {
+        const value = `
+          <?xml version="1.0" encoding="UTF-8"?>
+          <rss version="2.0">
+            <channel>
+              <title>Test</title>
+              <link>https://example.com</link>
+              <description>Test</description>
+              <item>
+                <title>Episode</title>
+                <enclosure type="audio/mpeg" length="5000000"/>
+              </item>
+            </channel>
+          </rss>
+        `
+        const expected = {
+          title: 'Test',
+          link: 'https://example.com',
+          description: 'Test',
+          items: [{
+            title: 'Episode',
+            enclosures: [{ type: 'audio/mpeg', length: 5000000 }],
+          }],
+        }
+
+        expect(parse(value)).toEqual(expected)
+      })
+
+      it('RW-A05: should drop enclosure with no attributes', () => {
+        const value = `
+          <?xml version="1.0" encoding="UTF-8"?>
+          <rss version="2.0">
+            <channel>
+              <title>Test</title>
+              <link>https://example.com</link>
+              <description>Test</description>
+              <item>
+                <title>Post</title>
+                <enclosure/>
+              </item>
+            </channel>
+          </rss>
+        `
+        const expected = {
+          title: 'Test',
+          link: 'https://example.com',
+          description: 'Test',
+          items: [{ title: 'Post' }],
+        }
+
+        expect(parse(value)).toEqual(expected)
+      })
+
+      it('RW-N02: should parse item with only guid', () => {
+        const value = `
+          <?xml version="1.0" encoding="UTF-8"?>
+          <rss version="2.0">
+            <channel>
+              <title>Test</title>
+              <link>https://example.com</link>
+              <description>Test</description>
+              <item>
+                <guid isPermaLink="false">unique-12345</guid>
+              </item>
+            </channel>
+          </rss>
+        `
+        const expected = {
+          title: 'Test',
+          link: 'https://example.com',
+          description: 'Test',
+          items: [{
+            guid: { value: 'unique-12345', isPermaLink: false },
+          }],
+        }
+
+        expect(parse(value)).toEqual(expected)
+      })
+
+      it('RW-T01: should handle invalid date strings as plain strings', () => {
+        const value = `
+          <?xml version="1.0" encoding="UTF-8"?>
+          <rss version="2.0">
+            <channel>
+              <title>Test</title>
+              <link>https://example.com</link>
+              <description>Test</description>
+              <item>
+                <title>Post</title>
+                <pubDate>sometime in January</pubDate>
+              </item>
+            </channel>
+          </rss>
+        `
+        const expected = {
+          title: 'Test',
+          link: 'https://example.com',
+          description: 'Test',
+          items: [{
+            title: 'Post',
+            pubDate: 'sometime in January',
+          }],
+        }
+
+        expect(parse(value)).toEqual(expected)
+      })
+
+      it('RW-A06: should handle large enclosure length values', () => {
+        const value = `
+          <?xml version="1.0" encoding="UTF-8"?>
+          <rss version="2.0">
+            <channel>
+              <title>Test</title>
+              <link>https://example.com</link>
+              <description>Test</description>
+              <item>
+                <title>Episode</title>
+                <enclosure url="https://example.com/ep.mp3" type="audio/mpeg" length="9007199254740992"/>
+              </item>
+            </channel>
+          </rss>
+        `
+        const result = parse(value)
+
+        expect(result.items?.[0]?.enclosures?.[0]?.length).toBe(9007199254740992)
+      })
+
+      it('RW-NS07: should parse nested iTunes categories', () => {
+        const value = `
+          <?xml version="1.0" encoding="UTF-8"?>
+          <rss version="2.0" xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd">
+            <channel>
+              <title>My Podcast</title>
+              <link>https://example.com</link>
+              <description>A podcast</description>
+              <itunes:category text="Technology">
+                <itunes:category text="Podcasting"/>
+              </itunes:category>
+              <itunes:category text="Society &amp; Culture"/>
+              <item>
+                <title>Episode 1</title>
+              </item>
+            </channel>
+          </rss>
+        `
+        const result = parse(value)
+
+        expect(result.itunes?.categories).toEqual([
+          { text: 'Technology', categories: [{ text: 'Podcasting' }] },
+          { text: 'Society & Culture' },
+        ])
+      })
+
+      it('RW-C13: should unwrap CDATA-wrapped pubDate', () => {
+        const value = `
+          <?xml version="1.0" encoding="UTF-8"?>
+          <rss version="2.0">
+            <channel>
+              <title>Test</title>
+              <link>https://example.com</link>
+              <description>Test</description>
+              <item>
+                <title>Post</title>
+                <pubDate><![CDATA[Mon, 01 Jan 2024 00:00:00 GMT]]></pubDate>
+              </item>
+            </channel>
+          </rss>
+        `
+        const expected = {
+          title: 'Test',
+          link: 'https://example.com',
+          description: 'Test',
+          items: [{
+            title: 'Post',
+            pubDate: 'Mon, 01 Jan 2024 00:00:00 GMT',
+          }],
+        }
+
+        expect(parse(value)).toEqual(expected)
+      })
+
+      it('RW-C14: should omit empty content:encoded and keep description', () => {
+        const value = `
+          <?xml version="1.0" encoding="UTF-8"?>
+          <rss version="2.0" xmlns:content="http://purl.org/rss/1.0/modules/content/">
+            <channel>
+              <title>Test</title>
+              <link>https://example.com</link>
+              <description>Test</description>
+              <item>
+                <title>Post</title>
+                <content:encoded/>
+                <description>Fallback content</description>
+              </item>
+            </channel>
+          </rss>
+        `
+        const expected = {
+          title: 'Test',
+          link: 'https://example.com',
+          description: 'Test',
+          items: [{
+            title: 'Post',
+            description: 'Fallback content',
+          }],
+        }
+
+        expect(parse(value)).toEqual(expected)
+      })
+
+      it('RW-L14: should parse guid with isPermaLink true and no link element', () => {
+        const value = `
+          <?xml version="1.0" encoding="UTF-8"?>
+          <rss version="2.0">
+            <channel>
+              <title>Test</title>
+              <link>https://example.com</link>
+              <description>Test</description>
+              <item>
+                <title>Post</title>
+                <guid isPermaLink="true">https://example.com/post/1</guid>
+              </item>
+            </channel>
+          </rss>
+        `
+        const expected = {
+          title: 'Test',
+          link: 'https://example.com',
+          description: 'Test',
+          items: [{
+            title: 'Post',
+            guid: { value: 'https://example.com/post/1', isPermaLink: true },
+          }],
+        }
+
+        expect(parse(value)).toEqual(expected)
+      })
+
+      it('RW-A13: should store non-MIME enclosure type as-is', () => {
+        const value = `
+          <?xml version="1.0" encoding="UTF-8"?>
+          <rss version="2.0">
+            <channel>
+              <title>Test</title>
+              <link>https://example.com</link>
+              <description>Test</description>
+              <item>
+                <title>Episode</title>
+                <enclosure url="https://example.com/audio.mp3" type="mp3" length="12345"/>
+              </item>
+            </channel>
+          </rss>
+        `
+        const expected = {
+          title: 'Test',
+          link: 'https://example.com',
+          description: 'Test',
+          items: [{
+            title: 'Episode',
+            enclosures: [{
+              url: 'https://example.com/audio.mp3',
+              type: 'mp3',
+              length: 12345,
+            }],
+          }],
+        }
+
+        expect(parse(value)).toEqual(expected)
+      })
+
+      it('RW-NS14: should parse dc:date in RSS 2.0', () => {
+        const value = `
+          <?xml version="1.0" encoding="UTF-8"?>
+          <rss version="2.0" xmlns:dc="http://purl.org/dc/elements/1.1/">
+            <channel>
+              <title>Test</title>
+              <link>https://example.com</link>
+              <description>Test</description>
+              <item>
+                <title>Post</title>
+                <dc:date>2025-02-21T16:00:00Z</dc:date>
+              </item>
+            </channel>
+          </rss>
+        `
+        const expected = {
+          title: 'Test',
+          link: 'https://example.com',
+          description: 'Test',
+          items: [{
+            title: 'Post',
+            dc: {
+              dates: ['2025-02-21T16:00:00Z'],
+              date: '2025-02-21T16:00:00Z',
+            },
+          }],
+        }
+
+        expect(parse(value)).toEqual(expected)
+      })
+
+      it('RW-NS15: should parse media:content with nested child elements', () => {
+        const value = `
+          <?xml version="1.0" encoding="UTF-8"?>
+          <rss version="2.0" xmlns:media="http://search.yahoo.com/mrss/">
+            <channel>
+              <title>Test</title>
+              <link>https://example.com</link>
+              <description>Test</description>
+              <item>
+                <title>Post</title>
+                <media:content url="https://example.com/image.png" type="image/png" medium="image">
+                  <media:rating scheme="urn:simple">nonadult</media:rating>
+                </media:content>
+              </item>
+            </channel>
+          </rss>
+        `
+        const expected = {
+          title: 'Test',
+          link: 'https://example.com',
+          description: 'Test',
+          items: [{
+            title: 'Post',
+            media: {
+              contents: [{
+                url: 'https://example.com/image.png',
+                type: 'image/png',
+                medium: 'image',
+                ratings: [{ value: 'nonadult', scheme: 'urn:simple' }],
+              }],
+            },
+          }],
+        }
+
+        expect(parse(value)).toEqual(expected)
+      })
+
+      it('RW-NS16: should parse both media:content and media:thumbnail', () => {
+        const value = `
+          <?xml version="1.0" encoding="UTF-8"?>
+          <rss version="2.0" xmlns:media="http://search.yahoo.com/mrss/">
+            <channel>
+              <title>Test</title>
+              <link>https://example.com</link>
+              <description>Test</description>
+              <item>
+                <title>Post</title>
+                <media:content url="https://example.com/full.jpg" type="image/jpeg"/>
+                <media:thumbnail url="https://example.com/thumb.jpg" width="120" height="90"/>
+              </item>
+            </channel>
+          </rss>
+        `
+        const expected = {
+          title: 'Test',
+          link: 'https://example.com',
+          description: 'Test',
+          items: [{
+            title: 'Post',
+            media: {
+              contents: [{
+                url: 'https://example.com/full.jpg',
+                type: 'image/jpeg',
+              }],
+              thumbnails: [{
+                url: 'https://example.com/thumb.jpg',
+                width: 120,
+                height: 90,
+              }],
+            },
+          }],
+        }
+
+        expect(parse(value)).toEqual(expected)
+      })
+
+      it('RW-NS17: should parse itunes:duration with MM:SS format', () => {
+        const value = `
+          <?xml version="1.0" encoding="UTF-8"?>
+          <rss version="2.0" xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd">
+            <channel>
+              <title>My Podcast</title>
+              <link>https://example.com</link>
+              <description>A podcast</description>
+              <item>
+                <title>Episode 1</title>
+                <itunes:duration>03:19</itunes:duration>
+              </item>
+            </channel>
+          </rss>
+        `
+        const result = parse(value)
+
+        expect(result.items?.[0]?.itunes?.duration).toBe(199)
+      })
+
+      it('RW-NS18: should handle HTTPS variant of DC namespace URI', () => {
+        const value = `
+          <?xml version="1.0" encoding="UTF-8"?>
+          <rss version="2.0" xmlns:dc="https://purl.org/dc/elements/1.1/">
+            <channel>
+              <title>Test</title>
+              <link>https://example.com</link>
+              <description>Test</description>
+              <item>
+                <title>Post</title>
+                <dc:creator>John Doe</dc:creator>
+              </item>
+            </channel>
+          </rss>
+        `
+        const expected = {
+          title: 'Test',
+          link: 'https://example.com',
+          description: 'Test',
+          items: [{
+            title: 'Post',
+            dc: {
+              creators: ['John Doe'],
+              creator: 'John Doe',
+            },
+          }],
+        }
+
+        expect(parse(value)).toEqual(expected)
+      })
+
+      it('RW-NS19: should parse atom:link declared inline on channel element', () => {
+        const value = `
+          <?xml version="1.0" encoding="UTF-8"?>
+          <rss version="2.0">
+            <channel>
+              <title>Test</title>
+              <link>https://example.com</link>
+              <description>Test</description>
+              <atom:link xmlns:atom="http://www.w3.org/2005/Atom" rel="self" href="https://example.com/feed.xml" type="application/rss+xml"/>
+            </channel>
+          </rss>
+        `
+        const expected = {
+          title: 'Test',
+          link: 'https://example.com',
+          description: 'Test',
+          atom: {
+            links: [{
+              href: 'https://example.com/feed.xml',
+              rel: 'self',
+              type: 'application/rss+xml',
+            }],
+          },
+        }
+
+        expect(parse(value)).toEqual(expected)
+      })
+
+      it('RW-X13: should decode numeric character reference &#39; in description', () => {
+        const value = `
+          <?xml version="1.0" encoding="UTF-8"?>
+          <rss version="2.0">
+            <channel>
+              <title>Test</title>
+              <link>https://example.com</link>
+              <description>Test</description>
+              <item>
+                <title>Post</title>
+                <description>It doesn&#39;t work</description>
+              </item>
+            </channel>
+          </rss>
+        `
+        const expected = {
+          title: 'Test',
+          link: 'https://example.com',
+          description: 'Test',
+          items: [{
+            title: 'Post',
+            description: "It doesn't work",
+          }],
+        }
+
+        expect(parse(value)).toEqual(expected)
+      })
+
+      it('RW-X14: should omit self-closing empty link element', () => {
+        const value = `
+          <?xml version="1.0" encoding="UTF-8"?>
+          <rss version="2.0">
+            <channel>
+              <title>Test</title>
+              <link>https://example.com</link>
+              <description>Test</description>
+              <item>
+                <title>Post</title>
+                <link/>
+              </item>
+            </channel>
+          </rss>
+        `
+        const expected = {
+          title: 'Test',
+          link: 'https://example.com',
+          description: 'Test',
+          items: [{ title: 'Post' }],
+        }
+
+        expect(parse(value)).toEqual(expected)
+      })
+
+      it('RW-X17: should handle leading whitespace before XML declaration', () => {
+        const value = `
+          <?xml version="1.0" encoding="UTF-8"?>
+          <rss version="2.0">
+            <channel>
+              <title>Test</title>
+              <link>https://example.com</link>
+              <description>Test</description>
+              <item>
+                <title>Post</title>
+              </item>
+            </channel>
+          </rss>
+        `
+        const expected = {
+          title: 'Test',
+          link: 'https://example.com',
+          description: 'Test',
+          items: [{ title: 'Post' }],
+        }
+
+        expect(parse(value)).toEqual(expected)
+      })
+
+      it('RW-X18: should ignore xml-stylesheet processing instruction', () => {
+        const value = `<?xml version="1.0" encoding="UTF-8"?><?xml-stylesheet type="text/xsl" href="style.xsl"?>
+          <rss version="2.0">
+            <channel>
+              <title>Test</title>
+              <link>https://example.com</link>
+              <description>Test</description>
+              <item>
+                <title>Post</title>
+              </item>
+            </channel>
+          </rss>
+        `
+        const expected = {
+          title: 'Test',
+          link: 'https://example.com',
+          description: 'Test',
+          items: [{ title: 'Post' }],
+        }
+
+        expect(parse(value)).toEqual(expected)
+      })
+
+      it('RW-X19: should preserve raw XML inside stop node pubDate', () => {
+        const value = `
+          <?xml version="1.0" encoding="UTF-8"?>
+          <rss version="2.0">
+            <channel>
+              <title>Test</title>
+              <link>https://example.com</link>
+              <description>Test</description>
+              <item>
+                <title>Post</title>
+                <pubDate><time datetime="2019-05-12">Sun, 05/12/2019</time></pubDate>
+              </item>
+            </channel>
+          </rss>
+        `
+        const expected = {
+          title: 'Test',
+          link: 'https://example.com',
+          description: 'Test',
+          items: [{
+            title: 'Post',
+            pubDate: '<time datetime="2019-05-12">Sun, 05/12/2019</time>',
+          }],
+        }
+
+        expect(parse(value)).toEqual(expected)
+      })
+
+      it('RW-X20: should scope image child elements without polluting channel', () => {
+        const value = `
+          <?xml version="1.0" encoding="UTF-8"?>
+          <rss version="2.0">
+            <channel>
+              <title>Channel Title</title>
+              <link>https://example.com</link>
+              <description>Test</description>
+              <image>
+                <title>Image Title</title>
+                <url>https://example.com/logo.png</url>
+                <link>https://example.com</link>
+              </image>
+              <item>
+                <title>Item</title>
+              </item>
+            </channel>
+          </rss>
+        `
+        const expected = {
+          title: 'Channel Title',
+          link: 'https://example.com',
+          description: 'Test',
+          image: {
+            title: 'Image Title',
+            url: 'https://example.com/logo.png',
+            link: 'https://example.com',
+          },
+          items: [{ title: 'Item' }],
+        }
+
+        expect(parse(value)).toEqual(expected)
+      })
+
+      it('RW-X21: should scope textInput child elements without polluting channel', () => {
+        const value = `
+          <?xml version="1.0" encoding="UTF-8"?>
+          <rss version="2.0">
+            <channel>
+              <title>Channel Title</title>
+              <link>https://example.com</link>
+              <description>Channel Desc</description>
+              <textInput>
+                <title>Search</title>
+                <description>Search this site</description>
+                <name>q</name>
+                <link>https://example.com/search</link>
+              </textInput>
+              <item>
+                <title>Item</title>
+              </item>
+            </channel>
+          </rss>
+        `
+        const expected = {
+          title: 'Channel Title',
+          link: 'https://example.com',
+          description: 'Channel Desc',
+          textInput: {
+            title: 'Search',
+            description: 'Search this site',
+            name: 'q',
+            link: 'https://example.com/search',
+          },
+          items: [{ title: 'Item' }],
+        }
+
+        expect(parse(value)).toEqual(expected)
+      })
+
+      it('RW-Q11: should preserve both author and dc:creator', () => {
+        const value = `
+          <?xml version="1.0" encoding="UTF-8"?>
+          <rss version="2.0" xmlns:dc="http://purl.org/dc/elements/1.1/">
+            <channel>
+              <title>Test</title>
+              <link>https://example.com</link>
+              <description>Test</description>
+              <item>
+                <title>Post</title>
+                <author>Regular Author</author>
+                <dc:creator>DC Author</dc:creator>
+              </item>
+            </channel>
+          </rss>
+        `
+        const expected = {
+          title: 'Test',
+          link: 'https://example.com',
+          description: 'Test',
+          items: [{
+            title: 'Post',
+            authors: ['Regular Author'],
+            dc: {
+              creators: ['DC Author'],
+              creator: 'DC Author',
+            },
+          }],
+        }
+
+        expect(parse(value)).toEqual(expected)
+      })
+
+      it('RW-Q12: should collect multiple dc:creator elements', () => {
+        const value = `
+          <?xml version="1.0" encoding="UTF-8"?>
+          <rss version="2.0" xmlns:dc="http://purl.org/dc/elements/1.1/">
+            <channel>
+              <title>Test</title>
+              <link>https://example.com</link>
+              <description>Test</description>
+              <item>
+                <title>Post</title>
+                <dc:creator>Alice</dc:creator>
+                <dc:creator>Bob</dc:creator>
+              </item>
+            </channel>
+          </rss>
+        `
+        const expected = {
+          title: 'Test',
+          link: 'https://example.com',
+          description: 'Test',
+          items: [{
+            title: 'Post',
+            dc: {
+              creators: ['Alice', 'Bob'],
+              creator: 'Alice',
+            },
+          }],
+        }
+
+        expect(parse(value)).toEqual(expected)
+      })
+
+      it('RW-Q13: should treat itunes:explicit "1" as false', () => {
+        const value = `
+          <?xml version="1.0" encoding="UTF-8"?>
+          <rss version="2.0" xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd">
+            <channel>
+              <title>My Podcast</title>
+              <link>https://example.com</link>
+              <description>A podcast</description>
+              <item>
+                <title>Episode 1</title>
+                <itunes:explicit>1</itunes:explicit>
+              </item>
+            </channel>
+          </rss>
+        `
+        const result = parse(value)
+
+        expect(result.items?.[0]?.itunes?.explicit).toBe(false)
+      })
+
+      it('RW-Q14: should parse itunes:duration with fractional seconds', () => {
+        const value = `
+          <?xml version="1.0" encoding="UTF-8"?>
+          <rss version="2.0" xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd">
+            <channel>
+              <title>My Podcast</title>
+              <link>https://example.com</link>
+              <description>A podcast</description>
+              <item>
+                <title>Episode 1</title>
+                <itunes:duration>3661.5</itunes:duration>
+              </item>
+            </channel>
+          </rss>
+        `
+        const result = parse(value)
+
+        expect(result.items?.[0]?.itunes?.duration).toBe(3661.5)
+      })
+
+      it('RW-Q15: should parse itunes:image as text content without @href', () => {
+        const value = `
+          <?xml version="1.0" encoding="UTF-8"?>
+          <rss version="2.0" xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd">
+            <channel>
+              <title>My Podcast</title>
+              <link>https://example.com</link>
+              <description>A podcast</description>
+              <item>
+                <title>Episode 1</title>
+                <itunes:image>https://example.com/art.jpg</itunes:image>
+              </item>
+            </channel>
+          </rss>
+        `
+        const result = parse(value)
+
+        expect(result.items?.[0]?.itunes?.image).toBe('https://example.com/art.jpg')
+      })
+    })
+
+    describe('unicode and special characters', () => {
+      it('RW-E18: should preserve BiDi control characters in category text', () => {
+        const value = `
+          <?xml version="1.0" encoding="UTF-8"?>
+          <rss version="2.0">
+            <channel>
+              <title>Test</title>
+              <link>https://example.com</link>
+              <description>Test</description>
+              <item>
+                <title>Post</title>
+                <category>\u202ASports\u202C</category>
+              </item>
+            </channel>
+          </rss>
+        `
+        const result = parse(value)
+
+        expect(result.items?.[0]?.categories?.[0]?.name).toBe('\u202ASports\u202C')
+      })
+    })
+
+    describe('description and content interaction', () => {
+      it('RW-D18: should parse both description and content:encoded regardless of order', () => {
+        const value = `
+          <?xml version="1.0" encoding="UTF-8"?>
+          <rss version="2.0" xmlns:content="http://purl.org/rss/1.0/modules/content/">
+            <channel>
+              <title>Test</title>
+              <link>https://example.com</link>
+              <description>Test</description>
+              <item>
+                <title>First</title>
+                <description>Desc first</description>
+                <content:encoded><![CDATA[<p>Content first</p>]]></content:encoded>
+              </item>
+              <item>
+                <title>Second</title>
+                <content:encoded><![CDATA[<p>Content second</p>]]></content:encoded>
+                <description>Desc second</description>
+              </item>
+            </channel>
+          </rss>
+        `
+        const expected = {
+          title: 'Test',
+          link: 'https://example.com',
+          description: 'Test',
+          items: [
+            {
+              title: 'First',
+              description: 'Desc first',
+              content: { encoded: '<p>Content first</p>' },
+            },
+            {
+              title: 'Second',
+              description: 'Desc second',
+              content: { encoded: '<p>Content second</p>' },
+            },
+          ],
+        }
+
+        expect(parse(value)).toEqual(expected)
+      })
+
+      it('RW-D23: should preserve bare HTML children inside description stop node', () => {
+        const value = `
+          <?xml version="1.0" encoding="UTF-8"?>
+          <rss version="2.0">
+            <channel>
+              <title>Test</title>
+              <link>https://example.com</link>
+              <description>Test</description>
+              <item>
+                <title>Post</title>
+                <description><p>Hello world</p></description>
+              </item>
+            </channel>
+          </rss>
+        `
+        const result = parse(value)
+
+        expect(result.items?.[0]?.description).toBe('<p>Hello world</p>')
+      })
+    })
+
+    describe('link edge cases', () => {
+      it('RW-L17: should parse text link separately from atom:link', () => {
+        const value = `
+          <?xml version="1.0" encoding="UTF-8"?>
+          <rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+            <channel>
+              <title>Test</title>
+              <link>https://example.com</link>
+              <description>Test</description>
+              <atom:link href="https://example.com/feed" rel="self" type="application/rss+xml"/>
+            </channel>
+          </rss>
+        `
+        const result = parse(value)
+
+        expect(result.link).toBe('https://example.com')
+        expect(result.atom?.links).toEqual([
+          {
+            href: 'https://example.com/feed',
+            rel: 'self',
+            type: 'application/rss+xml',
+          },
+        ])
+      })
+    })
+
+    describe('dc namespace edge cases', () => {
+      it('RW-M09: should collect multiple dc:creator elements in order', () => {
+        const value = `
+          <?xml version="1.0" encoding="UTF-8"?>
+          <rss version="2.0" xmlns:dc="http://purl.org/dc/elements/1.1/">
+            <channel>
+              <title>Test</title>
+              <link>https://example.com</link>
+              <description>Test</description>
+              <item>
+                <title>Post</title>
+                <dc:creator>Alice</dc:creator>
+                <dc:creator>Bob</dc:creator>
+                <dc:creator>Charlie</dc:creator>
+              </item>
+            </channel>
+          </rss>
+        `
+        const result = parse(value)
+
+        expect(result.items?.[0]?.dc?.creators).toEqual(['Alice', 'Bob', 'Charlie'])
+        expect(result.items?.[0]?.dc?.creator).toBe('Alice')
+      })
+
+      it('RW-NS24: should ignore empty dc:title and keep core title', () => {
+        const value = `
+          <?xml version="1.0" encoding="UTF-8"?>
+          <rss version="2.0" xmlns:dc="http://purl.org/dc/elements/1.1/">
+            <channel>
+              <title>Test</title>
+              <link>https://example.com</link>
+              <description>Test</description>
+              <item>
+                <title>Real Title</title>
+                <dc:title/>
+              </item>
+            </channel>
+          </rss>
+        `
+        const result = parse(value)
+
+        expect(result.items?.[0]?.title).toBe('Real Title')
+        expect(result.items?.[0]?.dc).toBeUndefined()
+      })
+    })
+
+    describe('duplicate element handling', () => {
+      it('RW-M11: should use first guid when multiple guid elements exist', () => {
+        const value = `
+          <?xml version="1.0" encoding="UTF-8"?>
+          <rss version="2.0">
+            <channel>
+              <title>Test</title>
+              <link>https://example.com</link>
+              <description>Test</description>
+              <item>
+                <title>Post</title>
+                <guid>first-guid</guid>
+                <guid>second-guid</guid>
+              </item>
+            </channel>
+          </rss>
+        `
+        const result = parse(value)
+
+        expect(result.items?.[0]?.guid).toEqual({ value: 'first-guid' })
+      })
+    })
+
+    describe('image edge cases', () => {
+      it('RW-N22: should parse channel image with only url', () => {
+        const value = `
+          <?xml version="1.0" encoding="UTF-8"?>
+          <rss version="2.0">
+            <channel>
+              <title>Test</title>
+              <link>https://example.com</link>
+              <description>Test</description>
+              <image>
+                <url>https://example.com/logo.png</url>
+              </image>
+            </channel>
+          </rss>
+        `
+        const result = parse(value)
+
+        expect(result.image).toEqual({ url: 'https://example.com/logo.png' })
+      })
+
+      it('RW-Q16: should not parse image element at item level', () => {
+        const value = `
+          <?xml version="1.0" encoding="UTF-8"?>
+          <rss version="2.0">
+            <channel>
+              <title>Test</title>
+              <link>https://example.com</link>
+              <description>Test</description>
+              <item>
+                <title>Post</title>
+                <image>https://example.com/pic.jpg</image>
+              </item>
+            </channel>
+          </rss>
+        `
+        const result = parse(value)
+
+        expect(result.items?.[0]).toEqual({ title: 'Post' })
+      })
+    })
+
+    describe('enclosure edge cases', () => {
+      it('RW-A14: should omit length for empty string enclosure length', () => {
+        const value = `
+          <?xml version="1.0" encoding="UTF-8"?>
+          <rss version="2.0">
+            <channel>
+              <title>Test</title>
+              <link>https://example.com</link>
+              <description>Test</description>
+              <item>
+                <title>Episode</title>
+                <enclosure url="https://example.com/file.mp3" length="" type="audio/mpeg"/>
+              </item>
+            </channel>
+          </rss>
+        `
+        const result = parse(value)
+
+        expect(result.items?.[0]?.enclosures).toEqual([
+          { url: 'https://example.com/file.mp3', type: 'audio/mpeg' },
+        ])
+      })
+
+      it('RW-A14: should omit length for non-numeric enclosure length', () => {
+        const value = `
+          <?xml version="1.0" encoding="UTF-8"?>
+          <rss version="2.0">
+            <channel>
+              <title>Test</title>
+              <link>https://example.com</link>
+              <description>Test</description>
+              <item>
+                <title>Episode</title>
+                <enclosure url="https://example.com/file.mp3" length="abc" type="audio/mpeg"/>
+              </item>
+            </channel>
+          </rss>
+        `
+        const result = parse(value)
+
+        expect(result.items?.[0]?.enclosures).toEqual([
+          { url: 'https://example.com/file.mp3', type: 'audio/mpeg' },
+        ])
+      })
+
+      it('RW-A15: should parse float enclosure length as number', () => {
+        const value = `
+          <?xml version="1.0" encoding="UTF-8"?>
+          <rss version="2.0">
+            <channel>
+              <title>Test</title>
+              <link>https://example.com</link>
+              <description>Test</description>
+              <item>
+                <title>Episode</title>
+                <enclosure url="https://example.com/file.mp3" length="1.5" type="audio/mpeg"/>
+              </item>
+            </channel>
+          </rss>
+        `
+        const result = parse(value)
+
+        expect(result.items?.[0]?.enclosures).toEqual([
+          { url: 'https://example.com/file.mp3', length: 1.5, type: 'audio/mpeg' },
+        ])
+      })
+
+      it('RW-A19: should ignore enclosure text content without attributes', () => {
+        const value = `
+          <?xml version="1.0" encoding="UTF-8"?>
+          <rss version="2.0">
+            <channel>
+              <title>Test</title>
+              <link>https://example.com</link>
+              <description>Test</description>
+              <item>
+                <title>Episode</title>
+                <enclosure>https://example.com/file.mp3</enclosure>
+              </item>
+            </channel>
+          </rss>
+        `
+        const result = parse(value)
+
+        expect(result.items?.[0]?.enclosures).toBeUndefined()
+      })
+
+      it('RW-A20: should preserve MIME type with parameters in enclosure', () => {
+        const value = `
+          <?xml version="1.0" encoding="UTF-8"?>
+          <rss version="2.0">
+            <channel>
+              <title>Test</title>
+              <link>https://example.com</link>
+              <description>Test</description>
+              <item>
+                <title>Post</title>
+                <enclosure url="https://example.com/page" length="5000" type="text/html; charset=utf-8"/>
+              </item>
+            </channel>
+          </rss>
+        `
+        const result = parse(value)
+
+        expect(result.items?.[0]?.enclosures).toEqual([
+          { url: 'https://example.com/page', length: 5000, type: 'text/html; charset=utf-8' },
+        ])
+      })
+    })
+
+    describe('guid edge cases', () => {
+      it('RW-A16: should parse guid without isPermaLink attribute', () => {
+        const value = `
+          <?xml version="1.0" encoding="UTF-8"?>
+          <rss version="2.0">
+            <channel>
+              <title>Test</title>
+              <link>https://example.com</link>
+              <description>Test</description>
+              <item>
+                <title>Post</title>
+                <guid>internal-id-12345</guid>
+              </item>
+            </channel>
+          </rss>
+        `
+        const result = parse(value)
+
+        expect(result.items?.[0]?.guid).toEqual({ value: 'internal-id-12345' })
+        expect(result.items?.[0]?.guid?.isPermaLink).toBeUndefined()
+      })
+    })
+
+    describe('source element', () => {
+      it('RW-A17: should parse source with url attribute and text', () => {
+        const value = `
+          <?xml version="1.0" encoding="UTF-8"?>
+          <rss version="2.0">
+            <channel>
+              <title>Test</title>
+              <link>https://example.com</link>
+              <description>Test</description>
+              <item>
+                <title>Post</title>
+                <source url="https://example.com/feed">Source Name</source>
+              </item>
+            </channel>
+          </rss>
+        `
+        const result = parse(value)
+
+        expect(result.items?.[0]?.source).toEqual({
+          title: 'Source Name',
+          url: 'https://example.com/feed',
+        })
+      })
+    })
+
+    describe('author edge cases', () => {
+      it('RW-A18: should parse plain author name string', () => {
+        const value = `
+          <?xml version="1.0" encoding="UTF-8"?>
+          <rss version="2.0">
+            <channel>
+              <title>Test</title>
+              <link>https://example.com</link>
+              <description>Test</description>
+              <item>
+                <title>Post</title>
+                <author>John Doe</author>
+              </item>
+            </channel>
+          </rss>
+        `
+        const result = parse(value)
+
+        expect(result.items?.[0]?.authors).toEqual(['John Doe'])
+      })
+    })
+
+    describe('foreign namespace on core elements', () => {
+      it('RW-NS25: should handle default namespace override on link element', () => {
+        const value = `
+          <?xml version="1.0" encoding="UTF-8"?>
+          <rss version="2.0">
+            <channel>
+              <title>Test</title>
+              <link xmlns="http://apache.org/cocoon/i18n/2.1">https://example.com</link>
+              <description>Test</description>
+            </channel>
+          </rss>
+        `
+        const result = parse(value)
+
+        expect(result.link).toBe('https://example.com')
+      })
+    })
+
+    describe('atom namespace in RSS items', () => {
+      it('RW-NS26: should parse atom:author inside RSS item', () => {
+        const value = `
+          <?xml version="1.0" encoding="UTF-8"?>
+          <rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+            <channel>
+              <title>Test</title>
+              <link>https://example.com</link>
+              <description>Test</description>
+              <item>
+                <title>Post</title>
+                <atom:author>
+                  <atom:name>John Doe</atom:name>
+                </atom:author>
+              </item>
+            </channel>
+          </rss>
+        `
+        const result = parse(value)
+
+        expect(result.items?.[0]?.atom?.authors).toEqual([{ name: 'John Doe' }])
+      })
+    })
+
+    describe('sy namespace edge cases', () => {
+      it('RW-NS27: should preserve bad date string in sy:updateBase', () => {
+        const value = `
+          <?xml version="1.0" encoding="UTF-8"?>
+          <rss version="2.0" xmlns:sy="http://purl.org/rss/1.0/modules/syndication/">
+            <channel>
+              <title>Test</title>
+              <link>https://example.com</link>
+              <description>Test</description>
+              <sy:updateBase>not-a-date</sy:updateBase>
+            </channel>
+          </rss>
+        `
+        const result = parse(value)
+
+        expect(result.sy?.updateBase).toBe('not-a-date')
+      })
+    })
+
+    describe('namespace scoping', () => {
+      it('RW-NS28: should not leak dc:identifier nested inside media:content to item level', () => {
+        const value = `
+          <?xml version="1.0" encoding="UTF-8"?>
+          <rss version="2.0"
+            xmlns:media="http://search.yahoo.com/mrss/"
+            xmlns:dc="http://purl.org/dc/elements/1.1/">
+            <channel>
+              <title>Test</title>
+              <link>https://example.com</link>
+              <description>Test</description>
+              <item>
+                <title>Post</title>
+                <media:content url="https://example.com/video.mp4">
+                  <dc:identifier>1</dc:identifier>
+                </media:content>
+              </item>
+            </channel>
+          </rss>
+        `
+        const result = parse(value)
+
+        expect(result.items?.[0]?.media?.contents?.[0]?.url).toBe('https://example.com/video.mp4')
+        expect(result.items?.[0]?.dc?.identifiers).toBeUndefined()
+      })
+    })
+
+    describe('itunes and core field independence', () => {
+      it('RW-NS29: should parse itunes:summary and description independently', () => {
+        const value = `
+          <?xml version="1.0" encoding="UTF-8"?>
+          <rss version="2.0" xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd">
+            <channel>
+              <title>My Podcast</title>
+              <link>https://example.com</link>
+              <description>A podcast</description>
+              <item>
+                <title>Episode 1</title>
+                <description>Real description</description>
+                <itunes:summary>iTunes summary</itunes:summary>
+              </item>
+            </channel>
+          </rss>
+        `
+        const result = parse(value)
+
+        expect(result.items?.[0]?.description).toBe('Real description')
+        expect(result.items?.[0]?.itunes?.summary).toBe('iTunes summary')
+      })
+    })
+
+    describe('concatenated and malformed XML', () => {
+      it('RW-X22: should parse only first document from concatenated RSS documents', () => {
+        const value = `
+          <?xml version="1.0" encoding="UTF-8"?>
+          <rss version="2.0">
+            <channel>
+              <title>First Feed</title>
+              <link>https://first.example.com</link>
+              <description>First</description>
+            </channel>
+          </rss>
+          <?xml version="1.0" encoding="UTF-8"?>
+          <rss version="2.0">
+            <channel>
+              <title>Second Feed</title>
+              <link>https://second.example.com</link>
+              <description>Second</description>
+            </channel>
+          </rss>
+        `
+        const expected = {
+          title: 'First Feed',
+          link: 'https://first.example.com',
+          description: 'First',
+        }
+
+        expect(parse(value)).toEqual(expected)
+      })
+
+      it('RW-X23: should parse adjacent elements without whitespace', () => {
+        const value = `
+          <?xml version="1.0" encoding="UTF-8"?>
+          <rss version="2.0"
+            xmlns:media="http://search.yahoo.com/mrss/"
+            xmlns:content="http://purl.org/rss/1.0/modules/content/">
+            <channel>
+              <title>Test</title>
+              <link>https://example.com</link>
+              <description>Test</description>
+              <item>
+                <title>Post</title>
+                <media:content url="https://example.com/img.jpg"/><content:encoded><![CDATA[Article text]]></content:encoded>
+              </item>
+            </channel>
+          </rss>
+        `
+        const result = parse(value)
+
+        expect(result.items?.[0]?.media?.contents?.[0]?.url).toBe('https://example.com/img.jpg')
+        expect(result.items?.[0]?.content?.encoded).toBe('Article text')
+      })
+    })
+
+    describe('non-standard RSS version', () => {
+      it('RW-X24: should parse RSS with version 0.91', () => {
+        const value = `
+          <?xml version="1.0" encoding="UTF-8"?>
+          <rss version="0.91">
+            <channel>
+              <title>Old Feed</title>
+              <link>https://example.com</link>
+              <description>An old RSS feed</description>
+              <item>
+                <title>Post</title>
+              </item>
+            </channel>
+          </rss>
+        `
+        const expected = {
+          title: 'Old Feed',
+          link: 'https://example.com',
+          description: 'An old RSS feed',
+          items: [{ title: 'Post' }],
+        }
+
+        expect(parse(value)).toEqual(expected)
+      })
+    })
+
+    describe('itunes:explicit values', () => {
+      it('RW-Q17: should treat itunes:explicit "no" as false', () => {
+        const value = `
+          <?xml version="1.0" encoding="UTF-8"?>
+          <rss version="2.0" xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd">
+            <channel>
+              <title>My Podcast</title>
+              <link>https://example.com</link>
+              <description>A podcast</description>
+              <item>
+                <title>Episode 1</title>
+                <itunes:explicit>no</itunes:explicit>
+              </item>
+            </channel>
+          </rss>
+        `
+        const result = parse(value)
+
+        expect(result.items?.[0]?.itunes?.explicit).toBe(false)
+      })
+    })
+
+    describe('category edge cases', () => {
+      it('RW-Q18: should parse category with domain but empty text', () => {
+        const value = `
+          <?xml version="1.0" encoding="UTF-8"?>
+          <rss version="2.0">
+            <channel>
+              <title>Test</title>
+              <link>https://example.com</link>
+              <description>Test</description>
+              <item>
+                <title>Post</title>
+                <category domain="dmoz"></category>
+              </item>
+            </channel>
+          </rss>
+        `
+        const result = parse(value)
+
+        expect(result.items?.[0]?.categories).toEqual([{ domain: 'dmoz' }])
       })
     })
   })

--- a/src/feeds/rss/parse/index.test.ts
+++ b/src/feeds/rss/parse/index.test.ts
@@ -870,7 +870,7 @@ describe('parse', () => {
     })
   })
 
-  // Catalogue: plans/real_world_test_suite.md
+  // Edge cases and quirks observed in feeds found in the wild.
   describe('real world feeds', () => {
     it('RW-C01: should preserve HTML entities inside CDATA in content:encoded', () => {
       const value = `
@@ -1172,9 +1172,11 @@ describe('parse', () => {
           title: 'Test',
           link: 'https://example.com',
           description: 'Test',
-          items: [{
-            title: 'Jahresr&uuml;ckblick 2017',
-          }],
+          items: [
+            {
+              title: 'Jahresr&uuml;ckblick 2017',
+            },
+          ],
         }
 
         expect(parse(value)).toEqual(expected)
@@ -1201,10 +1203,12 @@ describe('parse', () => {
           title: 'Test',
           link: 'https://example.com',
           description: 'Test',
-          items: [{
-            title: 'Post',
-            description: '<p>Actual content here</p>',
-          }],
+          items: [
+            {
+              title: 'Post',
+              description: '<p>Actual content here</p>',
+            },
+          ],
         }
 
         expect(parse(value)).toEqual(expected)
@@ -1229,10 +1233,12 @@ describe('parse', () => {
           title: 'Test',
           link: 'https://example.com',
           description: 'Test',
-          items: [{
-            title: 'Post',
-            content: { encoded: 'Use &amp; for ampersands' },
-          }],
+          items: [
+            {
+              title: 'Post',
+              content: { encoded: 'Use &amp; for ampersands' },
+            },
+          ],
         }
 
         expect(parse(value)).toEqual(expected)
@@ -1259,10 +1265,12 @@ describe('parse', () => {
           title: 'Test',
           link: 'https://example.com',
           description: 'Test',
-          items: [{
-            title: 'Post',
-            description: '<![CDATA[Some escaped CDATA content]]>',
-          }],
+          items: [
+            {
+              title: 'Post',
+              description: '<![CDATA[Some escaped CDATA content]]>',
+            },
+          ],
         }
 
         expect(parse(value)).toEqual(expected)
@@ -1290,11 +1298,13 @@ describe('parse', () => {
           title: 'Test',
           link: 'https://example.com',
           description: 'Test',
-          items: [{
-            title: 'Post',
-            description: 'Short summary',
-            content: { encoded: '<p>Full HTML content</p>' },
-          }],
+          items: [
+            {
+              title: 'Post',
+              description: 'Short summary',
+              content: { encoded: '<p>Full HTML content</p>' },
+            },
+          ],
         }
 
         expect(parse(value)).toEqual(expected)
@@ -1357,10 +1367,12 @@ describe('parse', () => {
           title: 'Test',
           link: 'https://example.com',
           description: 'Test',
-          items: [{
-            title: 'Post',
-            description: '<p>HTML content</p>',
-          }],
+          items: [
+            {
+              title: 'Post',
+              description: '<p>HTML content</p>',
+            },
+          ],
         }
 
         expect(parse(value)).toEqual(expected)
@@ -1387,10 +1399,12 @@ describe('parse', () => {
           title: 'Test',
           link: 'https://example.com',
           description: 'Test',
-          items: [{
-            title: 'Post',
-            link: '/blog/post-1',
-          }],
+          items: [
+            {
+              title: 'Post',
+              link: '/blog/post-1',
+            },
+          ],
         }
 
         expect(parse(value)).toEqual(expected)
@@ -1415,10 +1429,12 @@ describe('parse', () => {
           title: 'Test',
           link: 'https://example.com',
           description: 'Test',
-          items: [{
-            title: 'Post',
-            link: 'https://example.com/search?q=hello&lang=en',
-          }],
+          items: [
+            {
+              title: 'Post',
+              link: 'https://example.com/search?q=hello&lang=en',
+            },
+          ],
         }
 
         expect(parse(value)).toEqual(expected)
@@ -1441,7 +1457,9 @@ describe('parse', () => {
           link: 'https://example.com',
           description: 'Test',
           atom: {
-            links: [{ href: 'https://example.com/feed.xml', rel: 'self', type: 'application/rss+xml' }],
+            links: [
+              { href: 'https://example.com/feed.xml', rel: 'self', type: 'application/rss+xml' },
+            ],
           },
         }
 
@@ -1472,10 +1490,12 @@ describe('parse', () => {
           atom: {
             links: [{ href: 'https://example.com/rss', rel: 'self', type: 'application/rss+xml' }],
           },
-          items: [{
-            title: 'Post',
-            link: 'https://example.com/post/1',
-          }],
+          items: [
+            {
+              title: 'Post',
+              link: 'https://example.com/post/1',
+            },
+          ],
         }
 
         expect(parse(value)).toEqual(expected)
@@ -1503,13 +1523,15 @@ describe('parse', () => {
           title: 'Test',
           link: 'https://example.com',
           description: 'Test',
-          items: [{
-            title: 'Episode 1',
-            enclosures: [
-              { url: 'https://example.com/audio.mp3', type: 'audio/mpeg', length: 12345 },
-              { url: 'https://example.com/audio.ogg', type: 'audio/ogg', length: 23456 },
-            ],
-          }],
+          items: [
+            {
+              title: 'Episode 1',
+              enclosures: [
+                { url: 'https://example.com/audio.mp3', type: 'audio/mpeg', length: 12345 },
+                { url: 'https://example.com/audio.ogg', type: 'audio/ogg', length: 23456 },
+              ],
+            },
+          ],
         }
 
         expect(parse(value)).toEqual(expected)
@@ -1536,14 +1558,16 @@ describe('parse', () => {
           title: 'Test',
           link: 'https://example.com',
           description: 'Test',
-          items: [{
-            title: 'Post',
-            categories: [
-              { name: 'Technology' },
-              { name: 'JavaScript', domain: 'https://example.com/tags' },
-              { name: 'TypeScript', domain: 'https://example.com/tags' },
-            ],
-          }],
+          items: [
+            {
+              title: 'Post',
+              categories: [
+                { name: 'Technology' },
+                { name: 'JavaScript', domain: 'https://example.com/tags' },
+                { name: 'TypeScript', domain: 'https://example.com/tags' },
+              ],
+            },
+          ],
         }
 
         expect(parse(value)).toEqual(expected)
@@ -1569,10 +1593,12 @@ describe('parse', () => {
           title: 'Test',
           link: 'https://example.com',
           description: 'Test',
-          items: [{
-            title: 'Post',
-            authors: ['alice@example.com (Alice)', 'bob@example.com (Bob)'],
-          }],
+          items: [
+            {
+              title: 'Post',
+              authors: ['alice@example.com (Alice)', 'bob@example.com (Bob)'],
+            },
+          ],
         }
 
         expect(parse(value)).toEqual(expected)
@@ -1745,10 +1771,12 @@ describe('parse', () => {
           title: 'Test',
           link: 'https://example.com',
           description: 'Test',
-          items: [{
-            title: 'Post',
-            guid: { value: 'unique-id-123', isPermaLink: false },
-          }],
+          items: [
+            {
+              title: 'Post',
+              guid: { value: 'unique-id-123', isPermaLink: false },
+            },
+          ],
         }
 
         expect(parse(value)).toEqual(expected)
@@ -1773,10 +1801,12 @@ describe('parse', () => {
           title: 'Test',
           link: 'https://example.com',
           description: 'Test',
-          items: [{
-            title: 'Post',
-            guid: { value: 'unique-id-456', isPermaLink: false },
-          }],
+          items: [
+            {
+              title: 'Post',
+              guid: { value: 'unique-id-456', isPermaLink: false },
+            },
+          ],
         }
 
         expect(parse(value)).toEqual(expected)
@@ -1801,10 +1831,14 @@ describe('parse', () => {
           title: 'Test',
           link: 'https://example.com',
           description: 'Test',
-          items: [{
-            title: 'Episode',
-            enclosures: [{ url: 'https://example.com/ep.mp3', length: 12345678, type: 'audio/mpeg' }],
-          }],
+          items: [
+            {
+              title: 'Episode',
+              enclosures: [
+                { url: 'https://example.com/ep.mp3', length: 12345678, type: 'audio/mpeg' },
+              ],
+            },
+          ],
         }
 
         expect(parse(value)).toEqual(expected)
@@ -1831,13 +1865,15 @@ describe('parse', () => {
           title: 'Test',
           link: 'https://example.com',
           description: 'Test',
-          items: [{
-            title: 'Post',
-            dc: {
-              creators: ['John Doe'],
-              creator: 'John Doe',
+          items: [
+            {
+              title: 'Post',
+              dc: {
+                creators: ['John Doe'],
+                creator: 'John Doe',
+              },
             },
-          }],
+          ],
         }
 
         expect(parse(value)).toEqual(expected)
@@ -1869,13 +1905,15 @@ describe('parse', () => {
           atom: {
             links: [{ href: 'https://example.com/feed.xml', rel: 'self' }],
           },
-          items: [{
-            title: 'Post',
-            dc: {
-              creators: ['Jane'],
-              creator: 'Jane',
+          items: [
+            {
+              title: 'Post',
+              dc: {
+                creators: ['Jane'],
+                creator: 'Jane',
+              },
             },
-          }],
+          ],
         }
 
         expect(parse(value)).toEqual(expected)
@@ -1900,13 +1938,15 @@ describe('parse', () => {
           title: 'Test',
           link: 'https://example.com',
           description: 'Test',
-          items: [{
-            title: 'Post',
-            dc: {
-              creators: ['Author'],
-              creator: 'Author',
+          items: [
+            {
+              title: 'Post',
+              dc: {
+                creators: ['Author'],
+                creator: 'Author',
+              },
             },
-          }],
+          ],
         }
 
         expect(parse(value)).toEqual(expected)
@@ -1931,13 +1971,15 @@ describe('parse', () => {
           title: 'Test',
           link: 'https://example.com',
           description: 'Test',
-          items: [{
-            title: 'Post',
-            dc: {
-              creators: ['Inline Author'],
-              creator: 'Inline Author',
+          items: [
+            {
+              title: 'Post',
+              dc: {
+                creators: ['Inline Author'],
+                creator: 'Inline Author',
+              },
             },
-          }],
+          ],
         }
 
         expect(parse(value)).toEqual(expected)
@@ -1993,10 +2035,12 @@ describe('parse', () => {
           title: 'Aggregator',
           link: 'https://example.com',
           description: 'Aggregated feed',
-          items: [{
-            title: 'Cross-posted Article',
-            source: { title: 'Original Blog', url: 'https://original.com/feed.xml' },
-          }],
+          items: [
+            {
+              title: 'Cross-posted Article',
+              source: { title: 'Original Blog', url: 'https://original.com/feed.xml' },
+            },
+          ],
         }
 
         expect(parse(value)).toEqual(expected)
@@ -2021,10 +2065,12 @@ describe('parse', () => {
           title: 'Test',
           link: 'https://example.com',
           description: 'Test',
-          items: [{
-            title: 'Post',
-            comments: 'https://example.com/post/1#comments',
-          }],
+          items: [
+            {
+              title: 'Post',
+              comments: 'https://example.com/post/1#comments',
+            },
+          ],
         }
 
         expect(parse(value)).toEqual(expected)
@@ -2049,10 +2095,12 @@ describe('parse', () => {
           title: 'Test',
           link: 'https://example.com',
           description: 'Test',
-          items: [{
-            title: 'Post',
-            authors: ['john@example.com (John Doe)'],
-          }],
+          items: [
+            {
+              title: 'Post',
+              authors: ['john@example.com (John Doe)'],
+            },
+          ],
         }
 
         expect(parse(value)).toEqual(expected)
@@ -2118,10 +2166,12 @@ describe('parse', () => {
           title: 'Test',
           link: 'https://example.com',
           description: 'Test',
-          items: [{
-            title: 'Post',
-            description: 'Fish & Chips are great',
-          }],
+          items: [
+            {
+              title: 'Post',
+              description: 'Fish & Chips are great',
+            },
+          ],
         }
 
         expect(parse(value)).toEqual(expected)
@@ -2325,10 +2375,12 @@ describe('parse', () => {
           title: 'Feed',
           link: 'https://example.com',
           description: 'Test',
-          items: [{
-            title: 'Outside Item',
-            link: 'https://example.com/outside',
-          }],
+          items: [
+            {
+              title: 'Outside Item',
+              link: 'https://example.com/outside',
+            },
+          ],
         }
 
         expect(parse(value)).toEqual(expected)
@@ -2353,13 +2405,17 @@ describe('parse', () => {
           title: 'Test',
           link: 'https://example.com',
           description: 'Test',
-          items: [{
-            title: 'Post',
-            enclosures: [{
-              url: 'https://example.com/file.mp3',
-              type: 'audio/mpeg',
-            }],
-          }],
+          items: [
+            {
+              title: 'Post',
+              enclosures: [
+                {
+                  url: 'https://example.com/file.mp3',
+                  type: 'audio/mpeg',
+                },
+              ],
+            },
+          ],
         }
 
         expect(parse(value)).toEqual(expected)
@@ -2410,12 +2466,14 @@ describe('parse', () => {
           title: 'Test',
           link: 'https://example.com',
           description: 'Test',
-          items: [{
-            title: 'Code Example',
-            content: {
-              encoded: '<pre>for (i = 0; i < 10; i++) { console.log(i); }</pre>',
+          items: [
+            {
+              title: 'Code Example',
+              content: {
+                encoded: '<pre>for (i = 0; i < 10; i++) { console.log(i); }</pre>',
+              },
             },
-          }],
+          ],
         }
 
         expect(parse(value)).toEqual(expected)
@@ -2440,10 +2498,12 @@ describe('parse', () => {
           title: 'Test',
           link: 'https://example.com',
           description: 'Test',
-          items: [{
-            title: 'Post',
-            description: 'Click <a href="https://example.com">here</a> for more',
-          }],
+          items: [
+            {
+              title: 'Post',
+              description: 'Click <a href="https://example.com">here</a> for more',
+            },
+          ],
         }
 
         expect(parse(value)).toEqual(expected)
@@ -2470,10 +2530,12 @@ describe('parse', () => {
           title: 'Test',
           link: 'https://example.com',
           description: 'Test',
-          items: [{
-            title: 'Episode',
-            enclosures: [{ type: 'audio/mpeg', length: 5000000 }],
-          }],
+          items: [
+            {
+              title: 'Episode',
+              enclosures: [{ type: 'audio/mpeg', length: 5000000 }],
+            },
+          ],
         }
 
         expect(parse(value)).toEqual(expected)
@@ -2522,9 +2584,11 @@ describe('parse', () => {
           title: 'Test',
           link: 'https://example.com',
           description: 'Test',
-          items: [{
-            guid: { value: 'unique-12345', isPermaLink: false },
-          }],
+          items: [
+            {
+              guid: { value: 'unique-12345', isPermaLink: false },
+            },
+          ],
         }
 
         expect(parse(value)).toEqual(expected)
@@ -2549,10 +2613,12 @@ describe('parse', () => {
           title: 'Test',
           link: 'https://example.com',
           description: 'Test',
-          items: [{
-            title: 'Post',
-            pubDate: 'sometime in January',
-          }],
+          items: [
+            {
+              title: 'Post',
+              pubDate: 'sometime in January',
+            },
+          ],
         }
 
         expect(parse(value)).toEqual(expected)
@@ -2623,10 +2689,12 @@ describe('parse', () => {
           title: 'Test',
           link: 'https://example.com',
           description: 'Test',
-          items: [{
-            title: 'Post',
-            pubDate: 'Mon, 01 Jan 2024 00:00:00 GMT',
-          }],
+          items: [
+            {
+              title: 'Post',
+              pubDate: 'Mon, 01 Jan 2024 00:00:00 GMT',
+            },
+          ],
         }
 
         expect(parse(value)).toEqual(expected)
@@ -2652,10 +2720,12 @@ describe('parse', () => {
           title: 'Test',
           link: 'https://example.com',
           description: 'Test',
-          items: [{
-            title: 'Post',
-            description: 'Fallback content',
-          }],
+          items: [
+            {
+              title: 'Post',
+              description: 'Fallback content',
+            },
+          ],
         }
 
         expect(parse(value)).toEqual(expected)
@@ -2680,10 +2750,12 @@ describe('parse', () => {
           title: 'Test',
           link: 'https://example.com',
           description: 'Test',
-          items: [{
-            title: 'Post',
-            guid: { value: 'https://example.com/post/1', isPermaLink: true },
-          }],
+          items: [
+            {
+              title: 'Post',
+              guid: { value: 'https://example.com/post/1', isPermaLink: true },
+            },
+          ],
         }
 
         expect(parse(value)).toEqual(expected)
@@ -2708,14 +2780,18 @@ describe('parse', () => {
           title: 'Test',
           link: 'https://example.com',
           description: 'Test',
-          items: [{
-            title: 'Episode',
-            enclosures: [{
-              url: 'https://example.com/audio.mp3',
-              type: 'mp3',
-              length: 12345,
-            }],
-          }],
+          items: [
+            {
+              title: 'Episode',
+              enclosures: [
+                {
+                  url: 'https://example.com/audio.mp3',
+                  type: 'mp3',
+                  length: 12345,
+                },
+              ],
+            },
+          ],
         }
 
         expect(parse(value)).toEqual(expected)
@@ -2740,13 +2816,15 @@ describe('parse', () => {
           title: 'Test',
           link: 'https://example.com',
           description: 'Test',
-          items: [{
-            title: 'Post',
-            dc: {
-              dates: ['2025-02-21T16:00:00Z'],
-              date: '2025-02-21T16:00:00Z',
+          items: [
+            {
+              title: 'Post',
+              dc: {
+                dates: ['2025-02-21T16:00:00Z'],
+                date: '2025-02-21T16:00:00Z',
+              },
             },
-          }],
+          ],
         }
 
         expect(parse(value)).toEqual(expected)
@@ -2773,17 +2851,21 @@ describe('parse', () => {
           title: 'Test',
           link: 'https://example.com',
           description: 'Test',
-          items: [{
-            title: 'Post',
-            media: {
-              contents: [{
-                url: 'https://example.com/image.png',
-                type: 'image/png',
-                medium: 'image',
-                ratings: [{ value: 'nonadult', scheme: 'urn:simple' }],
-              }],
+          items: [
+            {
+              title: 'Post',
+              media: {
+                contents: [
+                  {
+                    url: 'https://example.com/image.png',
+                    type: 'image/png',
+                    medium: 'image',
+                    ratings: [{ value: 'nonadult', scheme: 'urn:simple' }],
+                  },
+                ],
+              },
             },
-          }],
+          ],
         }
 
         expect(parse(value)).toEqual(expected)
@@ -2809,20 +2891,26 @@ describe('parse', () => {
           title: 'Test',
           link: 'https://example.com',
           description: 'Test',
-          items: [{
-            title: 'Post',
-            media: {
-              contents: [{
-                url: 'https://example.com/full.jpg',
-                type: 'image/jpeg',
-              }],
-              thumbnails: [{
-                url: 'https://example.com/thumb.jpg',
-                width: 120,
-                height: 90,
-              }],
+          items: [
+            {
+              title: 'Post',
+              media: {
+                contents: [
+                  {
+                    url: 'https://example.com/full.jpg',
+                    type: 'image/jpeg',
+                  },
+                ],
+                thumbnails: [
+                  {
+                    url: 'https://example.com/thumb.jpg',
+                    width: 120,
+                    height: 90,
+                  },
+                ],
+              },
             },
-          }],
+          ],
         }
 
         expect(parse(value)).toEqual(expected)
@@ -2867,13 +2955,15 @@ describe('parse', () => {
           title: 'Test',
           link: 'https://example.com',
           description: 'Test',
-          items: [{
-            title: 'Post',
-            dc: {
-              creators: ['John Doe'],
-              creator: 'John Doe',
+          items: [
+            {
+              title: 'Post',
+              dc: {
+                creators: ['John Doe'],
+                creator: 'John Doe',
+              },
             },
-          }],
+          ],
         }
 
         expect(parse(value)).toEqual(expected)
@@ -2896,11 +2986,13 @@ describe('parse', () => {
           link: 'https://example.com',
           description: 'Test',
           atom: {
-            links: [{
-              href: 'https://example.com/feed.xml',
-              rel: 'self',
-              type: 'application/rss+xml',
-            }],
+            links: [
+              {
+                href: 'https://example.com/feed.xml',
+                rel: 'self',
+                type: 'application/rss+xml',
+              },
+            ],
           },
         }
 
@@ -2926,10 +3018,12 @@ describe('parse', () => {
           title: 'Test',
           link: 'https://example.com',
           description: 'Test',
-          items: [{
-            title: 'Post',
-            description: "It doesn't work",
-          }],
+          items: [
+            {
+              title: 'Post',
+              description: "It doesn't work",
+            },
+          ],
         }
 
         expect(parse(value)).toEqual(expected)
@@ -3026,10 +3120,12 @@ describe('parse', () => {
           title: 'Test',
           link: 'https://example.com',
           description: 'Test',
-          items: [{
-            title: 'Post',
-            pubDate: '<time datetime="2019-05-12">Sun, 05/12/2019</time>',
-          }],
+          items: [
+            {
+              title: 'Post',
+              pubDate: '<time datetime="2019-05-12">Sun, 05/12/2019</time>',
+            },
+          ],
         }
 
         expect(parse(value)).toEqual(expected)
@@ -3125,14 +3221,16 @@ describe('parse', () => {
           title: 'Test',
           link: 'https://example.com',
           description: 'Test',
-          items: [{
-            title: 'Post',
-            authors: ['Regular Author'],
-            dc: {
-              creators: ['DC Author'],
-              creator: 'DC Author',
+          items: [
+            {
+              title: 'Post',
+              authors: ['Regular Author'],
+              dc: {
+                creators: ['DC Author'],
+                creator: 'DC Author',
+              },
             },
-          }],
+          ],
         }
 
         expect(parse(value)).toEqual(expected)
@@ -3158,13 +3256,15 @@ describe('parse', () => {
           title: 'Test',
           link: 'https://example.com',
           description: 'Test',
-          items: [{
-            title: 'Post',
-            dc: {
-              creators: ['Alice', 'Bob'],
-              creator: 'Alice',
+          items: [
+            {
+              title: 'Post',
+              dc: {
+                creators: ['Alice', 'Bob'],
+                creator: 'Alice',
+              },
             },
-          }],
+          ],
         }
 
         expect(parse(value)).toEqual(expected)


### PR DESCRIPTION
This PR adds real-world feed parsing tests for RSS, Atom, RDF and JSON, covering the edge cases fixtures miss.

- Add comprehensive real-world feed parsing tests for RSS, Atom, RDF, and JSON formats
- Cover edge cases: CDATA handling, HTML entities, namespace scoping, stop node behavior, XML comments, malformed XML resilience, encoding issues, and more
- Document known limitations: unquoted attribute values (RW-X12), concatenated documents (RW-X22)
- One known failing test (RW-NS13) for prefixed core elements in RDF, tracked in #262
