### PR TITLE
feat: Replace generic Error with specialized error types

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -60,6 +60,7 @@ export default defineConfig({
           { text: 'Namespaces', link: '/parsing/namespaces' },
           { text: 'Dates', link: '/parsing/dates' },
           { text: 'Detecting', link: '/parsing/detecting' },
+          { text: 'Errors', link: '/parsing/errors' },
           { text: 'Examples', link: '/parsing/examples' },
         ],
       },

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -70,6 +70,7 @@ export default defineConfig({
           { text: 'Overview', link: '/generating' },
           { text: 'Styling', link: '/generating/styling' },
           { text: 'Strict Mode', link: '/generating/strict-mode' },
+          { text: 'Errors', link: '/generating/errors' },
           { text: 'Examples', link: '/generating/examples' },
         ],
       },

--- a/docs/generating/errors.md
+++ b/docs/generating/errors.md
@@ -1,0 +1,19 @@
+# Error Handling
+
+Feedsmith provides a dedicated error type for generation failures.
+
+## GenerateError
+
+Thrown when feed generation fails due to invalid input.
+
+```typescript
+import { generateRssFeed, GenerateError } from 'feedsmith'
+
+try {
+  generateRssFeed({})
+} catch (error) {
+  if (error instanceof GenerateError) {
+    console.log(error.message) // "Invalid input RSS"
+  }
+}
+```

--- a/docs/migration/v2-to-v3.md
+++ b/docs/migration/v2-to-v3.md
@@ -387,6 +387,15 @@ const created = feed.dcterms?.created?.[0]
 
 ## New Features
 
+### Improved Error Handling
+
+Parsing functions now throw dedicated error types for better error handling:
+
+- `DetectError` — thrown when input doesn't match the expected feed format
+- `ParseError` — thrown when XML parsing fails
+
+See [Error Handling](/parsing/errors) for more details.
+
 ### Namespace Type Exports
 
 All namespace types are now exported directly from the main package:
@@ -437,7 +446,7 @@ feed.pubDate // Date
 
 ### XML Namespace Support
 
-Version 3.x adds support for the [XML namespace](/reference/namespaces/xml) (`xml:*` attributes) in RSS, Atom, and RDF feeds. The `xml` property is available on both feed and item levels, providing access to `xml:lang`, `xml:base`, `xml:space`, and `xml:id` attributes.
+RSS, Atom, and RDF feeds now support the [XML namespace](/reference/namespaces/xml) (`xml:*` attributes). The `xml` property is available on both feed and item levels, providing access to `xml:lang`, `xml:base`, `xml:space`, and `xml:id` attributes.
 
 ## Migration Checklist
 
@@ -455,3 +464,4 @@ Use this checklist to ensure a complete migration:
 - Replace Dublin Core singular fields with plural arrays (e.g., `title` → `titles`)
 - Replace Dublin Core Terms singular fields with plural arrays (e.g., `title` → `titles`)
 - Test feed generation to ensure output is correct
+- Update error handling to use `DetectError` and `ParseError` instead of generic `Error`

--- a/docs/migration/v2-to-v3.md
+++ b/docs/migration/v2-to-v3.md
@@ -389,12 +389,14 @@ const created = feed.dcterms?.created?.[0]
 
 ### Improved Error Handling
 
-Parsing functions now throw dedicated error types for better error handling:
+Feedsmith now throws dedicated error types for different failure scenarios:
 
 - `DetectError` — thrown when input doesn't match the expected feed format
-- `ParseError` — thrown when XML parsing fails
+- `MalformedError` — thrown when content is malformed (e.g., invalid XML)
+- `ParseError` — thrown when content parsed but produced an invalid result
+- `GenerateError` — thrown when feed generation fails due to invalid input
 
-See [Error Handling](/parsing/errors) for more details.
+See [Parsing Errors](/parsing/errors) and [Generating Errors](/generating/errors) for more details.
 
 ### Namespace Type Exports
 
@@ -464,4 +466,4 @@ Use this checklist to ensure a complete migration:
 - Replace Dublin Core singular fields with plural arrays (e.g., `title` → `titles`)
 - Replace Dublin Core Terms singular fields with plural arrays (e.g., `title` → `titles`)
 - Test feed generation to ensure output is correct
-- Update error handling to use `DetectError` and `ParseError` instead of generic `Error`
+- Update error handling to use `DetectError`, `MalformedError`, `ParseError`, and `GenerateError` instead of generic `Error`

--- a/docs/parsing.md
+++ b/docs/parsing.md
@@ -41,7 +41,7 @@ The universal parser:
 - Automatically detects the feed format using format detection functions
 - Returns an object with `format` and `feed` properties
 - Supports RSS, Atom, RDF, and JSON Feed formats
-- Throws an error for unrecognized or invalid feeds
+- Throws `DetectError` or `ParseError` for invalid feeds
 
 > [!IMPORTANT]
 > The universal parser uses detection functions to identify the feed format. While these work well for most feeds, they might not perfectly detect all valid feeds, especially those with non-standard structures. If you know the feed format in advance, using a dedicated parser is more reliable.
@@ -89,26 +89,8 @@ opml.body?.outlines
 
 ## Error Handling
 
-If the feed is unrecognized or invalid, an `Error` will be thrown with a descriptive message.
-
-```typescript
-import { parseFeed, parseJsonFeed } from 'feedsmith'
-
-try {
-  const universalFeed = parseFeed('<not-a-feed></not-a-feed>')
-} catch (error) {
-  // Error: Unrecognized feed format
-}
-
-try {
-  const jsonFeed = parseJsonFeed('{}')
-} catch (error) {
-  // Error: Invalid feed format
-}
-```
+Parsing functions throw `DetectError` when the input doesn't match the expected format, or `ParseError` when XML parsing fails. See [Error Handling](/parsing/errors) for details on error types.
 
 ## Returned Values
 
