### PR TITLE
fix: Preserve HTML entities in JSON Feed text fields

### DIFF
--- a/src/common/utils.test.ts
+++ b/src/common/utils.test.ts
@@ -31,6 +31,7 @@ import {
   parseCsvOf,
   parseDate,
   parseJsonObject,
+  parseJsonString,
   parseNumber,
   parseSingular,
   parseSingularOf,
@@ -1223,6 +1224,77 @@ describe('parseString', () => {
         })
       }
     })
+  })
+})
+
+describe('parseJsonString', () => {
+  it('should return string as-is when no entities or comments are present', () => {
+    const value = 'plain text'
+    const expected = 'plain text'
+
+    expect(parseJsonString(value)).toBe(expected)
+  })
+
+  it('should trim leading and trailing whitespace', () => {
+    const value = '  hello  '
+    const expected = 'hello'
+
+    expect(parseJsonString(value)).toBe(expected)
+  })
+
+  it('should convert numbers to strings', () => {
+    const value = 42
+    const expected = '42'
+
+    expect(parseJsonString(value)).toBe(expected)
+  })
+
+  it('should return undefined for empty string', () => {
+    const value = ''
+
+    expect(parseJsonString(value)).toBeUndefined()
+  })
+
+  it('should return undefined for whitespace-only string', () => {
+    const value = '   '
+
+    expect(parseJsonString(value)).toBeUndefined()
+  })
+
+  it('should return undefined for non-string non-number inputs', () => {
+    expect(parseJsonString(null)).toBeUndefined()
+    expect(parseJsonString(undefined)).toBeUndefined()
+    expect(parseJsonString(true)).toBeUndefined()
+    expect(parseJsonString({})).toBeUndefined()
+    expect(parseJsonString([])).toBeUndefined()
+  })
+
+  it('should preserve XML entities (no entity decoding)', () => {
+    const value = '&lt;p&gt;hello&lt;/p&gt; &amp; goodbye'
+    const expected = '&lt;p&gt;hello&lt;/p&gt; &amp; goodbye'
+
+    expect(parseJsonString(value)).toBe(expected)
+  })
+
+  it('should preserve HTML comment markers (no comment stripping)', () => {
+    const value = 'before <!-- inline note --> after'
+    const expected = 'before <!-- inline note --> after'
+
+    expect(parseJsonString(value)).toBe(expected)
+  })
+
+  it('should preserve CDATA markers verbatim', () => {
+    const value = '<![CDATA[raw <p>text</p>]]>'
+    const expected = '<![CDATA[raw <p>text</p>]]>'
+
+    expect(parseJsonString(value)).toBe(expected)
+  })
+
+  it('should preserve numeric character references', () => {
+    const value = '&#60;tag&#62;'
+    const expected = '&#60;tag&#62;'
+
+    expect(parseJsonString(value)).toBe(expected)
   })
 })
 

--- a/src/common/utils.ts
+++ b/src/common/utils.ts
@@ -255,6 +255,26 @@ export const parseString: ParseExactUtil<string> = (value) => {
   }
 }
 
