### PR TITLE
fix: Handle prefixed RSS 1.0 elements in RDF feed parsing

### DIFF
--- a/src/common/config.ts
+++ b/src/common/config.ts
@@ -74,6 +74,7 @@ import {
   uris as rawvoiceUris,
 } from '../namespaces/rawvoice/common/config.js'
 import { stopNodes as rdfStopNodes, uris as rdfUris } from '../namespaces/rdf/common/config.js'
+import { uris as rssUris } from '../namespaces/rss/common/config.js'
 import {
   stopNodes as slashStopNodes,
   uris as slashUris,
@@ -154,7 +155,7 @@ export const namespaceUris = {
   googleplay: googleplayUris,
   spotify: spotifyUris,
   rdf: rdfUris,
-  rss: ['http://purl.org/rss/1.0/', 'https://purl.org/rss/1.0/'],
+  rss: rssUris,
   rawvoice: rawvoiceUris,
   cc: ccUris,
   opensearch: opensearchUris,

--- a/src/common/config.ts
+++ b/src/common/config.ts
@@ -154,6 +154,7 @@ export const namespaceUris = {
   googleplay: googleplayUris,
   spotify: spotifyUris,
   rdf: rdfUris,
+  rss: ['http://purl.org/rss/1.0/', 'https://purl.org/rss/1.0/'],
   rawvoice: rawvoiceUris,
   cc: ccUris,
   opensearch: opensearchUris,

--- a/src/common/utils.test.ts
+++ b/src/common/utils.test.ts
@@ -3225,11 +3225,9 @@ describe('createNamespaceNormalizator', () => {
 
     describe('default namespace handling', () => {
       it('should handle default Atom namespace with primary namespace', () => {
-        const normalizeNamespaces = createNamespaceNormalizator(
-          namespaceUris,
-          namespacePrefixes,
+        const normalizeNamespaces = createNamespaceNormalizator(namespaceUris, namespacePrefixes, [
           'atom',
-        )
+        ])
         const value = parser.parse(`
           <?xml version="1.0"?>
           <feed xmlns="http://www.w3.org/2005/Atom">
@@ -3303,11 +3301,9 @@ describe('createNamespaceNormalizator', () => {
       })
 
       it('should handle custom Atom prefix with primary namespace', () => {
-        const normalizeNamespaces = createNamespaceNormalizator(
-          namespaceUris,
-          namespacePrefixes,
+        const normalizeNamespaces = createNamespaceNormalizator(namespaceUris, namespacePrefixes, [
           'atom',
-        )
+        ])
         const value = parser.parse(`
           <?xml version="1.0"?>
           <a:feed xmlns:a="http://www.w3.org/2005/Atom">
@@ -3593,11 +3589,9 @@ describe('createNamespaceNormalizator', () => {
       })
 
       it('should handle complex nesting with namespace inheritance', () => {
-        const normalizeNamespaces = createNamespaceNormalizator(
-          namespaceUris,
-          namespacePrefixes,
+        const normalizeNamespaces = createNamespaceNormalizator(namespaceUris, namespacePrefixes, [
           'atom',
-        )
+        ])
         const value = parser.parse(`
           <?xml version="1.0"?>
           <feed xmlns="http://www.w3.org/2005/Atom">
@@ -3797,11 +3791,10 @@ describe('createNamespaceNormalizator', () => {
 
     describe('RDF primary namespace handling', () => {
       it('should normalize RDF namespace elements and attributes including arrays', () => {
-        const normalizeNamespaces = createNamespaceNormalizator(
-          namespaceUris,
-          namespacePrefixes,
+        const normalizeNamespaces = createNamespaceNormalizator(namespaceUris, namespacePrefixes, [
           'rdf',
-        )
+          'rss',
+        ])
         const value = parser.parse(`
           <?xml version="1.0" encoding="UTF-8"?>
           <rdf:RDF
@@ -3845,6 +3838,42 @@ describe('createNamespaceNormalizator', () => {
               { title: 'Item 1', '@about': 'http://example.com/item1' },
               { title: 'Item 2', '@about': 'http://example.com/item2' },
             ],
+          },
+        }
+
+        expect(normalizeNamespaces(value)).toEqual(expected)
+      })
+
+      it('should strip prefixes for multiple primary namespaces', () => {
+        const normalizeNamespaces = createNamespaceNormalizator(namespaceUris, namespacePrefixes, [
+          'rdf',
+          'rss',
+        ])
+        const value = parser.parse(`
+          <?xml version="1.0" encoding="UTF-8"?>
+          <rdf:RDF
+            xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+            xmlns:rss="http://purl.org/rss/1.0/"
+          >
+            <rss:channel>
+              <rss:title>Test Feed</rss:title>
+            </rss:channel>
+            <rss:item rdf:about="http://example.com/item1">
+              <rss:title>Item 1</rss:title>
+            </rss:item>
+          </rdf:RDF>
+        `)
+        const expected = {
+          rdf: {
+            '@xmlns:rdf': 'http://www.w3.org/1999/02/22-rdf-syntax-ns#',
+            '@xmlns:rss': 'http://purl.org/rss/1.0/',
+            channel: {
+              title: 'Test Feed',
+            },
+            item: {
+              title: 'Item 1',
+              '@about': 'http://example.com/item1',
+            },
           },
         }
 

--- a/src/common/utils.ts
+++ b/src/common/utils.ts
@@ -616,7 +616,7 @@ export const generateNamespaceAttrs = (
 export const createNamespaceNormalizator = <T extends Record<string, Array<string>>>(
   namespaceUris: T,
   namespacePrefixes: Record<string, string>,
-  primaryNamespace?: keyof T,
+  primaryNamespaces?: Array<keyof T>,
 ) => {
   const normalizedUriCache = new Map<string, string>()
 
@@ -635,10 +635,9 @@ export const createNamespaceNormalizator = <T extends Record<string, Array<strin
     return normalized
   }
 
-  const primaryNamespaceUris =
-    primaryNamespace && namespaceUris[primaryNamespace]
-      ? namespaceUris[primaryNamespace].map(normalizeNamespaceUri)
-      : undefined
+  const primaryNamespaceUris = primaryNamespaces?.length
+    ? primaryNamespaces.flatMap((key) => namespaceUris[key].map(normalizeNamespaceUri))
+    : undefined
 
   const resolveNamespacePrefix = (uri: string, localName: string, fallback: string): string => {
     const normalizedUri = normalizeNamespaceUri(uri)

--- a/src/feeds/atom/parse/index.ts
+++ b/src/feeds/atom/parse/index.ts
@@ -11,7 +11,9 @@ export const parse = (value: unknown, options?: ParseOptions): DeepPartial<Atom.
     throw new Error(locales.invalidFeedFormat)
   }
 
-  const normalizeNamespaces = createNamespaceNormalizator(namespaceUris, namespacePrefixes, 'atom')
+  const normalizeNamespaces = createNamespaceNormalizator(namespaceUris, namespacePrefixes, [
+    'atom',
+  ])
 
   const object = parser.parse(value)
   const normalized = normalizeNamespaces(object)

--- a/src/feeds/rdf/parse/index.ts
+++ b/src/feeds/rdf/parse/index.ts
@@ -11,7 +11,10 @@ export const parse = (value: unknown, options?: ParseOptions): DeepPartial<Rdf.F
     throw new Error(locales.invalidFeedFormat)
   }
 
-  const normalizeNamespaces = createNamespaceNormalizator(namespaceUris, namespacePrefixes, 'rdf')
+  const normalizeNamespaces = createNamespaceNormalizator(namespaceUris, namespacePrefixes, [
+    'rdf',
+    'rss',
+  ])
 
   const object = parser.parse(value)
   const normalized = normalizeNamespaces(object)

--- a/src/namespaces/rss/common/config.ts
+++ b/src/namespaces/rss/common/config.ts
@@ -1,0 +1,6 @@
+export const uris = [
+  'http://purl.org/rss/1.0/', // Official URI.
+  'https://purl.org/rss/1.0/',
+  'http://purl.org/rss/1.0',
+  'https://purl.org/rss/1.0',
+]


### PR DESCRIPTION
This PR handles prefixed RSS 1.0 elements in the RDF parser, so `<rss:channel>` and `<rss:item>` are recognized.

Closes #262

- Register RSS 1.0 namespace URI (`http://purl.org/rss/1.0/`) in `namespaceUris` config
- Extend `createNamespaceNormalizator` to accept multiple primary namespaces (`Array<keyof T>`)
- Pass both `rdf` and `rss` as primary namespaces in RDF parser so `<rss:channel>`, `<rss:item>`, etc. are correctly stripped
