### PR TITLE
Add GenerateError to JSON feed generator

### DIFF
--- a/src/common/config.ts
+++ b/src/common/config.ts
@@ -128,6 +128,7 @@ export const locales = {
   invalidInputOpml: 'Invalid input OPML',
   invalidInputAtom: 'Invalid input Atom',
   invalidInputRss: 'Invalid input RSS',
+  invalidInputJson: 'Invalid input JSON',
 }
 
 export const namespaceUris = {

--- a/src/feeds/json/generate/index.test.ts
+++ b/src/feeds/json/generate/index.test.ts
@@ -1,4 +1,6 @@
 import { describe, expect, it } from 'bun:test'
+import { locales } from '../../../common/config.js'
+import { GenerateError } from '../../../common/errors.js'
 import { generate } from './index.js'
 
 describe('generate', () => {
@@ -128,6 +130,15 @@ describe('strict mode', () => {
 
   it('should accept partial feed in lenient mode', () => {
     generate({ title: 'Test' })
+  })
+})
+
+describe('error types', () => {
+  it('should throw GenerateError for invalid input', () => {
+    const throwing = () => generate({})
+
+    expect(throwing).toThrow(GenerateError)
+    expect(throwing).toThrow(locales.invalidInputJson)
   })
 })
 

--- a/src/feeds/json/generate/index.ts
+++ b/src/feeds/json/generate/index.ts
@@ -1,7 +1,15 @@
+import { locales } from '../../../common/config.js'
+import { GenerateError } from '../../../common/errors.js'
 import type { DateLike, GenerateMainJson } from '../../../common/types.js'
 import type { Json } from '../common/types.js'
 import { generateFeed } from './utils.js'
 
 export const generate: GenerateMainJson<Json.Feed<DateLike>, Json.Feed<Date, true>> = (value) => {
-  return generateFeed(value)
+  const generated = generateFeed(value)
+
+  if (!generated) {
+    throw new GenerateError(locales.invalidInputJson)
+  }
+
+  return generated
 }

--- a/src/feeds/json/generate/utils.ts
+++ b/src/feeds/json/generate/utils.ts
@@ -1,5 +1,5 @@
 import type { DateLike } from '../../../common/types.js'
-import { generateRfc3339Date, trimArray, trimObject } from '../../../common/utils.js'
+import { generateRfc3339Date, isObject, trimArray, trimObject } from '../../../common/utils.js'
 import type { GenerateUtil, Json } from '../common/types.js'
 
 export const generateItem: GenerateUtil<Json.Item<DateLike>> = (item) => {
@@ -13,11 +13,23 @@ export const generateItem: GenerateUtil<Json.Item<DateLike>> = (item) => {
 }
 
 export const generateFeed: GenerateUtil<Json.Feed<DateLike>> = (feed) => {
+  if (!isObject(feed)) {
+    return
+  }
+
   const value = {
-    version: 'https://jsonfeed.org/version/1.1',
     ...feed,
     items: trimArray(feed?.items, generateItem),
   }
 
-  return trimObject(value)
+  const trimmed = trimObject(value)
+
+  if (!trimmed) {
+    return
+  }
+
+  return {
+    version: 'https://jsonfeed.org/version/1.1',
+    ...trimmed,
+  }
 }


### PR DESCRIPTION
This PR adds `GenerateError` to the JSON feed generator, for consistency with the RSS, Atom and OPML ones.

- Add `isObject` guard and deferred `version` injection in `generateFeed` so empty/invalid input returns `undefined` instead of a version-only object
- Throw `GenerateError` in `generate()` for consistency with RSS, Atom, and OPML generators
- Add `invalidInputJson` locale and error type test