+// Variant of parseString for JSON-sourced values: skips XML entity decoding and
+// HTML comment stripping. JSON.parse already produces the final string, so any
+// `&lt;` / `<!--` in fields like JSON Feed's `content_html` belongs to the HTML
+// payload and must be preserved verbatim.
+export const parseJsonString: ParseExactUtil<string> = (value) => {
+  if (typeof value === 'string') {
+    if (value === '') {
+      return
+    }
+
+    const string = value.trim()
+
+    return string || undefined
+  }
+
+  if (typeof value === 'number') {
+    return value.toString()
+  }
+}
+
 export const parseNumber: ParseExactUtil<number> = (value) => {
   if (typeof value === 'number') {
     return value

--- a/src/feeds/json/parse/utils.test.ts
+++ b/src/feeds/json/parse/utils.test.ts
@@ -689,6 +689,71 @@ describe('parseItem', () => {
 
     expect(parseItem(value)).toEqual(expected)
   })
+
+  it('should preserve HTML entities in content_html verbatim', () => {
+    const value = {
+      id: '1',
+      content_html: 'before <code>&lt;title&gt;</code> after &amp; &lt;p&gt;outside&lt;/p&gt;',
+    }
+    const expected = {
+      id: '1',
+      content_html: 'before <code>&lt;title&gt;</code> after &amp; &lt;p&gt;outside&lt;/p&gt;',
+    }
+
+    expect(parseItem(value)).toEqual(expected)
+  })
+
+  it('should preserve HTML entities in content_text verbatim', () => {
+    const value = {
+      id: '1',
+      content_text: 'Tom &amp; Jerry &lt; Bugs &amp; Daffy',
+    }
+    const expected = {
+      id: '1',
+      content_text: 'Tom &amp; Jerry &lt; Bugs &amp; Daffy',
+    }
+
+    expect(parseItem(value)).toEqual(expected)
+  })
+
+  it('should preserve HTML entities in summary verbatim', () => {
+    const value = {
+      id: '1',
+      summary: 'A &amp; B',
+    }
+    const expected = {
+      id: '1',
+      summary: 'A &amp; B',
+    }
+
+    expect(parseItem(value)).toEqual(expected)
+  })
+
+  it('should preserve HTML entities in title verbatim', () => {
+    const value = {
+      id: '1',
+      title: 'Tom &amp; Jerry',
+    }
+    const expected = {
+      id: '1',
+      title: 'Tom &amp; Jerry',
+    }
+
+    expect(parseItem(value)).toEqual(expected)
+  })
+
+  it('should preserve HTML comment markers inside content_html', () => {
+    const value = {
+      id: '1',
+      content_html: '<p>before</p><!-- inline note --><p>after</p>',
+    }
+    const expected = {
+      id: '1',
+      content_html: '<p>before</p><!-- inline note --><p>after</p>',
+    }
+
+    expect(parseItem(value)).toEqual(expected)
+  })
 })
 
 describe('parseHub', () => {
@@ -1127,6 +1192,21 @@ describe('parseFeed', () => {
       }
 
       expect(parseFeed(commonValue, { maxItems: undefined })).toEqual(expected)
+    })
+  })
+
+  describe('entity preservation', () => {
+    it('should preserve HTML entities in feed-level title and description', () => {
+      const value = {
+        title: 'Tom &amp; Jerry',
+        description: 'A &lt;strong&gt;great&lt;/strong&gt; feed',
+      }
+      const expected = {
+        title: 'Tom &amp; Jerry',
+        description: 'A &lt;strong&gt;great&lt;/strong&gt; feed',
+      }
+
+      expect(parseFeed(value)).toEqual(expected)
     })
   })
 })

--- a/src/feeds/json/parse/utils.ts
+++ b/src/feeds/json/parse/utils.ts
@@ -5,9 +5,9 @@ import {
   parseArrayOf,
   parseBoolean,
   parseDate,
+  parseJsonString,
   parseNumber,
   parseSingularOf,
-  parseString,
   trimObject,
 } from '../../../common/utils.js'
 import type { Json } from '../common/types.js'