-The parsing functions return JavaScript objects representing the feed in its original structure.
-
-For detailed examples of input and output for each feed format, see the [Parsing Examples](/parsing/examples) page.
+The parsing functions return JavaScript objects representing the feed in its original structure. See [Parsing Examples](/parsing/examples) page for detailed examples of input and output for each feed format.

--- a/docs/parsing.md
+++ b/docs/parsing.md
@@ -41,7 +41,7 @@ The universal parser:
 - Automatically detects the feed format using format detection functions
 - Returns an object with `format` and `feed` properties
 - Supports RSS, Atom, RDF, and JSON Feed formats
-- Throws `DetectError` or `ParseError` for invalid feeds
+- Throws `DetectError`, `MalformedError`, or `ParseError` for invalid feeds
 
 > [!IMPORTANT]
 > The universal parser uses detection functions to identify the feed format. While these work well for most feeds, they might not perfectly detect all valid feeds, especially those with non-standard structures. If you know the feed format in advance, using a dedicated parser is more reliable.
@@ -89,7 +89,7 @@ opml.body?.outlines
 
 ## Error Handling
 
-Parsing functions throw `DetectError` when the input doesn't match the expected format, or `ParseError` when XML parsing fails. See [Error Handling](/parsing/errors) for details on error types.
+Parsing functions throw `DetectError` when the input doesn't match the expected format, `MalformedError` when the content is malformed, or `ParseError` when the parsed result is invalid. See [Error Handling](/parsing/errors) for details.
 
 ## Returned Values
 

--- a/docs/parsing/errors.md
+++ b/docs/parsing/errors.md
@@ -1,12 +1,12 @@
 # Error Handling
 
-Feedsmith provides two error types for different failure scenarios during parsing.
+Feedsmith provides dedicated error types for different failure scenarios during parsing.
 
 ## Error Types
 
 ### DetectError
 
-Thrown when the input doesn't match the expected feed format. This happens before any XML parsing is attempted.
+Thrown when the input doesn't match the expected feed format. This happens before any parsing is attempted.
 
 ```typescript
 import { parseRssFeed, DetectError } from 'feedsmith'
@@ -20,15 +20,31 @@ try {
 }
 ```
 
+### MalformedError
+
+Thrown when the content is malformed and the underlying parser fails (e.g., invalid XML).
+
+```typescript
+import { parseRssFeed, MalformedError } from 'feedsmith'
+
+try {
+  parseRssFeed('<rss version="2.0"><channel><title>Test</title</channel></rss>')
+} catch (error) {
+  if (error instanceof MalformedError) {
+    console.log(error.message) // "Invalid feed format"
+  }
+}
+```
+
 ### ParseError
 
-Thrown when XML parsing fails due to malformed content.
+Thrown when the content is syntactically valid but produces an empty or invalid result.
 
 ```typescript
 import { parseRssFeed, ParseError } from 'feedsmith'
 
 try {
-  parseRssFeed('<rss><channel><title>Test</title></channel></rss>')
+  parseRssFeed('<rss version="2.0"></rss>')
 } catch (error) {
   if (error instanceof ParseError) {
     console.log(error.message) // "Invalid feed format"
@@ -41,15 +57,17 @@ try {
 The universal `parseFeed` function throws the same error types:
 
 ```typescript
-import { parseFeed, DetectError, ParseError } from 'feedsmith'
+import { parseFeed, DetectError, MalformedError, ParseError } from 'feedsmith'
 
 try {
   parseFeed('<not-a-feed></not-a-feed>')
 } catch (error) {
   if (error instanceof DetectError) {
     // Unrecognized feed format
-  } else if (error instanceof ParseError) {
+  } else if (error instanceof MalformedError) {
     // Malformed XML
+  } else if (error instanceof ParseError) {
+    // Valid XML but invalid feed structure
   }
 }
 ```

--- a/docs/parsing/errors.md
+++ b/docs/parsing/errors.md
@@ -1,0 +1,55 @@
+# Error Handling
+
+Feedsmith provides two error types for different failure scenarios during parsing.
+
+## Error Types
+
+### DetectError
+
+Thrown when the input doesn't match the expected feed format. This happens before any XML parsing is attempted.
+
+```typescript
+import { parseRssFeed, DetectError } from 'feedsmith'
+
+try {
+  parseRssFeed('<feed>not rss</feed>')
+} catch (error) {
+  if (error instanceof DetectError) {
+    console.log(error.message) // "Invalid feed format"
+  }
+}
+```
+
+### ParseError
+
+Thrown when XML parsing fails due to malformed content.
+
+```typescript
+import { parseRssFeed, ParseError } from 'feedsmith'
+
+try {
+  parseRssFeed('<rss><channel><title>Test</title></channel></rss>')
+} catch (error) {
+  if (error instanceof ParseError) {
+    console.log(error.message) // "Invalid feed format"
+  }
+}
+```
+
+## Universal Parser
+
+The universal `parseFeed` function throws the same error types:
+
+```typescript
+import { parseFeed, DetectError, ParseError } from 'feedsmith'
+
+try {
+  parseFeed('<not-a-feed></not-a-feed>')
+} catch (error) {
+  if (error instanceof DetectError) {
+    // Unrecognized feed format
+  } else if (error instanceof ParseError) {
+    // Malformed XML
+  }
+}
+```

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -127,26 +127,30 @@ console.log(rss) // Complete RSS XML
 
 ## Error Handling
 
-Parsing functions throw errors when the input is invalid:
+Feedsmith throws dedicated error types for different failure scenarios:
 
 - `DetectError` — input doesn't match the expected feed format
-- `ParseError` — XML parsing failed
+- `MalformedError` — content is malformed (e.g., invalid XML)
+- `ParseError` — content parsed but produced an invalid result
+- `GenerateError` — feed generation failed due to invalid input
 
 ```typescript
