### PR TITLE
perf: Create namespace normalizator once per feed format

### DIFF
--- a/src/feeds/atom/parse/config.ts
+++ b/src/feeds/atom/parse/config.ts
@@ -1,5 +1,11 @@
 import { XMLParser } from 'fast-xml-parser'
-import { namespaceStopNodes, parserConfig } from '../../../common/config.js'
+import {
+  namespacePrefixes,
+  namespaceStopNodes,
+  namespaceUris,
+  parserConfig,
+} from '../../../common/config.js'
+import { createNamespaceNormalizator } from '../../../common/utils.js'
 
 export const stopNodes = [
   ...namespaceStopNodes,
@@ -68,3 +74,7 @@ export const parser = new XMLParser({
   ...parserConfig,
   stopNodes,
 })
+
+export const normalizeNamespaces = createNamespaceNormalizator(namespaceUris, namespacePrefixes, [
+  'atom',
+])

--- a/src/feeds/atom/parse/index.ts
+++ b/src/feeds/atom/parse/index.ts
@@ -1,19 +1,14 @@
-import { locales, namespacePrefixes, namespaceUris } from '../../../common/config.js'
+import { locales } from '../../../common/config.js'
 import type { DeepPartial, ParseOptions } from '../../../common/types.js'
-import { createNamespaceNormalizator } from '../../../common/utils.js'
 import { detectAtomFeed } from '../../../index.js'
 import type { Atom } from '../common/types.js'
-import { parser } from './config.js'
+import { normalizeNamespaces, parser } from './config.js'
 import { retrieveFeed } from './utils.js'
 
 export const parse = (value: unknown, options?: ParseOptions): DeepPartial<Atom.Feed<string>> => {
   if (!detectAtomFeed(value)) {
     throw new Error(locales.invalidFeedFormat)
   }
-
-  const normalizeNamespaces = createNamespaceNormalizator(namespaceUris, namespacePrefixes, [
-    'atom',
-  ])
 
   const object = parser.parse(value)
   const normalized = normalizeNamespaces(object)

--- a/src/feeds/rdf/parse/config.ts
+++ b/src/feeds/rdf/parse/config.ts
@@ -1,5 +1,11 @@
 import { XMLParser } from 'fast-xml-parser'
-import { namespaceStopNodes, parserConfig } from '../../../common/config.js'
+import {
+  namespacePrefixes,
+  namespaceStopNodes,
+  namespaceUris,
+  parserConfig,
+} from '../../../common/config.js'
+import { createNamespaceNormalizator } from '../../../common/utils.js'
 
 export const stopNodes = [
   ...namespaceStopNodes,
@@ -22,3 +28,8 @@ export const parser = new XMLParser({
   ...parserConfig,
   stopNodes,
 })
+
+export const normalizeNamespaces = createNamespaceNormalizator(namespaceUris, namespacePrefixes, [
+  'rdf',
+  'rss',
+])

--- a/src/feeds/rdf/parse/index.ts
+++ b/src/feeds/rdf/parse/index.ts
@@ -1,20 +1,14 @@
-import { locales, namespacePrefixes, namespaceUris } from '../../../common/config.js'
+import { locales } from '../../../common/config.js'
 import type { DeepPartial, ParseOptions } from '../../../common/types.js'
-import { createNamespaceNormalizator } from '../../../common/utils.js'
 import { detectRdfFeed } from '../../../index.js'
 import type { Rdf } from '../common/types.js'
-import { parser } from './config.js'
+import { normalizeNamespaces, parser } from './config.js'
 import { retrieveFeed } from './utils.js'
 
 export const parse = (value: unknown, options?: ParseOptions): DeepPartial<Rdf.Feed<string>> => {
   if (!detectRdfFeed(value)) {
     throw new Error(locales.invalidFeedFormat)
   }
-
-  const normalizeNamespaces = createNamespaceNormalizator(namespaceUris, namespacePrefixes, [
-    'rdf',
-    'rss',
-  ])
 
   const object = parser.parse(value)
   const normalized = normalizeNamespaces(object)

--- a/src/feeds/rss/parse/config.ts
+++ b/src/feeds/rss/parse/config.ts
@@ -1,5 +1,11 @@
 import { XMLParser } from 'fast-xml-parser'
-import { namespaceStopNodes, parserConfig } from '../../../common/config.js'
+import {
+  namespacePrefixes,
+  namespaceStopNodes,
+  namespaceUris,
+  parserConfig,
+} from '../../../common/config.js'
+import { createNamespaceNormalizator } from '../../../common/utils.js'
 
 // These elements can appear both inside <channel> and as direct children of
 // <rss> in malformed feeds, so stop nodes are generated for both paths.
@@ -55,3 +61,5 @@ export const parser = new XMLParser({
   ...parserConfig,
   stopNodes,
 })
+
+export const normalizeNamespaces = createNamespaceNormalizator(namespaceUris, namespacePrefixes)

--- a/src/feeds/rss/parse/index.ts
+++ b/src/feeds/rss/parse/index.ts
@@ -1,17 +1,14 @@
-import { locales, namespacePrefixes, namespaceUris } from '../../../common/config.js'
+import { locales } from '../../../common/config.js'
 import type { DeepPartial, ParseOptions } from '../../../common/types.js'
-import { createNamespaceNormalizator } from '../../../common/utils.js'
 import { detectRssFeed } from '../../../index.js'
 import type { Rss } from '../common/types.js'
-import { parser } from './config.js'
+import { normalizeNamespaces, parser } from './config.js'
 import { retrieveFeed } from './utils.js'
 
 export const parse = (value: unknown, options?: ParseOptions): DeepPartial<Rss.Feed<string>> => {
   if (!detectRssFeed(value)) {
     throw new Error(locales.invalidFeedFormat)
   }
-
-  const normalizeNamespaces = createNamespaceNormalizator(namespaceUris, namespacePrefixes)
 
   const object = parser.parse(value)
   const normalized = normalizeNamespaces(object)


### PR DESCRIPTION
This PR creates the namespace normalizator once per format instead of once per parse call.

- Move `normalizeNamespaces` creation from inside `parse()` to the `config.ts` module of each feed format (RSS, Atom, RDF)
- The normalizator only depends on static config, so it's created once at module load instead of on every parse call