@@ -32,9 +32,9 @@ export const parseAuthor: ParsePartialUtil<Json.Author> = (value) => {
   if (isObject(value)) {
     const get = createCaseInsensitiveGetter(value)
     const author = {
-      name: parseSingularOf(get('name'), parseString),
-      url: parseSingularOf(get('url'), parseString),
-      avatar: parseSingularOf(get('avatar'), parseString),
+      name: parseSingularOf(get('name'), parseJsonString),
+      url: parseSingularOf(get('url'), parseJsonString),
+      avatar: parseSingularOf(get('avatar'), parseJsonString),
     }
 
     return trimObject(author)
@@ -42,7 +42,7 @@ export const parseAuthor: ParsePartialUtil<Json.Author> = (value) => {
 
   if (isNonEmptyStringOrNumber(value)) {
     const author = {
-      name: parseString(value),
+      name: parseJsonString(value),
     }
 
     return trimObject(author)
@@ -71,9 +71,9 @@ export const parseAttachment: ParsePartialUtil<Json.Attachment> = (value) => {
 
   const get = createCaseInsensitiveGetter(value)
   const attachment = {
-    url: parseSingularOf(get('url'), parseString),
-    mime_type: parseSingularOf(get('mime_type'), parseString),
-    title: parseSingularOf(get('title'), parseString),
+    url: parseSingularOf(get('url'), parseJsonString),
+    mime_type: parseSingularOf(get('mime_type'), parseJsonString),
+    title: parseSingularOf(get('title'), parseJsonString),
     size_in_bytes: parseSingularOf(get('size_in_bytes'), parseNumber),
     duration_in_seconds: parseSingularOf(get('duration_in_seconds'), parseNumber),
   }
@@ -88,20 +88,20 @@ export const parseItem: ParsePartialUtil<Json.Item<string>> = (value) => {
 
   const get = createCaseInsensitiveGetter(value)
   const item = {
-    id: parseSingularOf(get('id'), parseString),
-    url: parseSingularOf(get('url'), parseString),
-    external_url: parseSingularOf(get('external_url'), parseString),
-    title: parseSingularOf(get('title'), parseString),
-    content_html: parseSingularOf(get('content_html'), parseString),
-    content_text: parseSingularOf(get('content_text'), parseString),
-    summary: parseSingularOf(get('summary'), parseString),
-    image: parseSingularOf(get('image'), parseString),
-    banner_image: parseSingularOf(get('banner_image'), parseString),
+    id: parseSingularOf(get('id'), parseJsonString),
+    url: parseSingularOf(get('url'), parseJsonString),
+    external_url: parseSingularOf(get('external_url'), parseJsonString),
+    title: parseSingularOf(get('title'), parseJsonString),
+    content_html: parseSingularOf(get('content_html'), parseJsonString),
+    content_text: parseSingularOf(get('content_text'), parseJsonString),
+    summary: parseSingularOf(get('summary'), parseJsonString),
+    image: parseSingularOf(get('image'), parseJsonString),
+    banner_image: parseSingularOf(get('banner_image'), parseJsonString),
     date_published: parseSingularOf(get('date_published'), parseDate),
     date_modified: parseSingularOf(get('date_modified'), parseDate),
-    tags: parseArrayOf(get('tags'), parseString),
+    tags: parseArrayOf(get('tags'), parseJsonString),
     authors: retrieveAuthors(value),
-    language: parseSingularOf(get('language'), parseString),
+    language: parseSingularOf(get('language'), parseJsonString),
     attachments: parseArrayOf(get('attachments'), parseAttachment),
   }
 
@@ -115,8 +115,8 @@ export const parseHub: ParsePartialUtil<Json.Hub> = (value) => {
 
   const get = createCaseInsensitiveGetter(value)
   const hub = {
-    type: parseSingularOf(get('type'), parseString),
-    url: parseSingularOf(get('url'), parseString),
+    type: parseSingularOf(get('type'), parseJsonString),
+    url: parseSingularOf(get('url'), parseJsonString),
   }
 
   return trimObject(hub)
@@ -129,15 +129,15 @@ export const parseFeed: ParsePartialUtil<Json.Feed<string>, ParseOptions> = (val
 
   const get = createCaseInsensitiveGetter(value)
   const feed = {
-    title: parseSingularOf(get('title'), parseString),
-    home_page_url: parseSingularOf(get('home_page_url'), parseString),
-    feed_url: parseSingularOf(get('feed_url'), parseString),
-    description: parseSingularOf(get('description'), parseString),
-    user_comment: parseSingularOf(get('user_comment'), parseString),
-    next_url: parseSingularOf(get('next_url'), parseString),
-    icon: parseSingularOf(get('icon'), parseString),
-    favicon: parseSingularOf(get('favicon'), parseString),
-    language: parseSingularOf(get('language'), parseString),
+    title: parseSingularOf(get('title'), parseJsonString),
+    home_page_url: parseSingularOf(get('home_page_url'), parseJsonString),
+    feed_url: parseSingularOf(get('feed_url'), parseJsonString),
+    description: parseSingularOf(get('description'), parseJsonString),
+    user_comment: parseSingularOf(get('user_comment'), parseJsonString),
+    next_url: parseSingularOf(get('next_url'), parseJsonString),
+    icon: parseSingularOf(get('icon'), parseJsonString),
+    favicon: parseSingularOf(get('favicon'), parseJsonString),
+    language: parseSingularOf(get('language'), parseJsonString),
     expired: parseSingularOf(get('expired'), parseBoolean),
     hubs: parseArrayOf(get('hubs'), parseHub),
     authors: retrieveAuthors(value),


### PR DESCRIPTION
This PR stops JSON Feed text fields being entity-decoded, so an HTML payload survives verbatim.

- `parseJsonFeed` was running XML-style entity decoding (and HTML comment stripping) on every text field via `parseString` → `decodeWithCdata(stripComments(...))`. For JSON Feed this is incorrect: `JSON.parse` already produced the final string, so `&lt;`/`&amp;`/`<!-- ... -->` in fields like `content_html` belong to the HTML payload and must be preserved verbatim.
- Real-world impact: `https://www.manton.org/feed.json` contains `<code>&lt;title&gt;</code>` which became `<code><title></code>`. Downstream HTML5 sanitizers then treat `<title>` as a real raw-text element and consume the rest of the post.
- Added `parseJsonString` (trim only, no entity decoding, no comment stripping) and switched every text field in `src/feeds/json/parse/utils.ts` from `parseString` → `parseJsonString`. RSS/Atom paths (where XML entity decoding is correct) are untouched.

## Repro

```ts
parseJsonFeed(JSON.stringify({
  version: 'https://jsonfeed.org/version/1.1',
  title: 't',
  items: [{ id: 'a', content_html: '&lt;p&gt;hi&lt;/p&gt;' }],
}))
// before: item.content_html === '<p>hi</p>'
// after:  item.content_html === '&lt;p&gt;hi&lt;/p&gt;'
```