-import { parseRssFeed, DetectError, ParseError } from 'feedsmith'
+import { parseRssFeed, DetectError, MalformedError, ParseError } from 'feedsmith'
 
 try {
   parseRssFeed(input)
 } catch (error) {
   if (error instanceof DetectError) {
     // Not RSS format
-  } else if (error instanceof ParseError) {
+  } else if (error instanceof MalformedError) {
     // Malformed XML
+  } else if (error instanceof ParseError) {
+    // Valid XML but invalid feed structure
   }
 }
 ```
 
-See [Error Handling](/parsing/errors) for more details.
+See [Parsing Errors](/parsing/errors) and [Generating Errors](/generating/errors) for more details.
 
 ## TypeScript Types
 

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -127,23 +127,26 @@ console.log(rss) // Complete RSS XML
 
 ## Error Handling
 
-If the feed is unrecognized or invalid, an `Error` will be thrown with a descriptive message.
+Parsing functions throw errors when the input is invalid:
+
+- `DetectError` — input doesn't match the expected feed format
+- `ParseError` — XML parsing failed
 
 ```typescript
-import { parseFeed, parseJsonFeed } from 'feedsmith'
+import { parseRssFeed, DetectError, ParseError } from 'feedsmith'
 
 try {
-  const universalFeed = parseFeed('<not-a-feed></not-a-feed>')
+  parseRssFeed(input)
 } catch (error) {
-  // Error: Unrecognized feed format
-}
-
-try {
-  const jsonFeed = parseJsonFeed('{}')
-} catch (error) {
-  // Error: Invalid feed format
+  if (error instanceof DetectError) {
+    // Not RSS format
+  } else if (error instanceof ParseError) {
+    // Malformed XML
+  }
 }
 ```
+
+See [Error Handling](/parsing/errors) for more details.
 
 ## TypeScript Types
 

--- a/src/common/errors.test.ts
+++ b/src/common/errors.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'bun:test'
+import { DetectError, ParseError } from './errors.js'
+
+describe('DetectError', () => {
+  it('should set message', () => {
+    const error = new DetectError('Test error')
+
+    expect(error.message).toBe('Test error')
+  })
+
+  it('should be instance of Error', () => {
+    const error = new DetectError('Test error')
+
+    expect(error).toBeInstanceOf(Error)
+  })
+
+  it('should have name set to DetectError', () => {
+    const error = new DetectError('Test error')
+
+    expect(error.name).toBe('DetectError')
+  })
+})
+
+describe('ParseError', () => {
+  it('should set message', () => {
+    const error = new ParseError('Test error')
+
+    expect(error.message).toBe('Test error')
+  })
+
+  it('should be instance of Error', () => {
+    const error = new ParseError('Test error')
+
+    expect(error).toBeInstanceOf(Error)
+  })
+
+  it('should have name set to ParseError', () => {
+    const error = new ParseError('Test error')
+
+    expect(error.name).toBe('ParseError')
+  })
+})

--- a/src/common/errors.test.ts
+++ b/src/common/errors.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'bun:test'
-import { DetectError, ParseError } from './errors.js'
+import { DetectError, GenerateError, MalformedError, ParseError } from './errors.js'
 
 describe('DetectError', () => {
   it('should set message', () => {
@@ -18,6 +18,46 @@ describe('DetectError', () => {
     const error = new DetectError('Test error')
 
     expect(error.name).toBe('DetectError')
+  })
+})
+
+describe('GenerateError', () => {
+  it('should set message', () => {
+    const error = new GenerateError('Test error')
+
+    expect(error.message).toBe('Test error')
+  })
+
+  it('should be instance of Error', () => {
+    const error = new GenerateError('Test error')
+
+    expect(error).toBeInstanceOf(Error)
+  })
+
+  it('should have name set to GenerateError', () => {
+    const error = new GenerateError('Test error')
+
+    expect(error.name).toBe('GenerateError')
+  })
+})
+
+describe('MalformedError', () => {
+  it('should set message', () => {
+    const error = new MalformedError('Test error')
+
+    expect(error.message).toBe('Test error')
+  })
+
+  it('should be instance of Error', () => {
+    const error = new MalformedError('Test error')
+
+    expect(error).toBeInstanceOf(Error)
+  })
+
+  it('should have name set to MalformedError', () => {
+    const error = new MalformedError('Test error')
+
+    expect(error.name).toBe('MalformedError')
   })
 })
 

--- a/src/common/errors.ts
+++ b/src/common/errors.ts
@@ -1,0 +1,13 @@
+export class DetectError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'DetectError'
+  }
+}
+
+export class ParseError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'ParseError'
+  }
+}

--- a/src/common/errors.ts
+++ b/src/common/errors.ts
@@ -5,6 +5,20 @@ export class DetectError extends Error {
   }
 }
 
+export class GenerateError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'GenerateError'
+  }
+}
+
+export class MalformedError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'MalformedError'
+  }
+}
+
 export class ParseError extends Error {
   constructor(message: string) {
     super(message)

--- a/src/common/parse.test.ts
+++ b/src/common/parse.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'bun:test'
 import { locales } from './config.js'
+import { DetectError } from './errors.js'
 import { parse } from './parse.js'
 
 describe('parse', () => {
@@ -247,6 +248,15 @@ describe('parse', () => {
 
   it('should handle number input', () => {
     expect(() => parse(123)).toThrowError(locales.unrecognizedFeedFormat)
+  })
+
+  describe('error types', () => {
+    it('should throw DetectError for unrecognized format', () => {
+      const throwing = () => parse('not a feed')
+
+      expect(throwing).toThrow(DetectError)
+      expect(throwing).toThrow(locales.unrecognizedFeedFormat)
+    })
   })
 
   describe('leading/trailing garbage', () => {

--- a/src/common/parse.ts
+++ b/src/common/parse.ts
@@ -11,6 +11,7 @@ import type { Rss } from '../feeds/rss/common/types.js'
 import { detect as detectRssFeed } from '../feeds/rss/detect/index.js'
 import { parse as parseRssFeed } from '../feeds/rss/parse/index.js'
 import { locales } from './config.js'
+import { DetectError } from './errors.js'
 import type { ParseMainOptions } from './types.js'
 import { parseJsonObject } from './utils.js'
 
@@ -40,5 +41,5 @@ export const parse = <TDate = string>(
     return { format: 'json', feed: parseJsonFeed(json, options) }
   }
 
-  throw new Error(locales.unrecognizedFeedFormat)
+  throw new DetectError(locales.unrecognizedFeedFormat)
 }

--- a/src/feeds/atom/generate/index.test.ts
+++ b/src/feeds/atom/generate/index.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'bun:test'
 import { locales } from '../../../common/config.js'
+import { GenerateError } from '../../../common/errors.js'
 import { generate } from './index.js'
 
 describe('generate', () => {
@@ -249,10 +250,14 @@ describe('generate', () => {
     expect(generate(value)).toEqual(expected)
   })
 
-  it('should throw error for invalid Atom feed structure', () => {
-    const value = {}
+  describe('error types', () => {
+    it('should throw GenerateError for invalid Atom feed structure', () => {
+      const value = {}
+      const throwing = () => generate(value)
 
-    expect(() => generate(value)).toThrow(locales.invalidInputAtom)
+      expect(throwing).toThrow(GenerateError)
+      expect(throwing).toThrow(locales.invalidInputAtom)
+    })
   })
 
   it('should properly encode special characters in text content', () => {

--- a/src/feeds/atom/generate/index.ts
+++ b/src/feeds/atom/generate/index.ts
@@ -1,4 +1,5 @@
 import { locales } from '../../../common/config.js'
+import { GenerateError } from '../../../common/errors.js'
 import type { DateLike, GenerateMainXml } from '../../../common/types.js'
 import { generateXml } from '../../../common/utils.js'
 import type { Atom } from '../common/types.js'
@@ -12,7 +13,7 @@ export const generate: GenerateMainXml<Atom.Feed<DateLike>, Atom.Feed<Date, true
   const generated = generateFeed(value)
 
   if (!generated) {
-    throw new Error(locales.invalidInputAtom)
+    throw new GenerateError(locales.invalidInputAtom)
   }
 
   return generateXml(builder, generated, options)

--- a/src/feeds/atom/parse/index.test.ts
+++ b/src/feeds/atom/parse/index.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'bun:test'
 import { locales, namespaceUris } from '../../../common/config.js'
-import { DetectError, ParseError } from '../../../common/errors.js'
+import { DetectError, MalformedError, ParseError } from '../../../common/errors.js'
 import { parse } from './index.js'
 
 describe('parse', () => {
@@ -258,12 +258,21 @@ describe('parse', () => {
       expect(throwing).toThrow(locales.invalidFeedFormat)
     })
 
-    it('should throw ParseError for malformed XML', () => {
+    it('should throw MalformedError for malformed XML', () => {
       const value = `
         <?xml version="1.0"?>
         <feed xmlns="http://www.w3.org/2005/Atom">
           <title>Test</title
