### PR TITLE
feat: Add source:inReplyTo element and move source:localTime to channel level

### DIFF
--- a/src/feeds/rss/generate/index.test.ts
+++ b/src/feeds/rss/generate/index.test.ts
@@ -667,6 +667,7 @@ describe('generate', () => {
         accounts: [{ service: 'twitter', value: 'johndoe' }, { service: 'github' }],
         likes: { server: 'http://likes.example.com/' },
         blogroll: 'https://blog.example.com/blogroll.opml',
+        localTime: '2024-01-15 10:30:00',
       },
       items: [
         {
@@ -674,8 +675,8 @@ describe('generate', () => {
           sourceNs: {
             markdown: '# Example Post - This is markdown content for the post.',
             outlines: ['<outline text="Section 1"/>', '<outline text="Section 2"/>'],
-            localTime: '2024-01-15 10:30:00',
             linkFull: 'https://example.com/posts/full-version',
+            inReplyTo: { value: 'did:plc:iwl32vekohccji6khfdt3clw', isPermaLink: false },
           },
         },
       ],
@@ -689,6 +690,7 @@ describe('generate', () => {
     <source:account service="github"/>
     <source:likes server="http://likes.example.com/"/>
     <source:blogroll>https://blog.example.com/blogroll.opml</source:blogroll>
+    <source:localTime>2024-01-15 10:30:00</source:localTime>
     <item>
       <title>Item with source metadata</title>
       <source:markdown># Example Post - This is markdown content for the post.</source:markdown>
@@ -698,8 +700,8 @@ describe('generate', () => {
       <source:outline>
         <![CDATA[<outline text="Section 2"/>]]>
       </source:outline>
-      <source:localTime>2024-01-15 10:30:00</source:localTime>
       <source:linkFull>https://example.com/posts/full-version</source:linkFull>
+      <source:inReplyTo isPermaLink="false">did:plc:iwl32vekohccji6khfdt3clw</source:inReplyTo>
     </item>
   </channel>
 </rss>

--- a/src/feeds/rss/generate/utils.test.ts
+++ b/src/feeds/rss/generate/utils.test.ts
@@ -893,8 +893,8 @@ describe('generateItem', () => {
       sourceNs: {
         markdown: '# Example markdown content',
         outlines: ['<outline text="Section 1"/>', '<outline text="Section 2"/>'],
-        localTime: '2024-01-15 10:30:00',
         linkFull: 'https://example.com/full-article',
+        inReplyTo: { value: 'did:plc:iwl32vekohccji6khfdt3clw', isPermaLink: false },
       },
     }
     const expected = {
@@ -904,8 +904,11 @@ describe('generateItem', () => {
         { '#cdata': '<outline text="Section 1"/>' },
         { '#cdata': '<outline text="Section 2"/>' },
       ],
-      'source:localTime': '2024-01-15 10:30:00',
       'source:linkFull': 'https://example.com/full-article',
+      'source:inReplyTo': {
+        '#text': 'did:plc:iwl32vekohccji6khfdt3clw',
+        '@isPermaLink': false,
+      },
     }
 
     expect(generateItem(value)).toEqual(expected)
@@ -1518,6 +1521,7 @@ describe('generateFeed', () => {
         accounts: [{ service: 'twitter', value: 'johndoe' }, { service: 'github' }],
         likes: { server: 'http://likes.example.com/' },
         blogroll: 'https://example.com/blogroll.opml',
+        localTime: '2024-01-15 10:30:00',
       },
     }
     const expected = {
@@ -1533,6 +1537,7 @@ describe('generateFeed', () => {
           ],
           'source:likes': { '@server': 'http://likes.example.com/' },
           'source:blogroll': 'https://example.com/blogroll.opml',
+          'source:localTime': '2024-01-15 10:30:00',
         },
       },
     }

--- a/src/feeds/rss/parse/utils.test.ts
+++ b/src/feeds/rss/parse/utils.test.ts
@@ -990,13 +990,13 @@ describe('parseItem', () => {
     const value = {
       title: { '#text': 'Source Item' },
       'source:markdown': { '#text': '# Example markdown content' },
-      'source:localtime': { '#text': '2024-01-15 10:30:00' },
+      'source:inreplyto': { '@ispermalink': 'false', '#text': 'did:plc:iwl32vekohccji6khfdt3clw' },
     }
     const expected = {
       title: 'Source Item',
       sourceNs: {
         markdown: '# Example markdown content',
-        localTime: '2024-01-15 10:30:00',
+        inReplyTo: { value: 'did:plc:iwl32vekohccji6khfdt3clw', isPermaLink: false },
       },
     }
 
@@ -1533,6 +1533,7 @@ describe('parseFeed', () => {
       link: { '#text': 'https://example.com' },
       'source:account': { '@service': 'twitter', '#text': 'johndoe' },
       'source:blogroll': { '#text': 'https://example.com/blogroll.opml' },
+      'source:localtime': { '#text': '2024-01-15 10:30:00' },
     }
     const value = { channel }
     const expected = {
@@ -1541,6 +1542,7 @@ describe('parseFeed', () => {
       sourceNs: {
         accounts: [{ service: 'twitter', value: 'johndoe' }],
         blogroll: 'https://example.com/blogroll.opml',
+        localTime: '2024-01-15 10:30:00',
       },
     }
 

--- a/src/feeds/rss/references/rss-ns.json
+++ b/src/feeds/rss/references/rss-ns.json
@@ -1050,8 +1050,8 @@
           "<outline text=\"Introduction\"><outline text=\"What are namespaces?\"/></outline>",
           "<outline text=\"Implementation\"><outline text=\"RSS Integration\"/></outline>"
         ],
-        "localTime": "2023-12-25 10:30:00",
-        "linkFull": "http://example.org/item/1/understanding-xml-namespaces-complete-guide"
+        "linkFull": "http://example.org/item/1/understanding-xml-namespaces-complete-guide",
+        "inReplyTo": { "value": "did:plc:iwl32vekohccji6khfdt3clw", "isPermaLink": false }
       },
       "creativeCommons": {
         "licenses": ["http://creativecommons.org/licenses/by-sa/4.0/"]
@@ -2124,7 +2124,8 @@
     ],
     "cloud": "https://cloudserver.example.com/notify",
     "blogroll": "https://blog.example.com/blogroll.opml",
-    "self": "http://example.com/feed.xml"
+    "self": "http://example.com/feed.xml",
+    "localTime": "2023-12-25 10:30:00"
   },
   "blogChannel": {
     "blogRoll": "http://example.com/blogroll.opml",

--- a/src/feeds/rss/references/rss-ns.xml
+++ b/src/feeds/rss/references/rss-ns.xml
@@ -408,6 +408,7 @@
     <source:cloud>https://cloudserver.example.com/notify</source:cloud>
     <source:blogroll>https://blog.example.com/blogroll.opml</source:blogroll>
     <source:self>http://example.com/feed.xml</source:self>
+    <source:localTime>2023-12-25 10:30:00</source:localTime>
 
     <!-- blogChannel Namespace: Channel Level Tags -->
     <blogChannel:blogRoll>http://example.com/blogroll.opml</blogChannel:blogRoll>
@@ -842,8 +843,8 @@
       <source:markdown># Understanding XML Namespaces - This article explores the power and flexibility of XML namespaces in modern web syndication.</source:markdown>
       <source:outline>&lt;outline text="Introduction"&gt;&lt;outline text="What are namespaces?"/&gt;&lt;/outline&gt;</source:outline>
       <source:outline>&lt;outline text="Implementation"&gt;&lt;outline text="RSS Integration"/&gt;&lt;/outline&gt;</source:outline>
-      <source:localTime>2023-12-25 10:30:00</source:localTime>
       <source:linkFull>http://example.org/item/1/understanding-xml-namespaces-complete-guide</source:linkFull>
+      <source:inReplyTo isPermaLink="false">did:plc:iwl32vekohccji6khfdt3clw</source:inReplyTo>
 
       <!-- Creative Commons Namespace: Item Level Tags -->
       <creativeCommons:license>http://creativecommons.org/licenses/by-sa/4.0/</creativeCommons:license>

--- a/src/namespaces/source/common/config.ts
+++ b/src/namespaces/source/common/config.ts
@@ -19,4 +19,5 @@ export const stopNodes = [
   '*.source:outline',
   '*.source:localtime',
   '*.source:linkfull',
+  '*.source:inreplyto',
 ]

--- a/src/namespaces/source/common/types.ts
+++ b/src/namespaces/source/common/types.ts
@@ -21,6 +21,11 @@ export namespace SourceNs {
     value?: string
   }
 
+  export type InReplyTo = {
+    value: string
+    isPermaLink?: boolean
+  }
+
   export type Feed = {
     accounts?: Array<Account>
     likes?: Likes
@@ -29,13 +34,14 @@ export namespace SourceNs {
     cloud?: string
     blogroll?: string
     self?: string
+    localTime?: string
   }
 
   export type Item = {
     markdown?: string
     outlines?: Array<string>
-    localTime?: string
     linkFull?: string
+    inReplyTo?: InReplyTo
   }
 }
 // #endregion reference

--- a/src/namespaces/source/generate/utils.test.ts
+++ b/src/namespaces/source/generate/utils.test.ts
@@ -3,6 +3,7 @@ import {
   generateAccount,
   generateArchive,
   generateFeed,
+  generateInReplyTo,
   generateItem,
   generateLikes,
   generateSubscriptionList,
@@ -170,6 +171,62 @@ describe('generateSubscriptionList', () => {
   })
 })
 
+describe('generateInReplyTo', () => {
+  it('should generate a bare permalink value', () => {
+    const value = {
+      value: 'https://example.com/2026/05/16/hello-world.html',
+    }
+    const expected = {
+      '#text': 'https://example.com/2026/05/16/hello-world.html',
+    }
+
+    expect(generateInReplyTo(value)).toEqual(expected)
+  })
+
+  it('should generate value with isPermaLink set to false', () => {
+    const value = {
+      value: 'did:plc:iwl32vekohccji6khfdt3clw',
+      isPermaLink: false,
+    }
+    const expected = {
+      '#text': 'did:plc:iwl32vekohccji6khfdt3clw',
+      '@isPermaLink': false,
+    }
+
+    expect(generateInReplyTo(value)).toEqual(expected)
+  })
+
+  it('should generate value with isPermaLink set to true', () => {
+    const value = {
+      value: 'https://example.com/posts/123',
+      isPermaLink: true,
+    }
+    const expected = {
+      '#text': 'https://example.com/posts/123',
+      '@isPermaLink': true,
+    }
+
+    expect(generateInReplyTo(value)).toEqual(expected)
+  })
+
+  it('should return undefined when value is missing', () => {
+    const value = {
+      isPermaLink: false,
+    }
+
+    // @ts-expect-error: This is for testing purposes.
+    expect(generateInReplyTo(value)).toBeUndefined()
+  })
+
+  it('should return undefined for non-object input', () => {
+    expect(generateInReplyTo(undefined)).toBeUndefined()
+    // @ts-expect-error: This is for testing purposes.
+    expect(generateInReplyTo(null)).toBeUndefined()
+    // @ts-expect-error: This is for testing purposes.
+    expect(generateInReplyTo('not an object')).toBeUndefined()
+  })
+})
+
 describe('generateFeed', () => {
   it('should generate complete feed with all properties', () => {
     const value = {
@@ -184,6 +241,7 @@ describe('generateFeed', () => {
       cloud: 'https://cloudserver.example.com/notify',
       blogroll: 'https://blog.example.com/blogroll.opml',
       self: 'http://example.com/feed.xml',
+      localTime: '2023-12-25 10:30:00',
     }
     const expected = {
       'source:account': [{ '@service': 'twitter', '#text': 'davewiner' }],
@@ -199,6 +257,7 @@ describe('generateFeed', () => {
       'source:cloud': 'https://cloudserver.example.com/notify',
       'source:blogroll': 'https://blog.example.com/blogroll.opml',
       'source:self': 'http://example.com/feed.xml',
+      'source:localTime': '2023-12-25 10:30:00',
     }
 
     expect(generateFeed(value)).toEqual(expected)
@@ -250,16 +309,22 @@ describe('generateItem', () => {
     const value = {
       markdown: '# Title\n\nThis is **markdown** content.',
       outlines: ['<outline text="Item 1"><outline text="Subitem 1"/></outline>'],
-      localTime: '2023-12-25 10:30:00',
       linkFull: 'http://example.com/very/long/url/that/was/shortened',
+      inReplyTo: {
+        value: 'did:plc:iwl32vekohccji6khfdt3clw',
+        isPermaLink: false,
+      },
     }
     const expected = {
       'source:markdown': '# Title\n\nThis is **markdown** content.',
       'source:outline': [
         { '#cdata': '<outline text="Item 1"><outline text="Subitem 1"/></outline>' },
       ],
-      'source:localTime': '2023-12-25 10:30:00',
       'source:linkFull': 'http://example.com/very/long/url/that/was/shortened',
+      'source:inReplyTo': {
+        '#text': 'did:plc:iwl32vekohccji6khfdt3clw',
+        '@isPermaLink': false,
+      },
     }
 
     expect(generateItem(value)).toEqual(expected)

--- a/src/namespaces/source/generate/utils.ts
+++ b/src/namespaces/source/generate/utils.ts
@@ -1,5 +1,6 @@
 import type { GenerateUtil } from '../../../common/types.js'
 import {
+  generateBoolean,
   generateCdataString,
   generateTextOrCdataString,
   isNonEmptyString,
@@ -62,6 +63,19 @@ export const generateSubscriptionList: GenerateUtil<SourceNs.SubscriptionList> =
   return trimObject(value)
 }
 
+export const generateInReplyTo: GenerateUtil<SourceNs.InReplyTo> = (inReplyTo) => {
+  if (!isObject(inReplyTo) || !isNonEmptyString(inReplyTo.value)) {
+    return
+  }
+
+  const value = {
+    ...generateTextOrCdataString(inReplyTo.value),
+    '@isPermaLink': generateBoolean(inReplyTo.isPermaLink),
+  }
+
+  return trimObject(value)
+}
+
 export const generateFeed: GenerateUtil<SourceNs.Feed> = (feed) => {
   if (!isObject(feed)) {
     return
@@ -75,6 +89,7 @@ export const generateFeed: GenerateUtil<SourceNs.Feed> = (feed) => {
     'source:cloud': generateCdataString(feed.cloud),
     'source:blogroll': generateCdataString(feed.blogroll),
     'source:self': generateCdataString(feed.self),
+    'source:localTime': generateCdataString(feed.localTime),
   }
 
   return trimObject(value)
@@ -88,8 +103,8 @@ export const generateItem: GenerateUtil<SourceNs.Item> = (item) => {
   const value = {
     'source:markdown': generateCdataString(item.markdown),
     'source:outline': trimArray(item.outlines, generateCdataString),
-    'source:localTime': generateCdataString(item.localTime),
     'source:linkFull': generateCdataString(item.linkFull),
+    'source:inReplyTo': generateInReplyTo(item.inReplyTo),
   }
 
   return trimObject(value)

--- a/src/namespaces/source/parse/utils.test.ts
+++ b/src/namespaces/source/parse/utils.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'bun:test'
 import {
   parseAccount,
   parseArchive,
+  parseInReplyTo,
   parseLikes,
   parseSubscriptionList,
   retrieveFeed,
@@ -184,6 +185,60 @@ describe('parseSubscriptionList', () => {
   })
 })
 
+describe('parseInReplyTo', () => {
+  it('should parse a bare permalink string value', () => {
+    const value = 'https://example.com/2026/05/16/hello-world.html'
+    const expected = {
+      value: 'https://example.com/2026/05/16/hello-world.html',
+    }
+
+    expect(parseInReplyTo(value)).toEqual(expected)
+  })
+
+  it('should parse value with isPermaLink set to false', () => {
+    const value = {
+      '@ispermalink': 'false',
+      '#text': 'did:plc:iwl32vekohccji6khfdt3clw',
+    }
+    const expected = {
+      value: 'did:plc:iwl32vekohccji6khfdt3clw',
+      isPermaLink: false,
+    }
+
+    expect(parseInReplyTo(value)).toEqual(expected)
+  })
+
+  it('should parse value with isPermaLink set to true', () => {
+    const value = {
+      '@ispermalink': 'true',
+      '#text': 'https://example.com/posts/123',
+    }
+    const expected = {
+      value: 'https://example.com/posts/123',
+      isPermaLink: true,
+    }
+
+    expect(parseInReplyTo(value)).toEqual(expected)
+  })
+
+  it('should handle CDATA value', () => {
+    const value = {
+      '#text': '<![CDATA[https://example.com/posts/123]]>',
+    }
+    const expected = {
+      value: 'https://example.com/posts/123',
+    }
+
+    expect(parseInReplyTo(value)).toEqual(expected)
+  })
+
+  it('should return undefined when value is empty', () => {
+    expect(parseInReplyTo('')).toBeUndefined()
+    expect(parseInReplyTo('   ')).toBeUndefined()
+    expect(parseInReplyTo(undefined)).toBeUndefined()
+  })
+})
+
 describe('retrieveFeed', () => {
   it('should parse complete feed with all properties', () => {
     const value = {
@@ -201,6 +256,7 @@ describe('retrieveFeed', () => {
       'source:cloud': 'https://cloudserver.example.com/notify',
       'source:blogroll': 'https://blog.example.com/blogroll.opml',
       'source:self': 'http://example.com/feed.xml',
+      'source:localtime': '2023-12-25 10:30:00',
     }
     const expected = {
       accounts: [{ service: 'twitter', value: 'johndoe' }],
@@ -214,6 +270,7 @@ describe('retrieveFeed', () => {
       cloud: 'https://cloudserver.example.com/notify',
       blogroll: 'https://blog.example.com/blogroll.opml',
       self: 'http://example.com/feed.xml',
+      localTime: '2023-12-25 10:30:00',
     }
 
     expect(retrieveFeed(value)).toEqual(expected)
@@ -248,14 +305,20 @@ describe('retrieveItem', () => {
     const value = {
       'source:markdown': '# Title\n\nThis is **markdown** content.',
       'source:outline': '<outline text="Item 1"><outline text="Subitem 1"/></outline>',
-      'source:localtime': '2023-12-25 10:30:00',
       'source:linkfull': 'http://example.com/very/long/url/that/was/shortened',
+      'source:inreplyto': {
+        '@ispermalink': 'false',
+        '#text': 'did:plc:iwl32vekohccji6khfdt3clw',
+      },
     }
     const expected = {
       markdown: '# Title\n\nThis is **markdown** content.',
       outlines: ['<outline text="Item 1"><outline text="Subitem 1"/></outline>'],
-      localTime: '2023-12-25 10:30:00',
       linkFull: 'http://example.com/very/long/url/that/was/shortened',
+      inReplyTo: {
+        value: 'did:plc:iwl32vekohccji6khfdt3clw',
+        isPermaLink: false,
+      },
     }
 
     expect(retrieveItem(value)).toEqual(expected)
@@ -267,6 +330,17 @@ describe('retrieveItem', () => {
     }
     const expected = {
       markdown: '**Bold** text in markdown',
+    }
+
+    expect(retrieveItem(value)).toEqual(expected)
+  })
+
+  it('should parse item with bare-string inReplyTo permalink', () => {
+    const value = {
+      'source:inreplyto': 'https://example.com/2026/05/16/hello-world.html',
+    }
+    const expected = {
+      inReplyTo: { value: 'https://example.com/2026/05/16/hello-world.html' },
     }
 
     expect(retrieveItem(value)).toEqual(expected)

--- a/src/namespaces/source/parse/utils.ts
+++ b/src/namespaces/source/parse/utils.ts
@@ -2,6 +2,7 @@ import type { ParsePartialUtil } from '../../../common/types.js'
 import {
   isObject,
   parseArrayOf,
+  parseBoolean,
   parseSingularOf,
   parseString,
   retrieveText,
@@ -66,6 +67,15 @@ export const parseSubscriptionList: ParsePartialUtil<SourceNs.SubscriptionList> 
   return trimObject(subscriptionList)
 }
 
+export const parseInReplyTo: ParsePartialUtil<SourceNs.InReplyTo> = (value) => {
+  const inReplyTo = {
+    value: parseString(retrieveText(value)),
+    isPermaLink: parseBoolean(value?.['@ispermalink']),
+  }
+
+  return trimObject(inReplyTo)
+}
+
 export const retrieveFeed: ParsePartialUtil<SourceNs.Feed> = (value) => {
   if (!isObject(value)) {
     return
@@ -81,6 +91,9 @@ export const retrieveFeed: ParsePartialUtil<SourceNs.Feed> = (value) => {
       parseString(retrieveText(value)),
     ),
     self: parseSingularOf(value['source:self'], (value) => parseString(retrieveText(value))),
+    localTime: parseSingularOf(value['source:localtime'], (value) =>
+      parseString(retrieveText(value)),
+    ),
   }
 
   return trimObject(feed)
@@ -96,12 +109,10 @@ export const retrieveItem: ParsePartialUtil<SourceNs.Item> = (value) => {
       parseString(retrieveText(value)),
     ),
     outlines: parseArrayOf(value['source:outline'], (value) => parseString(retrieveText(value))),
-    localTime: parseSingularOf(value['source:localtime'], (value) =>
-      parseString(retrieveText(value)),
-    ),
     linkFull: parseSingularOf(value['source:linkfull'], (value) =>
       parseString(retrieveText(value)),
     ),
+    inReplyTo: parseSingularOf(value['source:inreplyto'], parseInReplyTo),
   }
 
   return trimObject(item)


### PR DESCRIPTION
Implements two updates to the [source namespace](https://source.scripting.com/) spec:

- **`source:inReplyTo`** (new, item-level): identifies the item that this item replies to. Defaults to a permalink URL; supports the optional `isPermaLink="false"` attribute, following the RSS 2.0 `guid` model.
- **`source:localTime`**: moved from item-level to channel-level, matching the 3/18/2026 spec correction at source.scripting.com.

Both parse and generate are covered, with unit and RSS integration tests.