-        </feed>`
+        </feed>
+      `
+      const throwing = () => parse(value)
+
+      expect(throwing).toThrow(MalformedError)
+      expect(throwing).toThrow(locales.invalidFeedFormat)
+    })
+
+    it('should throw ParseError for valid XML with invalid structure', () => {
+      const value = '<feed xmlns="http://www.w3.org/2005/Atom"></feed>'
       const throwing = () => parse(value)
 
       expect(throwing).toThrow(ParseError)

--- a/src/feeds/atom/parse/index.test.ts
+++ b/src/feeds/atom/parse/index.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'bun:test'
 import { locales, namespaceUris } from '../../../common/config.js'
+import { DetectError, ParseError } from '../../../common/errors.js'
 import { parse } from './index.js'
 
 describe('parse', () => {
@@ -247,6 +248,27 @@ describe('parse', () => {
 
   it('should handle number input', () => {
     expect(() => parse(123)).toThrowError(locales.invalidFeedFormat)
+  })
+
+  describe('error types', () => {
+    it('should throw DetectError for non-feed input', () => {
+      const throwing = () => parse('not a feed')
+
+      expect(throwing).toThrow(DetectError)
+      expect(throwing).toThrow(locales.invalidFeedFormat)
+    })
+
+    it('should throw ParseError for malformed XML', () => {
+      const value = `
+        <?xml version="1.0"?>
+        <feed xmlns="http://www.w3.org/2005/Atom">
+          <title>Test</title
+        </feed>`
+      const throwing = () => parse(value)
+
+      expect(throwing).toThrow(ParseError)
+      expect(throwing).toThrow(locales.invalidFeedFormat)
+    })
   })
 
   it('should correctly parse Atom feed with YouTube namespace', () => {

--- a/src/feeds/atom/parse/index.ts
+++ b/src/feeds/atom/parse/index.ts
@@ -1,6 +1,6 @@
-import { locales, namespacePrefixes, namespaceUris } from '../../../common/config.js'
-import type { ParseMainOptions } from '../../../common/types.js'
-import { createNamespaceNormalizator } from '../../../common/utils.js'
+import { locales } from '../../../common/config.js'
+import { DetectError, ParseError } from '../../../common/errors.js'
+import type { ParseMainOptions, Unreliable } from '../../../common/types.js'
 import { detectAtomFeed } from '../../../index.js'
 import type { Atom } from '../common/types.js'
 import { normalizeNamespaces, parser } from './config.js'
@@ -11,15 +11,22 @@ export const parse = <TDate = string>(
   options?: ParseMainOptions<TDate>,
 ): Atom.Feed<TDate> => {
   if (!detectAtomFeed(value)) {
-    throw new Error(locales.invalidFeedFormat)
+    throw new DetectError(locales.invalidFeedFormat)
   }
 
-  const object = parser.parse(value)
-  const normalized = normalizeNamespaces(object)
+  let normalized: Unreliable
+
+  try {
+    const object = parser.parse(value)
+    normalized = normalizeNamespaces(object)
+  } catch {
+    throw new ParseError(locales.invalidFeedFormat)
+  }
+
   const parsed = retrieveFeed(normalized, options)
 
   if (!parsed) {
-    throw new Error(locales.invalidFeedFormat)
+    throw new ParseError(locales.invalidFeedFormat)
   }
 
   return parsed as Atom.Feed<TDate>

--- a/src/feeds/atom/parse/index.ts
+++ b/src/feeds/atom/parse/index.ts
@@ -1,5 +1,5 @@
 import { locales } from '../../../common/config.js'
-import { DetectError, ParseError } from '../../../common/errors.js'
+import { DetectError, MalformedError, ParseError } from '../../../common/errors.js'
 import type { ParseMainOptions, Unreliable } from '../../../common/types.js'
 import { detectAtomFeed } from '../../../index.js'
 import type { Atom } from '../common/types.js'
@@ -20,7 +20,7 @@ export const parse = <TDate = string>(
     const object = parser.parse(value)
     normalized = normalizeNamespaces(object)
   } catch {
-    throw new ParseError(locales.invalidFeedFormat)
+    throw new MalformedError(locales.invalidFeedFormat)
   }
 
   const parsed = retrieveFeed(normalized, options)

--- a/src/feeds/json/parse/index.test.ts
+++ b/src/feeds/json/parse/index.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'bun:test'
 import { locales } from '../../../common/config.js'
+import { DetectError, ParseError } from '../../../common/errors.js'
 import { parse } from './index.js'
 
 describe('parse', () => {
@@ -259,6 +260,25 @@ describe('parse', () => {
 
   it('should handle number input', () => {
     expect(() => parse(123)).toThrowError(locales.invalidFeedFormat)
+  })
+
+  describe('error types', () => {
+    it('should throw DetectError for non-feed input', () => {
+      const throwing = () => parse({})
+
+      expect(throwing).toThrow(DetectError)
+      expect(throwing).toThrow(locales.invalidFeedFormat)
+    })
+
+    it('should throw ParseError for detected but invalid feed', () => {
+      const value = {
+        version: 'https://jsonfeed.org/version/1',
+      }
+      const throwing = () => parse(value)
+
+      expect(throwing).toThrow(ParseError)
+      expect(throwing).toThrow(locales.invalidFeedFormat)
+    })
   })
 
   describe('with maxItems option', () => {

--- a/src/feeds/json/parse/index.ts
+++ b/src/feeds/json/parse/index.ts
@@ -1,4 +1,5 @@
 import { locales } from '../../../common/config.js'
+import { DetectError, ParseError } from '../../../common/errors.js'
 import type { ParseMainOptions } from '../../../common/types.js'
 import { parseJsonObject } from '../../../common/utils.js'
 import { detectJsonFeed } from '../../../index.js'
@@ -11,14 +12,15 @@ export const parse = <TDate = string>(
 ): Json.Feed<TDate> => {
   const json = parseJsonObject(value)
 
+  // TODO: Detect malformed JSON input and throw MalformedError.
   if (!detectJsonFeed(json)) {
-    throw new Error(locales.invalidFeedFormat)
+    throw new DetectError(locales.invalidFeedFormat)
   }
 
   const parsed = parseFeed(json, options)
 
   if (!parsed) {
-    throw new Error(locales.invalidFeedFormat)
+    throw new ParseError(locales.invalidFeedFormat)
   }
 
   return parsed as Json.Feed<TDate>

--- a/src/feeds/rdf/parse/index.test.ts
+++ b/src/feeds/rdf/parse/index.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'bun:test'
 import { locales, namespaceUris } from '../../../common/config.js'
+import { DetectError, ParseError } from '../../../common/errors.js'
 import { parse } from './index.js'
 
 describe('parse', () => {
@@ -81,6 +82,31 @@ describe('parse', () => {
 
   it('should handle number input', () => {
     expect(() => parse(123)).toThrowError(locales.invalidFeedFormat)
+  })
+
+  describe('error types', () => {
+    it('should throw DetectError for non-feed input', () => {
+      const throwing = () => parse('not a feed')
+
+      expect(throwing).toThrow(DetectError)
+      expect(throwing).toThrow(locales.invalidFeedFormat)
+    })
+
+    it('should throw ParseError for malformed XML', () => {
+      const value = `
+        <?xml version="1.0"?>
+        <rdf:RDF
+          xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+          xmlns="http://purl.org/rss/1.0/">
+          <channel>
+            <title>Test</title
+          </channel>
+        </rdf:RDF>`
+      const throwing = () => parse(value)
+
+      expect(throwing).toThrow(ParseError)
+      expect(throwing).toThrow(locales.invalidFeedFormat)
+    })
   })
 
   it('should handle non-standard atom namespace prefix', () => {

--- a/src/feeds/rdf/parse/index.test.ts
+++ b/src/feeds/rdf/parse/index.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'bun:test'
 import { locales, namespaceUris } from '../../../common/config.js'
-import { DetectError, ParseError } from '../../../common/errors.js'
+import { DetectError, MalformedError, ParseError } from '../../../common/errors.js'
 import { parse } from './index.js'
 
 describe('parse', () => {
@@ -92,7 +92,7 @@ describe('parse', () => {
       expect(throwing).toThrow(locales.invalidFeedFormat)
     })
 
-    it('should throw ParseError for malformed XML', () => {
+    it('should throw MalformedError for malformed XML', () => {
       const value = `
         <?xml version="1.0"?>
         <rdf:RDF
@@ -101,7 +101,22 @@ describe('parse', () => {
           <channel>
             <title>Test</title
           </channel>
-        </rdf:RDF>`
+        </rdf:RDF>
+      `
+      const throwing = () => parse(value)
+
+      expect(throwing).toThrow(MalformedError)
+      expect(throwing).toThrow(locales.invalidFeedFormat)
+    })
+
+    it('should throw ParseError for valid XML with invalid structure', () => {
+      const value = `
+        <?xml version="1.0"?>
+        <rdf:RDF
+          xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+          xmlns="http://purl.org/rss/1.0/">
+        </rdf:RDF>
+      `
       const throwing = () => parse(value)
 
       expect(throwing).toThrow(ParseError)

--- a/src/feeds/rdf/parse/index.ts
+++ b/src/feeds/rdf/parse/index.ts
@@ -1,6 +1,6 @@
-import { locales, namespacePrefixes, namespaceUris } from '../../../common/config.js'
-import type { ParseMainOptions } from '../../../common/types.js'
-import { createNamespaceNormalizator } from '../../../common/utils.js'
+import { locales } from '../../../common/config.js'
+import { DetectError, ParseError } from '../../../common/errors.js'
+import type { ParseMainOptions, Unreliable } from '../../../common/types.js'
 import { detectRdfFeed } from '../../../index.js'
 import type { Rdf } from '../common/types.js'
 import { normalizeNamespaces, parser } from './config.js'
@@ -11,15 +11,22 @@ export const parse = <TDate = string>(
   options?: ParseMainOptions<TDate>,
 ): Rdf.Feed<TDate> => {
   if (!detectRdfFeed(value)) {
-    throw new Error(locales.invalidFeedFormat)
+    throw new DetectError(locales.invalidFeedFormat)
   }
 
-  const object = parser.parse(value)
-  const normalized = normalizeNamespaces(object)
+  let normalized: Unreliable
+
+  try {
+    const object = parser.parse(value)
+    normalized = normalizeNamespaces(object)
+  } catch {
+    throw new ParseError(locales.invalidFeedFormat)
+  }
+
   const parsed = retrieveFeed(normalized, options)
 
   if (!parsed) {
-    throw new Error(locales.invalidFeedFormat)
+    throw new ParseError(locales.invalidFeedFormat)
   }
 
   return parsed as Rdf.Feed<TDate>

--- a/src/feeds/rdf/parse/index.ts
+++ b/src/feeds/rdf/parse/index.ts
@@ -1,5 +1,5 @@
 import { locales } from '../../../common/config.js'
-import { DetectError, ParseError } from '../../../common/errors.js'
+import { DetectError, MalformedError, ParseError } from '../../../common/errors.js'
 import type { ParseMainOptions, Unreliable } from '../../../common/types.js'
 import { detectRdfFeed } from '../../../index.js'
 import type { Rdf } from '../common/types.js'
@@ -20,7 +20,7 @@ export const parse = <TDate = string>(
     const object = parser.parse(value)
     normalized = normalizeNamespaces(object)
   } catch {
-    throw new ParseError(locales.invalidFeedFormat)
+    throw new MalformedError(locales.invalidFeedFormat)
   }
 
   const parsed = retrieveFeed(normalized, options)

--- a/src/feeds/rss/generate/index.test.ts
+++ b/src/feeds/rss/generate/index.test.ts
@@ -1,4 +1,6 @@
 import { describe, expect, it } from 'bun:test'
+import { locales } from '../../../common/config.js'
+import { GenerateError } from '../../../common/errors.js'
 import type { DateLike } from '../../../common/types.js'
 import type { Rss } from '../common/types.js'
 import { generate } from './index.js'
@@ -1430,5 +1432,15 @@ describe('generate edge cases', () => {
 `
 
     expect(generate(value)).toEqual(expected)
+  })
+
+  describe('error types', () => {
+    it('should throw GenerateError for empty input', () => {
+      const value = {}
+      const throwing = () => generate(value)
+
+      expect(throwing).toThrow(GenerateError)
+      expect(throwing).toThrow(locales.invalidInputRss)
+    })
   })
 })

--- a/src/feeds/rss/generate/index.test.ts
+++ b/src/feeds/rss/generate/index.test.ts
@@ -1433,14 +1433,14 @@ describe('generate edge cases', () => {
 
     expect(generate(value)).toEqual(expected)
   })
+})
 
-  describe('error types', () => {
-    it('should throw GenerateError for empty input', () => {
-      const value = {}
-      const throwing = () => generate(value)
+describe('error types', () => {
+  it('should throw GenerateError for empty input', () => {
+    const value = {}
+    const throwing = () => generate(value)
 
-      expect(throwing).toThrow(GenerateError)
-      expect(throwing).toThrow(locales.invalidInputRss)
-    })
+    expect(throwing).toThrow(GenerateError)
+    expect(throwing).toThrow(locales.invalidInputRss)
   })
 })

--- a/src/feeds/rss/generate/index.ts
+++ b/src/feeds/rss/generate/index.ts
@@ -1,4 +1,5 @@
 import { locales } from '../../../common/config.js'
+import { GenerateError } from '../../../common/errors.js'
 import type { DateLike, GenerateMainXml } from '../../../common/types.js'
 import { generateXml } from '../../../common/utils.js'
 import type { Rss } from '../common/types.js'
@@ -12,7 +13,7 @@ export const generate: GenerateMainXml<
   const generated = generateFeed(value)
 
   if (!generated) {
-    throw new Error(locales.invalidInputRss)
+    throw new GenerateError(locales.invalidInputRss)
   }
 
   return generateXml(builder, generated, options)

--- a/src/feeds/rss/parse/index.test.ts
+++ b/src/feeds/rss/parse/index.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'bun:test'
 import { locales } from '../../../common/config.js'
-import { DetectError, ParseError } from '../../../common/errors.js'
+import { DetectError, MalformedError, ParseError } from '../../../common/errors.js'
 import { parse } from './index.js'
 
 describe('parse', () => {
@@ -223,14 +223,23 @@ describe('parse', () => {
       expect(throwing).toThrow(locales.invalidFeedFormat)
     })
 
-    it('should throw ParseError for malformed XML', () => {
+    it('should throw MalformedError for malformed XML', () => {
       const value = `
         <?xml version="1.0"?>
         <rss version="2.0">
           <channel>
             <title>Test</title
           </channel>
-        </rss>`
+        </rss>
+      `
+      const throwing = () => parse(value)
+
+      expect(throwing).toThrow(MalformedError)
+      expect(throwing).toThrow(locales.invalidFeedFormat)
+    })
+
+    it('should throw ParseError for valid XML with invalid structure', () => {
+      const value = '<rss version="2.0"></rss>'
       const throwing = () => parse(value)
 
       expect(throwing).toThrow(ParseError)

--- a/src/feeds/rss/parse/index.test.ts
+++ b/src/feeds/rss/parse/index.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'bun:test'
 import { locales } from '../../../common/config.js'
+import { DetectError, ParseError } from '../../../common/errors.js'
 import { parse } from './index.js'
 
 describe('parse', () => {
@@ -212,6 +213,29 @@ describe('parse', () => {
 
   it('should handle number input', () => {
     expect(() => parse(123)).toThrowError(locales.invalidFeedFormat)
+  })
+
+  describe('error types', () => {
+    it('should throw DetectError for non-feed input', () => {
+      const throwing = () => parse('not a feed')
+
+      expect(throwing).toThrow(DetectError)
+      expect(throwing).toThrow(locales.invalidFeedFormat)
+    })
+
+    it('should throw ParseError for malformed XML', () => {
+      const value = `
+        <?xml version="1.0"?>
+        <rss version="2.0">
+          <channel>
+            <title>Test</title
+          </channel>
+        </rss>`
+      const throwing = () => parse(value)
+
+      expect(throwing).toThrow(ParseError)
+      expect(throwing).toThrow(locales.invalidFeedFormat)
+    })
   })
 
   it('should handle non-standard atom namespace prefix', () => {

--- a/src/feeds/rss/parse/index.ts
+++ b/src/feeds/rss/parse/index.ts
@@ -1,6 +1,6 @@
-import { locales, namespacePrefixes, namespaceUris } from '../../../common/config.js'
-import type { ParseMainOptions } from '../../../common/types.js'
-import { createNamespaceNormalizator } from '../../../common/utils.js'
+import { locales } from '../../../common/config.js'
+import { DetectError, ParseError } from '../../../common/errors.js'
+import type { ParseMainOptions, Unreliable } from '../../../common/types.js'
 import { detectRssFeed } from '../../../index.js'
 import type { Rss } from '../common/types.js'
 import { normalizeNamespaces, parser } from './config.js'
@@ -11,15 +11,22 @@ export const parse = <TDate = string>(
   options?: ParseMainOptions<TDate>,
 ): Rss.Feed<TDate> => {
   if (!detectRssFeed(value)) {
-    throw new Error(locales.invalidFeedFormat)
+    throw new DetectError(locales.invalidFeedFormat)
   }
 
-  const object = parser.parse(value)
-  const normalized = normalizeNamespaces(object)
+  let normalized: Unreliable
+
+  try {
+    const object = parser.parse(value)
+    normalized = normalizeNamespaces(object)
+  } catch {
+    throw new ParseError(locales.invalidFeedFormat)
+  }
+
   const parsed = retrieveFeed(normalized, options)
 
   if (!parsed) {
-    throw new Error(locales.invalidFeedFormat)
+    throw new ParseError(locales.invalidFeedFormat)
   }
 
   return parsed as Rss.Feed<TDate>

--- a/src/feeds/rss/parse/index.ts
+++ b/src/feeds/rss/parse/index.ts
@@ -1,5 +1,5 @@
 import { locales } from '../../../common/config.js'
-import { DetectError, ParseError } from '../../../common/errors.js'
+import { DetectError, MalformedError, ParseError } from '../../../common/errors.js'
 import type { ParseMainOptions, Unreliable } from '../../../common/types.js'
 import { detectRssFeed } from '../../../index.js'
 import type { Rss } from '../common/types.js'
@@ -20,7 +20,7 @@ export const parse = <TDate = string>(
     const object = parser.parse(value)
     normalized = normalizeNamespaces(object)
   } catch {
-    throw new ParseError(locales.invalidFeedFormat)
+    throw new MalformedError(locales.invalidFeedFormat)
   }
 
   const parsed = retrieveFeed(normalized, options)

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+export { DetectError, ParseError } from './common/errors.js'
 export { parse as parseFeed } from './common/parse.js'
 export type { DateLike, XmlStylesheet } from './common/types.js'
 export type { Atom } from './feeds/atom/common/types.js'

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-export { DetectError, ParseError } from './common/errors.js'
+export { DetectError, GenerateError, MalformedError, ParseError } from './common/errors.js'
 export { parse as parseFeed } from './common/parse.js'
 export type { DateLike, XmlStylesheet } from './common/types.js'
 export type { Atom } from './feeds/atom/common/types.js'

--- a/src/opml/generate/index.test.ts
+++ b/src/opml/generate/index.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'bun:test'
+import { locales } from '../../common/config.js'
 import { GenerateError } from '../../common/errors.js'
 import { generate } from './index.js'
 
@@ -227,6 +228,7 @@ describe('generate', () => {
       const throwing = () => generate(value)
 
       expect(throwing).toThrow(GenerateError)
+      expect(throwing).toThrow(locales.invalidInputOpml)
     })
   })
 

--- a/src/opml/generate/index.test.ts
+++ b/src/opml/generate/index.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'bun:test'
+import { GenerateError } from '../../common/errors.js'
 import { generate } from './index.js'
 
 describe('generate', () => {
@@ -216,14 +217,17 @@ describe('generate', () => {
     expect(generate(value)).toEqual(expected)
   })
 
-  it('should throw error for invalid OPML structure', () => {
-    const value = {
-      head: {
-        title: 'Invalid OPML',
-      },
-    }
+  describe('error types', () => {
+    it('should throw GenerateError for invalid OPML structure', () => {
+      const value = {
+        head: {
+          title: 'Invalid OPML',
+        },
+      }
+      const throwing = () => generate(value)
 
-    expect(() => generate(value)).toThrow()
+      expect(throwing).toThrow(GenerateError)
+    })
   })
 
   it('should properly encode special characters in attributes', () => {

--- a/src/opml/generate/index.ts
+++ b/src/opml/generate/index.ts
@@ -1,4 +1,5 @@
 import { locales } from '../../common/config.js'
+import { GenerateError } from '../../common/errors.js'
 import type { DateLike, GenerateMainXmlOptions } from '../../common/types.js'
 import { generateXml } from '../../common/utils.js'
 import type { GenerateMainOptions, Opml } from '../common/types.js'
@@ -12,7 +13,7 @@ export const generate = <TExtra extends ReadonlyArray<string> = [], S extends bo
   const generated = generateDocument(value, options)
 
   if (!generated) {
-    throw new Error(locales.invalidInputOpml)
+    throw new GenerateError(locales.invalidInputOpml)
   }
 
   return generateXml(builder, generated, options)

--- a/src/opml/parse/index.test.ts
+++ b/src/opml/parse/index.test.ts
@@ -1,4 +1,6 @@
 import { describe, expect, it } from 'bun:test'
+import { locales } from '../../common/config.js'
+import { ParseError } from '../../common/errors.js'
 import { parse } from './index.js'
 
 describe('parse', () => {
@@ -118,6 +120,22 @@ describe('parse', () => {
     `
 
     expect(() => parse(value)).toThrow()
+  })
+
+  describe('error types', () => {
+    it('should throw ParseError for invalid XML', () => {
+      const value = `
+        <?xml version="1.0"?>
+        <opml version="2.0">
+          <head>
+            <title>Test</title
+          </head>
+        </opml>`
+      const throwing = () => parse(value)
+
+      expect(throwing).toThrow(ParseError)
+      expect(throwing).toThrow(locales.invalidOpmlFormat)
+    })
   })
 
   describe('custom attributes', () => {

--- a/src/opml/parse/index.test.ts
+++ b/src/opml/parse/index.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'bun:test'
 import { locales } from '../../common/config.js'
-import { ParseError } from '../../common/errors.js'
+import { MalformedError, ParseError } from '../../common/errors.js'
 import { parse } from './index.js'
 
 describe('parse', () => {
@@ -123,14 +123,23 @@ describe('parse', () => {
   })
 
   describe('error types', () => {
-    it('should throw ParseError for invalid XML', () => {
+    it('should throw MalformedError for invalid XML', () => {
       const value = `
         <?xml version="1.0"?>
         <opml version="2.0">
           <head>
             <title>Test</title
           </head>
-        </opml>`
+        </opml>
+      `
+      const throwing = () => parse(value)
+
+      expect(throwing).toThrow(MalformedError)
+      expect(throwing).toThrow(locales.invalidOpmlFormat)
+    })
+
+    it('should throw ParseError for valid XML with invalid structure', () => {
+      const value = '<opml version="2.0"></opml>'
       const throwing = () => parse(value)
 
       expect(throwing).toThrow(ParseError)

--- a/src/opml/parse/index.ts
+++ b/src/opml/parse/index.ts
@@ -1,4 +1,6 @@
 import { locales } from '../../common/config.js'
+import { ParseError } from '../../common/errors.js'
+import type { Unreliable } from '../../common/types.js'
 import type { Opml, ParseMainOptions } from '../common/types.js'
 import { parser } from './config.js'
 import { parseDocument } from './utils.js'
@@ -10,11 +12,18 @@ export const parse = <
   value: string,
   options?: ParseMainOptions<TDate, TExtra>,
 ): Opml.Document<TDate, TExtra> => {
-  const object = parser.parse(value)
+  let object: Unreliable
+
+  try {
+    object = parser.parse(value)
+  } catch {
+    throw new ParseError(locales.invalidOpmlFormat)
+  }
+
   const parsed = parseDocument(object, options)
 
   if (!parsed) {
-    throw new Error(locales.invalidOpmlFormat)
+    throw new ParseError(locales.invalidOpmlFormat)
   }
 
   return parsed as Opml.Document<TDate, TExtra>

--- a/src/opml/parse/index.ts
+++ b/src/opml/parse/index.ts
@@ -1,5 +1,5 @@
 import { locales } from '../../common/config.js'
-import { ParseError } from '../../common/errors.js'
+import { MalformedError, ParseError } from '../../common/errors.js'
 import type { Unreliable } from '../../common/types.js'
 import type { Opml, ParseMainOptions } from '../common/types.js'
 import { parser } from './config.js'
@@ -17,7 +17,7 @@ export const parse = <
   try {
     object = parser.parse(value)
   } catch {
-    throw new ParseError(locales.invalidOpmlFormat)
+    throw new MalformedError(locales.invalidOpmlFormat)
   }
 
   const parsed = parseDocument(object, options)


### PR DESCRIPTION
This PR replaces the generic `Error` throws with `DetectError` and `ParseError`.

- Add `DetectError` (thrown when input doesn't match expected feed format) and `ParseError` (thrown when XML parsing fails) replacing generic `Error` throws
- Integrate error types into all parsers (RSS, Atom, RDF, OPML) with try-catch wrapping
- Export both classes from main entry point
- Add error handling docs page and update existing docs
