### PR TITLE
feat: Add support for Byline namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ Feedsmith aims to fully support all major feed formats and namespaces in complet
 | [Administrative](https://feedsmith.dev/reference/namespaces/admin) | `<admin:*>` | RSS, Atom, RDF | ✅ | ✅ |
 | [Pingback](https://feedsmith.dev/reference/namespaces/pingback) | `<pingback:*>` | RSS, Atom | ✅ | ✅ |
 | [Trackback](https://feedsmith.dev/reference/namespaces/trackback) | `<trackback:*>` | RSS, Atom | ✅ | ✅ |
+| [Byline](https://feedsmith.dev/reference/namespaces/byline) | `<byline:*>` | RSS, Atom | ✅ | ✅ |
 | [Source](https://feedsmith.dev/reference/namespaces/source) | `<source:*>` | RSS | ✅ | ✅ |
 | [blogChannel](https://feedsmith.dev/reference/namespaces/blogchannel) | `<blogChannel:*>` | RSS | ✅ | ✅ |
 | [YouTube](https://feedsmith.dev/reference/namespaces/yt) | `<yt:*>` | Atom | ✅ | ✅ |

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -134,6 +134,7 @@ export default defineConfig({
               { text: 'Administrative', link: '/reference/namespaces/admin' },
               { text: 'Pingback', link: '/reference/namespaces/pingback' },
               { text: 'Trackback', link: '/reference/namespaces/trackback' },
+              { text: 'Byline', link: '/reference/namespaces/byline' },
               { text: 'Source', link: '/reference/namespaces/source' },
               { text: 'blogChannel', link: '/reference/namespaces/blogchannel' },
               { text: 'YouTube', link: '/reference/namespaces/yt' },

--- a/docs/index.md
+++ b/docs/index.md
@@ -93,6 +93,7 @@ Feedsmith aims to fully support all major feed formats and namespaces in complet
 | [Administrative](/reference/namespaces/admin) | `<admin:*>` | RSS, Atom, RDF | ✅ | ✅ |
 | [Pingback](/reference/namespaces/pingback) | `<pingback:*>` | RSS, Atom | ✅ | ✅ |
 | [Trackback](/reference/namespaces/trackback) | `<trackback:*>` | RSS, Atom | ✅ | ✅ |
+| [Byline](/reference/namespaces/byline) | `<byline:*>` | RSS, Atom | ✅ | ✅ |
 | [Source](/reference/namespaces/source) | `<source:*>` | RSS | ✅ | ✅ |
 | [blogChannel](/reference/namespaces/blogchannel) | `<blogChannel:*>` | RSS | ✅ | ✅ |
 | [YouTube](/reference/namespaces/yt) | `<yt:*>` | Atom | ✅ | ✅ |

--- a/docs/reference/namespaces/byline.md
+++ b/docs/reference/namespaces/byline.md
@@ -1,0 +1,47 @@
+---
+title: "Reference: Byline Namespace"
+---
+
+# Byline Namespace
+
+The Byline namespace adds structured author identity, context, and content perspective to feeds. It addresses "content collapse" — the loss of context when content from diverse sources arrives in a unified stream — by describing who an author is, their relationship to the content, and how an item should be read (reporting, opinion, satire, sponsored, and so on).
+
+<table>
+  <tbody>
+    <tr>
+      <th>Namespace URI</th>
+      <td><code>https://bylinespec.org/1.0</code></td>
+    </tr>
+    <tr>
+      <th>Specification</th>
+      <td><a href="https://www.bylinespec.org/spec" target="_blank">Byline Specification</a></td>
+    </tr>
+    <tr>
+      <th>Prefix</th>
+      <td><code>&lt;byline:*&gt;</code></td>
+    </tr>
+    <tr>
+      <th>Available in</th>
+      <td>
+        <a href="/reference/feeds/rss">RSS</a>,
+        <a href="/reference/feeds/atom">Atom</a>
+      </td>
+    </tr>
+    <tr>
+      <th>Property</th>
+      <td><code>byline</code></td>
+    </tr>
+  </tbody>
+</table>
+
+::: tip Draft specification
+Byline is a `0.1.0` draft. Field names and structure may change before it stabilizes. Feed-level authors and organizations are grouped in `<byline:contributors>` and `<byline:organizations>` containers, following the specification's examples.
+:::
+
+## Types
+
+<<< @/../src/namespaces/byline/common/types.ts#reference
+
+## Related
+
+- **[Parsing Namespaces](/parsing/namespaces)** - How namespace parsing works

--- a/src/common/config.ts
+++ b/src/common/config.ts
@@ -17,6 +17,10 @@ import {
   stopNodes as blogchannelStopNodes,
   uris as blogchannelUris,
 } from '../namespaces/blogchannel/common/config.js'
+import {
+  stopNodes as bylineStopNodes,
+  uris as bylineUris,
+} from '../namespaces/byline/common/config.js'
 import { stopNodes as ccStopNodes, uris as ccUris } from '../namespaces/cc/common/config.js'
 import {
   stopNodes as contentStopNodes,
@@ -150,6 +154,7 @@ export const namespaceUris = {
   thr: thrUris,
   dcterms: dctermsUris,
   wfw: wfwUris,
+  byline: bylineUris,
   source: sourceUris,
   feedpress: feedpressUris,
   yt: ytUris,
@@ -185,6 +190,7 @@ export const namespaceStopNodes = [
   ...appStopNodes,
   ...arxivStopNodes,
   ...blogchannelStopNodes,
+  ...bylineStopNodes,
   ...ccStopNodes,
   ...contentStopNodes,
   ...creativecommonsStopNodes,

--- a/src/feeds/atom/common/types.ts
+++ b/src/feeds/atom/common/types.ts
@@ -7,6 +7,7 @@ import type {
 import type { AdminNs } from '../../../namespaces/admin/common/types.js'
 import type { AppNs } from '../../../namespaces/app/common/types.js'
 import type { ArxivNs } from '../../../namespaces/arxiv/common/types.js'
+import type { BylineNs } from '../../../namespaces/byline/common/types.js'
 import type { CcNs } from '../../../namespaces/cc/common/types.js'
 import type { CreativeCommonsNs } from '../../../namespaces/creativecommons/common/types.js'
 import type { DcNs } from '../../../namespaces/dc/common/types.js'
@@ -115,6 +116,7 @@ export namespace Atom {
     yt?: YtNs.Item
     pingback?: PingbackNs.Item
     trackback?: TrackbackNs.Item
+    byline?: BylineNs.Item
   }
 
   export type Feed<TDate extends DateLike> = {
@@ -145,6 +147,7 @@ export namespace Atom {
     yt?: YtNs.Feed
     admin?: AdminNs.Feed
     pingback?: PingbackNs.Feed
+    byline?: BylineNs.Feed
   }
 }
 // #endregion reference

--- a/src/feeds/atom/generate/index.test.ts
+++ b/src/feeds/atom/generate/index.test.ts
@@ -1367,4 +1367,73 @@ describe('generate with lenient mode', () => {
 
     expect(generate(value)).toEqual(expected)
   })
+
+  it('should generate Atom feed with byline namespace', () => {
+    const value = {
+      id: 'https://example.com/feed',
+      title: 'Feed with Byline namespace',
+      updated: new Date('2024-01-10T12:00:00Z'),
+      byline: {
+        contributors: [
+          {
+            id: 'annie',
+            name: 'Annie Park',
+            urls: ['https://annie.example.com'],
+            profiles: [{ href: 'https://mastodon.social/@annie', rel: 'mastodon' }],
+            theme: { color: '#4A90A4', style: 'light' },
+          },
+        ],
+        organizations: [{ id: 'ttr', name: 'The Tech Review', type: 'news' }],
+      },
+      entries: [
+        {
+          id: 'https://example.com/entry/1',
+          title: 'First entry',
+          updated: new Date('2024-01-10T12:00:00Z'),
+          byline: {
+            author: { ref: 'annie' },
+            role: 'staff',
+            perspective: 'reporting',
+            affiliation: { org: 'ttr', relationship: 'employed', title: 'Senior Engineer' },
+          },
+        },
+      ],
+    }
+    const expected = `<?xml version="1.0" encoding="utf-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom" xmlns:byline="https://bylinespec.org/1.0">
+  <id>https://example.com/feed</id>
+  <title>Feed with Byline namespace</title>
+  <updated>2024-01-10T12:00:00.000Z</updated>
+  <byline:contributors>
+    <byline:person id="annie">
+      <byline:name>Annie Park</byline:name>
+      <byline:url>https://annie.example.com</byline:url>
+      <byline:profile href="https://mastodon.social/@annie" rel="mastodon"/>
+      <byline:theme color="#4A90A4" style="light"/>
+    </byline:person>
+  </byline:contributors>
+  <byline:organizations>
+    <byline:org id="ttr">
+      <byline:name>The Tech Review</byline:name>
+      <byline:type>news</byline:type>
+    </byline:org>
+  </byline:organizations>
+  <entry>
+    <id>https://example.com/entry/1</id>
+    <title>First entry</title>
+    <updated>2024-01-10T12:00:00.000Z</updated>
+    <byline:author ref="annie"/>
+    <byline:role>staff</byline:role>
+    <byline:perspective>reporting</byline:perspective>
+    <byline:affiliation>
+      <byline:org-ref ref="ttr"/>
+      <byline:relationship>employed</byline:relationship>
+      <byline:title>Senior Engineer</byline:title>
+    </byline:affiliation>
+  </entry>
+</feed>
+`
+
+    expect(generate(value)).toEqual(expected)
+  })
 })

--- a/src/feeds/atom/generate/utils.test.ts
+++ b/src/feeds/atom/generate/utils.test.ts
@@ -959,6 +959,35 @@ describe('generateEntry', () => {
 
     expect(generateEntry(value)).toEqual(expected)
   })
+
+  it('should generate entry with byline namespace properties', () => {
+    const value = {
+      id: 'https://example.com/entry/1',
+      title: 'Entry with Byline namespace',
+      updated: new Date('2023-03-15T12:00:00Z'),
+      byline: {
+        author: { ref: 'annie' },
+        role: 'staff',
+        perspective: 'reporting',
+        affiliation: { org: 'apple', relationship: 'employed', title: 'Senior Engineer' },
+      },
+    }
+    const expected = {
+      id: 'https://example.com/entry/1',
+      title: 'Entry with Byline namespace',
+      updated: '2023-03-15T12:00:00.000Z',
+      'byline:author': { '@ref': 'annie' },
+      'byline:role': 'staff',
+      'byline:perspective': 'reporting',
+      'byline:affiliation': {
+        'byline:org-ref': { '@ref': 'apple' },
+        'byline:relationship': 'employed',
+        'byline:title': 'Senior Engineer',
+      },
+    }
+
+    expect(generateEntry(value)).toEqual(expected)
+  })
 })
 
 describe('generateFeed', () => {
@@ -1801,6 +1830,35 @@ describe('generateFeed', () => {
         'googleplay:new-feed-url': 'https://example.com/new-feed.xml',
         'googleplay:email': 'podcast@example.com',
         'googleplay:category': [{ '@text': 'Technology' }, { '@text': 'Science' }],
+      },
+    }
+
+    expect(generateFeed(value)).toEqual(expected)
+  })
+
+  it('should generate Atom feed with byline namespace properties', () => {
+    const value = {
+      id: 'https://example.com/feed',
+      title: 'Feed with Byline namespace',
+      updated: new Date('2023-03-15T12:00:00Z'),
+      byline: {
+        contributors: [{ id: 'annie', name: 'Annie Park' }],
+        organizations: [{ id: 'ttr', name: 'The Tech Review', type: 'news' }],
+      },
+    }
+    const expected = {
+      feed: {
+        '@xmlns': 'http://www.w3.org/2005/Atom',
+        '@xmlns:byline': 'https://bylinespec.org/1.0',
+        id: 'https://example.com/feed',
+        title: 'Feed with Byline namespace',
+        updated: '2023-03-15T12:00:00.000Z',
+        'byline:contributors': {
+          'byline:person': [{ '@id': 'annie', 'byline:name': 'Annie Park' }],
+        },
+        'byline:organizations': {
+          'byline:org': [{ '@id': 'ttr', 'byline:name': 'The Tech Review', 'byline:type': 'news' }],
+        },
       },
     }
 

--- a/src/feeds/atom/generate/utils.ts
+++ b/src/feeds/atom/generate/utils.ts
@@ -17,6 +17,10 @@ import {
   generateAuthor as generateArxivAuthor,
   generateEntry as generateArxivEntry,
 } from '../../../namespaces/arxiv/generate/utils.js'
+import {
+  generateFeed as generateBylineFeed,
+  generateItem as generateBylineItem,
+} from '../../../namespaces/byline/generate/utils.js'
 import { generateItemOrFeed as generateCc } from '../../../namespaces/cc/generate/utils.js'
 import { generateItemOrFeed as generateCreativeCommonsItemOrFeed } from '../../../namespaces/creativecommons/generate/utils.js'
 import { generateItemOrFeed as generateDcItemOrFeed } from '../../../namespaces/dc/generate/utils.js'
@@ -203,6 +207,7 @@ export const generateEntry: GenerateUtil<Atom.Entry<DateLike>> = (entry, options
     ...generateYtItem(entry.yt),
     ...generatePingbackItem(entry.pingback),
     ...generateTrackbackItem(entry.trackback),
+    ...generateBylineItem(entry.byline),
   }
 }
 
@@ -268,6 +273,7 @@ export const generateFeed: GenerateUtil<Atom.Feed<DateLike>> = (feed, options) =
     ...generateYtFeed(feed.yt),
     ...generateAdminFeed(feed.admin),
     ...generatePingbackFeed(feed.pingback),
+    ...generateBylineFeed(feed.byline),
     ...valueEntries,
   }
 

--- a/src/feeds/atom/parse/utils.ts
+++ b/src/feeds/atom/parse/utils.ts
@@ -16,6 +16,10 @@ import {
   retrieveAuthor as retrieveArxivAuthor,
   retrieveEntry as retrieveArxivEntry,
 } from '../../../namespaces/arxiv/parse/utils.js'
+import {
+  retrieveFeed as retrieveBylineFeed,
+  retrieveItem as retrieveBylineItem,
+} from '../../../namespaces/byline/parse/utils.js'
 import { retrieveItemOrFeed as retrieveCc } from '../../../namespaces/cc/parse/utils.js'
 import { retrieveItemOrFeed as retrieveCreativeCommonsItemOrFeed } from '../../../namespaces/creativecommons/parse/utils.js'
 import { retrieveItemOrFeed as retrieveDcItemOrFeed } from '../../../namespaces/dc/parse/utils.js'
@@ -249,6 +253,7 @@ export const parseEntry: ParsePartialUtil<Atom.Entry<string>> = (value, options)
     yt: namespaces?.has('yt') ? retrieveYtItem(value) : undefined,
     pingback: namespaces?.has('pingback') ? retrievePingbackItem(value) : undefined,
     trackback: namespaces?.has('trackback') ? retrieveTrackbackItem(value) : undefined,
+    byline: namespaces?.has('byline') ? retrieveBylineItem(value) : undefined,
   }
 
   return trimObject(entry)
@@ -291,6 +296,7 @@ export const parseFeed: ParsePartialUtil<Atom.Feed<string>> = (value, options) =
     yt: namespaces?.has('yt') ? retrieveYtFeed(value) : undefined,
     admin: namespaces?.has('admin') ? retrieveAdminFeed(value) : undefined,
     pingback: namespaces?.has('pingback') ? retrievePingbackFeed(value) : undefined,
+    byline: namespaces?.has('byline') ? retrieveBylineFeed(value) : undefined,
   }
 
   return trimObject(feed)

--- a/src/feeds/atom/references/atom-ns.json
+++ b/src/feeds/atom/references/atom-ns.json
@@ -802,7 +802,19 @@
             "updated": "2025-05-10T16:45:00Z"
           }
         }
-      ]
+      ],
+      "byline": {
+        "author": {
+          "ref": "annie"
+        },
+        "role": "staff",
+        "perspective": "reporting",
+        "affiliation": {
+          "org": "ttr",
+          "relationship": "employed",
+          "title": "Senior Engineer"
+        }
+      }
     }
   ],
   "dc": {
@@ -1543,5 +1555,42 @@
     "elev": 360,
     "floor": 4,
     "radius": 50000
+  },
+  "byline": {
+    "contributors": [
+      {
+        "id": "annie",
+        "name": "Annie Park",
+        "context": "Designer and photographer.",
+        "urls": ["https://annie.example.com"],
+        "avatar": "https://annie.example.com/avatar.jpg",
+        "profiles": [
+          {
+            "href": "https://mastodon.social/@annie",
+            "rel": "mastodon"
+          }
+        ],
+        "now": "https://annie.example.com/now",
+        "uses": "https://annie.example.com/uses",
+        "theme": {
+          "color": "#4A90A4",
+          "accent": "#FF6B6B",
+          "style": "light"
+        }
+      }
+    ],
+    "organizations": [
+      {
+        "id": "ttr",
+        "name": "The Tech Review",
+        "url": "https://thetechreview.example.com",
+        "type": "news",
+        "theme": {
+          "color": "#1A1A2E",
+          "accent": "#E94560",
+          "style": "dark"
+        }
+      }
+    ]
   }
 }

--- a/src/feeds/atom/references/atom-ns.xml
+++ b/src/feeds/atom/references/atom-ns.xml
@@ -22,6 +22,7 @@
       xmlns:georss="http://www.georss.org/georss"
       xmlns:geo="http://www.w3.org/2003/01/geo/wgs84_pos#"
       xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+      xmlns:byline="https://bylinespec.org/1.0"
 >
   <id>example-feed</id>
   <title>Example Feed</title>
@@ -287,6 +288,28 @@
   <!-- YouTube Namespace: Feed Level Tags -->
   <yt:channelId>UCuAXFkgsw1L7xaCfnd5JJOw</yt:channelId>
   <yt:playlistId>PLrAXtmErZgOeiKm4sgNOknGvNjby9efdf</yt:playlistId>
+
+  <!-- Byline Namespace: Feed Level Tags -->
+  <byline:contributors>
+    <byline:person id="annie">
+      <byline:name>Annie Park</byline:name>
+      <byline:context>Designer and photographer.</byline:context>
+      <byline:url>https://annie.example.com</byline:url>
+      <byline:avatar>https://annie.example.com/avatar.jpg</byline:avatar>
+      <byline:profile href="https://mastodon.social/@annie" rel="mastodon"/>
+      <byline:now>https://annie.example.com/now</byline:now>
+      <byline:uses>https://annie.example.com/uses</byline:uses>
+      <byline:theme color="#4A90A4" accent="#FF6B6B" style="light"/>
+    </byline:person>
+  </byline:contributors>
+  <byline:organizations>
+    <byline:org id="ttr">
+      <byline:name>The Tech Review</byline:name>
+      <byline:url>https://thetechreview.example.com</byline:url>
+      <byline:type>news</byline:type>
+      <byline:theme color="#1A1A2E" accent="#E94560" style="dark"/>
+    </byline:org>
+  </byline:organizations>
 
   <entry>
     <id>example-entry</id>
@@ -578,5 +601,15 @@
     <!-- YouTube Namespace: Entry Level Tags -->
     <yt:videoId>dQw4w9WgXcQ</yt:videoId>
     <yt:channelId>UCuAXFkgsw1L7xaCfnd5JJOw</yt:channelId>
+
+    <!-- Byline Namespace: Entry Level Tags -->
+    <byline:author ref="annie"/>
+    <byline:role>staff</byline:role>
+    <byline:perspective>reporting</byline:perspective>
+    <byline:affiliation>
+      <byline:org-ref ref="ttr"/>
+      <byline:relationship>employed</byline:relationship>
+      <byline:title>Senior Engineer</byline:title>
+    </byline:affiliation>
   </entry>
 </feed>

--- a/src/feeds/rss/common/types.ts
+++ b/src/feeds/rss/common/types.ts
@@ -3,6 +3,7 @@ import type { AcastNs } from '../../../namespaces/acast/common/types.js'
 import type { AdminNs } from '../../../namespaces/admin/common/types.js'
 import type { AtomNs } from '../../../namespaces/atom/common/types.js'
 import type { BlogChannelNs } from '../../../namespaces/blogchannel/common/types.js'
+import type { BylineNs } from '../../../namespaces/byline/common/types.js'
 import type { CcNs } from '../../../namespaces/cc/common/types.js'
 import type { ContentNs } from '../../../namespaces/content/common/types.js'
 import type { CreativeCommonsNs } from '../../../namespaces/creativecommons/common/types.js'
@@ -112,6 +113,7 @@ export namespace Rss {
     dcterms?: DcTermsNs.ItemOrFeed<TDate>
     prism?: PrismNs.Item<TDate>
     wfw?: WfwNs.Item
+    byline?: BylineNs.Item
     sourceNs?: SourceNs.Item
     rawvoice?: RawVoiceNs.Item
     spotify?: SpotifyNs.Item
@@ -159,6 +161,7 @@ export namespace Rss {
     feedpress?: FeedPressNs.Feed
     opensearch?: OpenSearchNs.Feed
     admin?: AdminNs.Feed
+    byline?: BylineNs.Feed
     sourceNs?: SourceNs.Feed
     blogChannel?: BlogChannelNs.Feed
     rawvoice?: RawVoiceNs.Feed<TDate>

--- a/src/feeds/rss/generate/index.test.ts
+++ b/src/feeds/rss/generate/index.test.ts
@@ -1314,4 +1314,69 @@ describe('generate with lenient mode', () => {
 
     expect(generate(value)).toEqual(expected)
   })
+
+  it('should generate RSS with byline namespace', () => {
+    const value = {
+      title: 'Feed with byline namespace',
+      description: 'Test feed with Byline namespace',
+      byline: {
+        contributors: [
+          {
+            id: 'annie',
+            name: 'Annie Park',
+            urls: ['https://annie.example.com'],
+            profiles: [{ href: 'https://mastodon.social/@annie', rel: 'mastodon' }],
+            theme: { color: '#4A90A4', style: 'light' },
+          },
+        ],
+        organizations: [{ id: 'ttr', name: 'The Tech Review', type: 'news' }],
+      },
+      items: [
+        {
+          title: 'First item',
+          byline: {
+            author: { ref: 'annie' },
+            role: 'staff',
+            perspective: 'reporting',
+            affiliation: { org: 'ttr', relationship: 'employed', title: 'Senior Engineer' },
+          },
+        },
+      ],
+    }
+    const expected = `<?xml version="1.0" encoding="utf-8"?>
+<rss version="2.0" xmlns:byline="https://bylinespec.org/1.0">
+  <channel>
+    <title>Feed with byline namespace</title>
+    <description>Test feed with Byline namespace</description>
+    <byline:contributors>
+      <byline:person id="annie">
+        <byline:name>Annie Park</byline:name>
+        <byline:url>https://annie.example.com</byline:url>
+        <byline:profile href="https://mastodon.social/@annie" rel="mastodon"/>
+        <byline:theme color="#4A90A4" style="light"/>
+      </byline:person>
+    </byline:contributors>
+    <byline:organizations>
+      <byline:org id="ttr">
+        <byline:name>The Tech Review</byline:name>
+        <byline:type>news</byline:type>
+      </byline:org>
+    </byline:organizations>
+    <item>
+      <title>First item</title>
+      <byline:author ref="annie"/>
+      <byline:role>staff</byline:role>
+      <byline:perspective>reporting</byline:perspective>
+      <byline:affiliation>
+        <byline:org-ref ref="ttr"/>
+        <byline:relationship>employed</byline:relationship>
+        <byline:title>Senior Engineer</byline:title>
+      </byline:affiliation>
+    </item>
+  </channel>
+</rss>
+`
+
+    expect(generate(value)).toEqual(expected)
+  })
 })

--- a/src/feeds/rss/generate/utils.test.ts
+++ b/src/feeds/rss/generate/utils.test.ts
@@ -1040,6 +1040,31 @@ describe('generateItem', () => {
 
     expect(generateItem(value)).toEqual(expected)
   })
+
+  it('should generate item with byline namespace properties', () => {
+    const value = {
+      title: 'Item with byline namespace',
+      byline: {
+        author: { ref: 'annie' },
+        role: 'staff',
+        perspective: 'reporting',
+        affiliation: { org: 'apple', relationship: 'employed', title: 'Senior Engineer' },
+      },
+    }
+    const expected = {
+      title: 'Item with byline namespace',
+      'byline:author': { '@ref': 'annie' },
+      'byline:role': 'staff',
+      'byline:perspective': 'reporting',
+      'byline:affiliation': {
+        'byline:org-ref': { '@ref': 'apple' },
+        'byline:relationship': 'employed',
+        'byline:title': 'Senior Engineer',
+      },
+    }
+
+    expect(generateItem(value)).toEqual(expected)
+  })
 })
 
 describe('generateFeed', () => {
@@ -2101,6 +2126,47 @@ describe('generateFeed', () => {
           title: 'Licensed Feed',
           description: 'A feed with Creative Commons properties',
           'creativeCommons:license': ['http://creativecommons.org/licenses/by-nc-nd/2.0/'],
+        },
+      },
+    }
+
+    expect(generateFeed(value)).toEqual(expected)
+  })
+
+  it('should generate RSS feed with byline namespace properties', () => {
+    const value = {
+      title: 'Feed with byline namespace',
+      description: 'A feed with Byline contributors and organizations',
+      byline: {
+        contributors: [{ id: 'annie', name: 'Annie Park', urls: ['https://annie.example.com'] }],
+        organizations: [{ id: 'ttr', name: 'The Tech Review', type: 'news' }],
+      },
+    }
+    const expected = {
+      rss: {
+        '@version': '2.0',
+        '@xmlns:byline': 'https://bylinespec.org/1.0',
+        channel: {
+          title: 'Feed with byline namespace',
+          description: 'A feed with Byline contributors and organizations',
+          'byline:contributors': {
+            'byline:person': [
+              {
+                '@id': 'annie',
+                'byline:name': 'Annie Park',
+                'byline:url': ['https://annie.example.com'],
+              },
+            ],
+          },
+          'byline:organizations': {
+            'byline:org': [
+              {
+                '@id': 'ttr',
+                'byline:name': 'The Tech Review',
+                'byline:type': 'news',
+              },
+            ],
+          },
         },
       },
     }

--- a/src/feeds/rss/generate/utils.ts
+++ b/src/feeds/rss/generate/utils.ts
@@ -22,6 +22,10 @@ import {
   generateFeed as generateAtomFeed,
 } from '../../../namespaces/atom/generate/utils.js'
 import { generateFeed as generateBlogChannelFeed } from '../../../namespaces/blogchannel/generate/utils.js'
+import {
+  generateFeed as generateBylineFeed,
+  generateItem as generateBylineItem,
+} from '../../../namespaces/byline/generate/utils.js'
 import { generateItemOrFeed as generateCc } from '../../../namespaces/cc/generate/utils.js'
 import { generateItem as generateContentItem } from '../../../namespaces/content/generate/utils.js'
 import { generateItemOrFeed as generateCreativeCommonsItemOrFeed } from '../../../namespaces/creativecommons/generate/utils.js'
@@ -241,6 +245,7 @@ export const generateItem: GenerateUtil<Rss.Item<DateLike, Rss.PersonLike>> = (i
     ...generateDctermsItemOrFeed(item.dcterms),
     ...generatePrismItem(item.prism),
     ...generateWfwItem(item.wfw),
+    ...generateBylineItem(item.byline),
     ...generateSourceItem(item.sourceNs),
     ...generateRawVoiceItem(item.rawvoice),
     ...generateSpotifyItem(item.spotify),
@@ -293,6 +298,7 @@ export const generateFeed: GenerateUtil<Rss.Feed<DateLike, Rss.PersonLike>> = (f
     ...generateFeedPressFeed(feed.feedpress),
     ...generateOpenSearchFeed(feed.opensearch),
     ...generateAdminFeed(feed.admin),
+    ...generateBylineFeed(feed.byline),
     ...generateSourceFeed(feed.sourceNs),
     ...generateBlogChannelFeed(feed.blogChannel),
     ...generateRawVoiceFeed(feed.rawvoice),

--- a/src/feeds/rss/parse/utils.ts
+++ b/src/feeds/rss/parse/utils.ts
@@ -23,6 +23,10 @@ import {
   retrieveFeed as retrieveAtomFeed,
 } from '../../../namespaces/atom/parse/utils.js'
 import { retrieveFeed as retrieveBlogChannelFeed } from '../../../namespaces/blogchannel/parse/utils.js'
+import {
+  retrieveFeed as retrieveBylineFeed,
+  retrieveItem as retrieveBylineItem,
+} from '../../../namespaces/byline/parse/utils.js'
 import { retrieveItemOrFeed as retrieveCc } from '../../../namespaces/cc/parse/utils.js'
 import { retrieveItem as retrieveContentItem } from '../../../namespaces/content/parse/utils.js'
 import { retrieveItemOrFeed as retrieveCreativeCommonsItemOrFeed } from '../../../namespaces/creativecommons/parse/utils.js'
@@ -237,6 +241,7 @@ export const parseItem: ParsePartialUtil<Rss.Item<string>> = (value) => {
     dcterms: namespaces.has('dcterms') ? retrieveDctermsItemOrFeed(value) : undefined,
     prism: namespaces.has('prism') ? retrievePrismItem(value) : undefined,
     wfw: namespaces.has('wfw') ? retrieveWfwItem(value) : undefined,
+    byline: namespaces.has('byline') ? retrieveBylineItem(value) : undefined,
     sourceNs: namespaces.has('source') ? retrieveSourceItem(value) : undefined,
     rawvoice: namespaces.has('rawvoice') ? retrieveRawVoiceItem(value) : undefined,
     spotify: namespaces.has('spotify') ? retrieveSpotifyItem(value) : undefined,
@@ -297,6 +302,7 @@ export const parseFeed: ParsePartialUtil<Rss.Feed<string>, ParseOptions> = (valu
     feedpress: namespaces.has('feedpress') ? retrieveFeedPressFeed(channel) : undefined,
     opensearch: namespaces.has('opensearch') ? retrieveOpenSearchFeed(channel) : undefined,
     admin: namespaces.has('admin') ? retrieveAdminFeed(channel) : undefined,
+    byline: namespaces.has('byline') ? retrieveBylineFeed(channel) : undefined,
     sourceNs: namespaces.has('source') ? retrieveSourceFeed(channel) : undefined,
     blogChannel: namespaces.has('blogchannel') ? retrieveBlogChannelFeed(channel) : undefined,
     rawvoice: namespaces.has('rawvoice') ? retrieveRawVoiceFeed(channel) : undefined,

--- a/src/feeds/rss/references/rss-ns.json
+++ b/src/feeds/rss/references/rss-ns.json
@@ -1044,6 +1044,18 @@
         "ping": "https://example.com/trackback/123",
         "abouts": ["https://blog1.com/trackback/456", "https://blog2.com/trackback/789"]
       },
+      "byline": {
+        "author": {
+          "ref": "annie"
+        },
+        "role": "staff",
+        "perspective": "reporting",
+        "affiliation": {
+          "org": "ttr",
+          "relationship": "employed",
+          "title": "Senior Engineer"
+        }
+      },
       "sourceNs": {
         "markdown": "# Understanding XML Namespaces - This article explores the power and flexibility of XML namespaces in modern web syndication.",
         "outlines": [
@@ -2105,6 +2117,43 @@
   },
   "pingback": {
     "to": "https://example.com/pingback-service"
+  },
+  "byline": {
+    "contributors": [
+      {
+        "id": "annie",
+        "name": "Annie Park",
+        "context": "Designer and photographer.",
+        "urls": ["https://annie.example.com"],
+        "avatar": "https://annie.example.com/avatar.jpg",
+        "profiles": [
+          {
+            "href": "https://mastodon.social/@annie",
+            "rel": "mastodon"
+          }
+        ],
+        "now": "https://annie.example.com/now",
+        "uses": "https://annie.example.com/uses",
+        "theme": {
+          "color": "#4A90A4",
+          "accent": "#FF6B6B",
+          "style": "light"
+        }
+      }
+    ],
+    "organizations": [
+      {
+        "id": "ttr",
+        "name": "The Tech Review",
+        "url": "https://thetechreview.example.com",
+        "type": "news",
+        "theme": {
+          "color": "#1A1A2E",
+          "accent": "#E94560",
+          "style": "dark"
+        }
+      }
+    ]
   },
   "sourceNs": {
     "accounts": [

--- a/src/feeds/rss/references/rss-ns.xml
+++ b/src/feeds/rss/references/rss-ns.xml
@@ -24,6 +24,7 @@
      xmlns:admin="http://webns.net/mvcb/"
      xmlns:pingback="http://purl.org/net/pingback/"
      xmlns:trackback="http://madskills.com/public/xml/rss/module/trackback/"
+     xmlns:byline="https://bylinespec.org/1.0"
      xmlns:source="http://source.scripting.com/"
      xmlns:blogChannel="http://backend.userland.com/blogChannelModule"
      xmlns:georss="http://www.georss.org/georss"
@@ -392,6 +393,28 @@
 
     <!-- Pingback Namespace: Channel Level Tags -->
     <pingback:to>https://example.com/pingback-service</pingback:to>
+
+    <!-- Byline Namespace: Channel Level Tags -->
+    <byline:contributors>
+      <byline:person id="annie">
+        <byline:name>Annie Park</byline:name>
+        <byline:context>Designer and photographer.</byline:context>
+        <byline:url>https://annie.example.com</byline:url>
+        <byline:avatar>https://annie.example.com/avatar.jpg</byline:avatar>
+        <byline:profile href="https://mastodon.social/@annie" rel="mastodon"/>
+        <byline:now>https://annie.example.com/now</byline:now>
+        <byline:uses>https://annie.example.com/uses</byline:uses>
+        <byline:theme color="#4A90A4" accent="#FF6B6B" style="light"/>
+      </byline:person>
+    </byline:contributors>
+    <byline:organizations>
+      <byline:org id="ttr">
+        <byline:name>The Tech Review</byline:name>
+        <byline:url>https://thetechreview.example.com</byline:url>
+        <byline:type>news</byline:type>
+        <byline:theme color="#1A1A2E" accent="#E94560" style="dark"/>
+      </byline:org>
+    </byline:organizations>
 
     <!-- Source Namespace: Channel Level Tags -->
     <source:account service="twitter">johndoe</source:account>
@@ -838,6 +861,16 @@
       <trackback:ping>https://example.com/trackback/123</trackback:ping>
       <trackback:about>https://blog1.com/trackback/456</trackback:about>
       <trackback:about>https://blog2.com/trackback/789</trackback:about>
+
+      <!-- Byline Namespace: Item Level Tags -->
+      <byline:author ref="annie"/>
+      <byline:role>staff</byline:role>
+      <byline:perspective>reporting</byline:perspective>
+      <byline:affiliation>
+        <byline:org-ref ref="ttr"/>
+        <byline:relationship>employed</byline:relationship>
+        <byline:title>Senior Engineer</byline:title>
+      </byline:affiliation>
 
       <!-- Source Namespace: Item Level Tags -->
       <source:markdown># Understanding XML Namespaces - This article explores the power and flexibility of XML namespaces in modern web syndication.</source:markdown>

--- a/src/namespaces/byline/common/config.ts
+++ b/src/namespaces/byline/common/config.ts
@@ -1,0 +1,20 @@
+export const uris = [
+  'https://bylinespec.org/1.0', // Official URI.
+  'http://bylinespec.org/1.0',
+  'https://bylinespec.org/1.0/',
+  'http://bylinespec.org/1.0/',
+]
+
+export const stopNodes = [
+  '*.byline:name',
+  '*.byline:context',
+  '*.byline:url',
+  '*.byline:avatar',
+  '*.byline:type',
+  '*.byline:now',
+  '*.byline:uses',
+  '*.byline:role',
+  '*.byline:perspective',
+  '*.byline:relationship',
+  '*.byline:title',
+]

--- a/src/namespaces/byline/common/types.ts
+++ b/src/namespaces/byline/common/types.ts
@@ -1,0 +1,57 @@
+// #region reference
+export namespace BylineNs {
+  export type Profile = {
+    href: string
+    rel?: string
+  }
+
+  export type Theme = {
+    color?: string
+    accent?: string
+    style?: string
+  }
+
+  export type Person = {
+    id?: string
+    name: string
+    context?: string
+    urls?: Array<string>
+    avatar?: string
+    profiles?: Array<Profile>
+    now?: string
+    uses?: string
+    theme?: Theme
+  }
+
+  export type Org = {
+    id?: string
+    name: string
+    url?: string
+    type?: string
+    theme?: Theme
+  }
+
+  export type Author = {
+    ref?: string
+    person?: Person
+  }
+
+  export type Affiliation = {
+    org?: string
+    relationship?: string
+    title?: string
+  }
+
+  export type Feed = {
+    contributors?: Array<Person>
+    organizations?: Array<Org>
+  }
+
+  export type Item = {
+    author?: Author
+    role?: string
+    perspective?: string
+    affiliation?: Affiliation
+  }
+}
+// #endregion reference

--- a/src/namespaces/byline/generate/utils.test.ts
+++ b/src/namespaces/byline/generate/utils.test.ts
@@ -1,0 +1,354 @@
+import { describe, expect, it } from 'bun:test'
+import {
+  generateAffiliation,
+  generateAuthor,
+  generateFeed,
+  generateItem,
+  generateOrg,
+  generatePerson,
+  generateProfile,
+  generateTheme,
+} from './utils.js'
+
+describe('generateProfile', () => {
+  it('should generate profile with href and rel', () => {
+    const value = {
+      href: 'https://mastodon.social/@annie',
+      rel: 'mastodon',
+    }
+    const expected = {
+      '@href': 'https://mastodon.social/@annie',
+      '@rel': 'mastodon',
+    }
+
+    expect(generateProfile(value)).toEqual(expected)
+  })
+
+  it('should generate profile with only href', () => {
+    const value = {
+      href: 'https://example.com',
+    }
+    const expected = {
+      '@href': 'https://example.com',
+    }
+
+    expect(generateProfile(value)).toEqual(expected)
+  })
+
+  it('should return undefined when href is missing', () => {
+    // @ts-expect-error: This is for testing purposes.
+    expect(generateProfile({ rel: 'mastodon' })).toBeUndefined()
+  })
+
+  it('should handle non-object inputs', () => {
+    // @ts-expect-error: This is for testing purposes.
+    expect(generateProfile('string')).toBeUndefined()
+    expect(generateProfile(undefined)).toBeUndefined()
+    // @ts-expect-error: This is for testing purposes.
+    expect(generateProfile(null)).toBeUndefined()
+  })
+})
+
+describe('generateTheme', () => {
+  it('should generate theme with all attributes', () => {
+    const value = {
+      color: '#4A90A4',
+      accent: '#FF6B6B',
+      style: 'light',
+    }
+    const expected = {
+      '@color': '#4A90A4',
+      '@accent': '#FF6B6B',
+      '@style': 'light',
+    }
+
+    expect(generateTheme(value)).toEqual(expected)
+  })
+
+  it('should generate theme with only style', () => {
+    const value = {
+      style: 'dark',
+    }
+    const expected = {
+      '@style': 'dark',
+    }
+
+    expect(generateTheme(value)).toEqual(expected)
+  })
+
+  it('should return undefined for empty object', () => {
+    expect(generateTheme({})).toBeUndefined()
+  })
+
+  it('should handle non-object inputs', () => {
+    // @ts-expect-error: This is for testing purposes.
+    expect(generateTheme('string')).toBeUndefined()
+    expect(generateTheme(undefined)).toBeUndefined()
+  })
+})
+
+describe('generatePerson', () => {
+  it('should generate complete person with all properties', () => {
+    const value = {
+      id: 'annie',
+      name: 'Annie Park',
+      context: 'Designer and photographer.',
+      urls: ['https://annie.example.com'],
+      avatar: 'https://annie.example.com/avatar.jpg',
+      profiles: [
+        { href: 'https://mastodon.social/@annie', rel: 'mastodon' },
+        { href: 'https://github.com/annie', rel: 'github' },
+      ],
+      now: 'https://annie.example.com/now',
+      uses: 'https://annie.example.com/uses',
+      theme: { color: '#4A90A4', accent: '#FF6B6B', style: 'light' },
+    }
+    const expected = {
+      '@id': 'annie',
+      'byline:name': 'Annie Park',
+      'byline:context': 'Designer and photographer.',
+      'byline:url': ['https://annie.example.com'],
+      'byline:avatar': 'https://annie.example.com/avatar.jpg',
+      'byline:profile': [
+        { '@href': 'https://mastodon.social/@annie', '@rel': 'mastodon' },
+        { '@href': 'https://github.com/annie', '@rel': 'github' },
+      ],
+      'byline:now': 'https://annie.example.com/now',
+      'byline:uses': 'https://annie.example.com/uses',
+      'byline:theme': { '@color': '#4A90A4', '@accent': '#FF6B6B', '@style': 'light' },
+    }
+
+    expect(generatePerson(value)).toEqual(expected)
+  })
+
+  it('should generate person with only name', () => {
+    const value = {
+      name: 'Marcus Chen',
+    }
+    const expected = {
+      'byline:name': 'Marcus Chen',
+    }
+
+    expect(generatePerson(value)).toEqual(expected)
+  })
+
+  it('should return undefined when name is missing', () => {
+    // @ts-expect-error: This is for testing purposes.
+    expect(generatePerson({ id: 'annie' })).toBeUndefined()
+  })
+
+  it('should handle non-object inputs', () => {
+    // @ts-expect-error: This is for testing purposes.
+    expect(generatePerson('string')).toBeUndefined()
+    expect(generatePerson(undefined)).toBeUndefined()
+    // @ts-expect-error: This is for testing purposes.
+    expect(generatePerson(null)).toBeUndefined()
+  })
+})
+
+describe('generateOrg', () => {
+  it('should generate complete org with all properties', () => {
+    const value = {
+      id: 'ttr',
+      name: 'The Tech Review',
+      url: 'https://thetechreview.example.com',
+      type: 'news',
+      theme: { color: '#1A1A2E', accent: '#E94560', style: 'dark' },
+    }
+    const expected = {
+      '@id': 'ttr',
+      'byline:name': 'The Tech Review',
+      'byline:url': 'https://thetechreview.example.com',
+      'byline:type': 'news',
+      'byline:theme': { '@color': '#1A1A2E', '@accent': '#E94560', '@style': 'dark' },
+    }
+
+    expect(generateOrg(value)).toEqual(expected)
+  })
+
+  it('should return undefined when name is missing', () => {
+    // @ts-expect-error: This is for testing purposes.
+    expect(generateOrg({ id: 'ttr' })).toBeUndefined()
+  })
+
+  it('should handle non-object inputs', () => {
+    // @ts-expect-error: This is for testing purposes.
+    expect(generateOrg('string')).toBeUndefined()
+    expect(generateOrg(undefined)).toBeUndefined()
+  })
+})
+
+describe('generateAuthor', () => {
+  it('should generate author reference by ref', () => {
+    const value = {
+      ref: 'annie',
+    }
+    const expected = {
+      '@ref': 'annie',
+    }
+
+    expect(generateAuthor(value)).toEqual(expected)
+  })
+
+  it('should generate author with inline person', () => {
+    const value = {
+      person: {
+        id: 'guest-sara',
+        name: 'Sara Mitchell',
+        context: 'Guest contributor.',
+      },
+    }
+    const expected = {
+      'byline:person': {
+        '@id': 'guest-sara',
+        'byline:name': 'Sara Mitchell',
+        'byline:context': 'Guest contributor.',
+      },
+    }
+
+    expect(generateAuthor(value)).toEqual(expected)
+  })
+
+  it('should return undefined for empty object', () => {
+    expect(generateAuthor({})).toBeUndefined()
+  })
+
+  it('should handle non-object inputs', () => {
+    // @ts-expect-error: This is for testing purposes.
+    expect(generateAuthor('string')).toBeUndefined()
+    expect(generateAuthor(undefined)).toBeUndefined()
+  })
+})
+
+describe('generateAffiliation', () => {
+  it('should generate complete affiliation', () => {
+    const value = {
+      org: 'apple',
+      relationship: 'employed',
+      title: 'Senior Engineer',
+    }
+    const expected = {
+      'byline:org-ref': { '@ref': 'apple' },
+      'byline:relationship': 'employed',
+      'byline:title': 'Senior Engineer',
+    }
+
+    expect(generateAffiliation(value)).toEqual(expected)
+  })
+
+  it('should generate affiliation with only relationship', () => {
+    const value = {
+      relationship: 'sponsored',
+    }
+    const expected = {
+      'byline:relationship': 'sponsored',
+    }
+
+    expect(generateAffiliation(value)).toEqual(expected)
+  })
+
+  it('should return undefined for empty object', () => {
+    expect(generateAffiliation({})).toBeUndefined()
+  })
+
+  it('should handle non-object inputs', () => {
+    // @ts-expect-error: This is for testing purposes.
+    expect(generateAffiliation('string')).toBeUndefined()
+    expect(generateAffiliation(undefined)).toBeUndefined()
+  })
+})
+
+describe('generateFeed', () => {
+  it('should generate feed with contributors and organizations', () => {
+    const value = {
+      contributors: [
+        { id: 'marcus', name: 'Marcus Chen' },
+        { id: 'elena', name: 'Elena Vance' },
+      ],
+      organizations: [{ id: 'ttr', name: 'The Tech Review' }],
+    }
+    const expected = {
+      'byline:contributors': {
+        'byline:person': [
+          { '@id': 'marcus', 'byline:name': 'Marcus Chen' },
+          { '@id': 'elena', 'byline:name': 'Elena Vance' },
+        ],
+      },
+      'byline:organizations': {
+        'byline:org': [{ '@id': 'ttr', 'byline:name': 'The Tech Review' }],
+      },
+    }
+
+    expect(generateFeed(value)).toEqual(expected)
+  })
+
+  it('should generate feed with only contributors', () => {
+    const value = {
+      contributors: [{ name: 'Annie Park' }],
+    }
+    const expected = {
+      'byline:contributors': {
+        'byline:person': [{ 'byline:name': 'Annie Park' }],
+      },
+    }
+
+    expect(generateFeed(value)).toEqual(expected)
+  })
+
+  it('should return undefined for empty object', () => {
+    expect(generateFeed({})).toBeUndefined()
+  })
+
+  it('should handle non-object inputs', () => {
+    // @ts-expect-error: This is for testing purposes.
+    expect(generateFeed('string')).toBeUndefined()
+    expect(generateFeed(undefined)).toBeUndefined()
+    // @ts-expect-error: This is for testing purposes.
+    expect(generateFeed(null)).toBeUndefined()
+  })
+})
+
+describe('generateItem', () => {
+  it('should generate complete item with all properties', () => {
+    const value = {
+      author: { ref: 'marcus' },
+      role: 'staff',
+      perspective: 'reporting',
+      affiliation: { org: 'apple', relationship: 'employed' },
+    }
+    const expected = {
+      'byline:author': { '@ref': 'marcus' },
+      'byline:role': 'staff',
+      'byline:perspective': 'reporting',
+      'byline:affiliation': {
+        'byline:org-ref': { '@ref': 'apple' },
+        'byline:relationship': 'employed',
+      },
+    }
+
+    expect(generateItem(value)).toEqual(expected)
+  })
+
+  it('should generate item with only perspective', () => {
+    const value = {
+      perspective: 'personal',
+    }
+    const expected = {
+      'byline:perspective': 'personal',
+    }
+
+    expect(generateItem(value)).toEqual(expected)
+  })
+
+  it('should return undefined for empty object', () => {
+    expect(generateItem({})).toBeUndefined()
+  })
+
+  it('should handle non-object inputs', () => {
+    // @ts-expect-error: This is for testing purposes.
+    expect(generateItem('string')).toBeUndefined()
+    expect(generateItem(undefined)).toBeUndefined()
+    // @ts-expect-error: This is for testing purposes.
+    expect(generateItem(null)).toBeUndefined()
+  })
+})

--- a/src/namespaces/byline/generate/utils.ts
+++ b/src/namespaces/byline/generate/utils.ts
@@ -1,0 +1,131 @@
+import type { GenerateUtil } from '../../../common/types.js'
+import {
+  generateCdataString,
+  generatePlainString,
+  isNonEmptyString,
+  isObject,
+  trimArray,
+  trimObject,
+} from '../../../common/utils.js'
+import type { BylineNs } from '../common/types.js'
+
+export const generateProfile: GenerateUtil<BylineNs.Profile> = (profile) => {
+  if (!isObject(profile) || !isNonEmptyString(profile.href)) {
+    return
+  }
+
+  const value = {
+    '@href': profile.href,
+    '@rel': generatePlainString(profile.rel),
+  }
+
+  return trimObject(value)
+}
+
+export const generateTheme: GenerateUtil<BylineNs.Theme> = (theme) => {
+  if (!isObject(theme)) {
+    return
+  }
+
+  const value = {
+    '@color': generatePlainString(theme.color),
+    '@accent': generatePlainString(theme.accent),
+    '@style': generatePlainString(theme.style),
+  }
+
+  return trimObject(value)
+}
+
+export const generatePerson: GenerateUtil<BylineNs.Person> = (person) => {
+  if (!isObject(person) || !isNonEmptyString(person.name)) {
+    return
+  }
+
+  const value = {
+    '@id': generatePlainString(person.id),
+    'byline:name': generateCdataString(person.name),
+    'byline:context': generateCdataString(person.context),
+    'byline:url': trimArray(person.urls, generateCdataString),
+    'byline:avatar': generateCdataString(person.avatar),
+    'byline:profile': trimArray(person.profiles, generateProfile),
+    'byline:now': generateCdataString(person.now),
+    'byline:uses': generateCdataString(person.uses),
+    'byline:theme': generateTheme(person.theme),
+  }
+
+  return trimObject(value)
+}
+
+export const generateOrg: GenerateUtil<BylineNs.Org> = (org) => {
+  if (!isObject(org) || !isNonEmptyString(org.name)) {
+    return
+  }
+
+  const value = {
+    '@id': generatePlainString(org.id),
+    'byline:name': generateCdataString(org.name),
+    'byline:url': generateCdataString(org.url),
+    'byline:type': generateCdataString(org.type),
+    'byline:theme': generateTheme(org.theme),
+  }
+
+  return trimObject(value)
+}
+
+export const generateAuthor: GenerateUtil<BylineNs.Author> = (author) => {
+  if (!isObject(author)) {
+    return
+  }
+
+  const value = {
+    '@ref': generatePlainString(author.ref),
+    'byline:person': generatePerson(author.person),
+  }
+
+  return trimObject(value)
+}
+
+export const generateAffiliation: GenerateUtil<BylineNs.Affiliation> = (affiliation) => {
+  if (!isObject(affiliation)) {
+    return
+  }
+
+  const value = {
+    'byline:org-ref': isNonEmptyString(affiliation.org) ? { '@ref': affiliation.org } : undefined,
+    'byline:relationship': generateCdataString(affiliation.relationship),
+    'byline:title': generateCdataString(affiliation.title),
+  }
+
+  return trimObject(value)
+}
+
+export const generateFeed: GenerateUtil<BylineNs.Feed> = (feed) => {
+  if (!isObject(feed)) {
+    return
+  }
+
+  const persons = trimArray(feed.contributors, generatePerson)
+  const organizations = trimArray(feed.organizations, generateOrg)
+
+  const value = {
+    'byline:contributors': persons ? { 'byline:person': persons } : undefined,
+    'byline:organizations': organizations ? { 'byline:org': organizations } : undefined,
+  }
+
+  return trimObject(value)
+}
+
+export const generateItem: GenerateUtil<BylineNs.Item> = (item) => {
+  if (!isObject(item)) {
+    return
+  }
+
+  const value = {
+    'byline:author': generateAuthor(item.author),
+    'byline:role': generateCdataString(item.role),
+    'byline:perspective': generateCdataString(item.perspective),
+    'byline:affiliation': generateAffiliation(item.affiliation),
+  }
+
+  return trimObject(value)
+}

--- a/src/namespaces/byline/parse/utils.test.ts
+++ b/src/namespaces/byline/parse/utils.test.ts
@@ -1,0 +1,376 @@
+import { describe, expect, it } from 'bun:test'
+import {
+  parseAffiliation,
+  parseAuthor,
+  parseOrg,
+  parsePerson,
+  parseProfile,
+  parseTheme,
+  retrieveFeed,
+  retrieveItem,
+} from './utils.js'
+
+describe('parseProfile', () => {
+  it('should parse profile with href and rel', () => {
+    const value = {
+      '@href': 'https://mastodon.social/@annie',
+      '@rel': 'mastodon',
+    }
+    const expected = {
+      href: 'https://mastodon.social/@annie',
+      rel: 'mastodon',
+    }
+
+    expect(parseProfile(value)).toEqual(expected)
+  })
+
+  it('should parse profile with only href', () => {
+    const value = {
+      '@href': 'https://example.com',
+    }
+    const expected = {
+      href: 'https://example.com',
+    }
+
+    expect(parseProfile(value)).toEqual(expected)
+  })
+
+  it('should return undefined for empty object', () => {
+    expect(parseProfile({})).toBeUndefined()
+  })
+
+  it('should return undefined for non-object inputs', () => {
+    expect(parseProfile(null)).toBeUndefined()
+    expect(parseProfile(undefined)).toBeUndefined()
+    expect(parseProfile('string')).toBeUndefined()
+    expect(parseProfile(123)).toBeUndefined()
+  })
+})
+
+describe('parseTheme', () => {
+  it('should parse theme with all attributes', () => {
+    const value = {
+      '@color': '#4A90A4',
+      '@accent': '#FF6B6B',
+      '@style': 'light',
+    }
+    const expected = {
+      color: '#4A90A4',
+      accent: '#FF6B6B',
+      style: 'light',
+    }
+
+    expect(parseTheme(value)).toEqual(expected)
+  })
+
+  it('should parse theme with only style', () => {
+    const value = {
+      '@style': 'dark',
+    }
+    const expected = {
+      style: 'dark',
+    }
+
+    expect(parseTheme(value)).toEqual(expected)
+  })
+
+  it('should return undefined for empty object', () => {
+    expect(parseTheme({})).toBeUndefined()
+  })
+
+  it('should return undefined for non-object inputs', () => {
+    expect(parseTheme(null)).toBeUndefined()
+    expect(parseTheme(undefined)).toBeUndefined()
+    expect(parseTheme('string')).toBeUndefined()
+  })
+})
+
+describe('parsePerson', () => {
+  it('should parse complete person with all properties', () => {
+    const value = {
+      '@id': 'annie',
+      'byline:name': 'Annie Park',
+      'byline:context': 'Designer and photographer.',
+      'byline:url': 'https://annie.example.com',
+      'byline:avatar': 'https://annie.example.com/avatar.jpg',
+      'byline:profile': [
+        { '@href': 'https://mastodon.social/@annie', '@rel': 'mastodon' },
+        { '@href': 'https://github.com/annie', '@rel': 'github' },
+      ],
+      'byline:now': 'https://annie.example.com/now',
+      'byline:uses': 'https://annie.example.com/uses',
+      'byline:theme': { '@color': '#4A90A4', '@accent': '#FF6B6B', '@style': 'light' },
+    }
+    const expected = {
+      id: 'annie',
+      name: 'Annie Park',
+      context: 'Designer and photographer.',
+      urls: ['https://annie.example.com'],
+      avatar: 'https://annie.example.com/avatar.jpg',
+      profiles: [
+        { href: 'https://mastodon.social/@annie', rel: 'mastodon' },
+        { href: 'https://github.com/annie', rel: 'github' },
+      ],
+      now: 'https://annie.example.com/now',
+      uses: 'https://annie.example.com/uses',
+      theme: { color: '#4A90A4', accent: '#FF6B6B', style: 'light' },
+    }
+
+    expect(parsePerson(value)).toEqual(expected)
+  })
+
+  it('should parse person with only name', () => {
+    const value = {
+      'byline:name': 'Marcus Chen',
+    }
+    const expected = {
+      name: 'Marcus Chen',
+    }
+
+    expect(parsePerson(value)).toEqual(expected)
+  })
+
+  it('should parse multiple urls into an array', () => {
+    const value = {
+      'byline:name': 'Annie Park',
+      'byline:url': ['https://annie.example.com', 'https://annie.dev'],
+    }
+    const expected = {
+      name: 'Annie Park',
+      urls: ['https://annie.example.com', 'https://annie.dev'],
+    }
+
+    expect(parsePerson(value)).toEqual(expected)
+  })
+
+  it('should handle HTML entities in text content', () => {
+    const value = {
+      'byline:name': { '#text': 'Tom &amp; Jerry' },
+    }
+    const expected = {
+      name: 'Tom & Jerry',
+    }
+
+    expect(parsePerson(value)).toEqual(expected)
+  })
+
+  it('should return undefined for empty object', () => {
+    expect(parsePerson({})).toBeUndefined()
+  })
+
+  it('should return undefined for non-object inputs', () => {
+    expect(parsePerson(null)).toBeUndefined()
+    expect(parsePerson(undefined)).toBeUndefined()
+    expect(parsePerson('string')).toBeUndefined()
+  })
+})
+
+describe('parseOrg', () => {
+  it('should parse complete org with all properties', () => {
+    const value = {
+      '@id': 'ttr',
+      'byline:name': 'The Tech Review',
+      'byline:url': 'https://thetechreview.example.com',
+      'byline:type': 'news',
+      'byline:theme': { '@color': '#1A1A2E', '@accent': '#E94560', '@style': 'dark' },
+    }
+    const expected = {
+      id: 'ttr',
+      name: 'The Tech Review',
+      url: 'https://thetechreview.example.com',
+      type: 'news',
+      theme: { color: '#1A1A2E', accent: '#E94560', style: 'dark' },
+    }
+
+    expect(parseOrg(value)).toEqual(expected)
+  })
+
+  it('should parse org with only name', () => {
+    const value = {
+      'byline:name': 'Acme Inc.',
+    }
+    const expected = {
+      name: 'Acme Inc.',
+    }
+
+    expect(parseOrg(value)).toEqual(expected)
+  })
+
+  it('should return undefined for empty object', () => {
+    expect(parseOrg({})).toBeUndefined()
+  })
+
+  it('should return undefined for non-object inputs', () => {
+    expect(parseOrg(null)).toBeUndefined()
+    expect(parseOrg(undefined)).toBeUndefined()
+  })
+})
+
+describe('parseAuthor', () => {
+  it('should parse author reference by ref', () => {
+    const value = {
+      '@ref': 'annie',
+    }
+    const expected = {
+      ref: 'annie',
+    }
+
+    expect(parseAuthor(value)).toEqual(expected)
+  })
+
+  it('should parse author with inline person', () => {
+    const value = {
+      'byline:person': {
+        '@id': 'guest-sara',
+        'byline:name': 'Sara Mitchell',
+        'byline:context': 'Guest contributor.',
+      },
+    }
+    const expected = {
+      person: {
+        id: 'guest-sara',
+        name: 'Sara Mitchell',
+        context: 'Guest contributor.',
+      },
+    }
+
+    expect(parseAuthor(value)).toEqual(expected)
+  })
+
+  it('should return undefined for empty object', () => {
+    expect(parseAuthor({})).toBeUndefined()
+  })
+
+  it('should return undefined for non-object inputs', () => {
+    expect(parseAuthor(null)).toBeUndefined()
+    expect(parseAuthor(undefined)).toBeUndefined()
+  })
+})
+
+describe('parseAffiliation', () => {
+  it('should parse complete affiliation', () => {
+    const value = {
+      'byline:org-ref': { '@ref': 'apple' },
+      'byline:relationship': 'employed',
+      'byline:title': 'Senior Engineer',
+    }
+    const expected = {
+      org: 'apple',
+      relationship: 'employed',
+      title: 'Senior Engineer',
+    }
+
+    expect(parseAffiliation(value)).toEqual(expected)
+  })
+
+  it('should parse affiliation with only relationship', () => {
+    const value = {
+      'byline:relationship': 'sponsored',
+    }
+    const expected = {
+      relationship: 'sponsored',
+    }
+
+    expect(parseAffiliation(value)).toEqual(expected)
+  })
+
+  it('should return undefined for empty object', () => {
+    expect(parseAffiliation({})).toBeUndefined()
+  })
+
+  it('should return undefined for non-object inputs', () => {
+    expect(parseAffiliation(null)).toBeUndefined()
+    expect(parseAffiliation(undefined)).toBeUndefined()
+  })
+})
+
+describe('retrieveFeed', () => {
+  it('should parse feed with contributors and organizations', () => {
+    const value = {
+      'byline:contributors': {
+        'byline:person': [
+          { '@id': 'marcus', 'byline:name': 'Marcus Chen' },
+          { '@id': 'elena', 'byline:name': 'Elena Vance' },
+        ],
+      },
+      'byline:organizations': {
+        'byline:org': { '@id': 'ttr', 'byline:name': 'The Tech Review' },
+      },
+    }
+    const expected = {
+      contributors: [
+        { id: 'marcus', name: 'Marcus Chen' },
+        { id: 'elena', name: 'Elena Vance' },
+      ],
+      organizations: [{ id: 'ttr', name: 'The Tech Review' }],
+    }
+
+    expect(retrieveFeed(value)).toEqual(expected)
+  })
+
+  it('should parse feed with a single contributor', () => {
+    const value = {
+      'byline:contributors': {
+        'byline:person': { '@id': 'annie', 'byline:name': 'Annie Park' },
+      },
+    }
+    const expected = {
+      contributors: [{ id: 'annie', name: 'Annie Park' }],
+    }
+
+    expect(retrieveFeed(value)).toEqual(expected)
+  })
+
+  it('should return undefined for empty object', () => {
+    expect(retrieveFeed({})).toBeUndefined()
+  })
+
+  it('should return undefined for non-object inputs', () => {
+    expect(retrieveFeed(null)).toBeUndefined()
+    expect(retrieveFeed(undefined)).toBeUndefined()
+    expect(retrieveFeed('string')).toBeUndefined()
+  })
+})
+
+describe('retrieveItem', () => {
+  it('should parse complete item with all properties', () => {
+    const value = {
+      'byline:author': { '@ref': 'marcus' },
+      'byline:role': 'staff',
+      'byline:perspective': 'reporting',
+      'byline:affiliation': {
+        'byline:org-ref': { '@ref': 'apple' },
+        'byline:relationship': 'employed',
+      },
+    }
+    const expected = {
+      author: { ref: 'marcus' },
+      role: 'staff',
+      perspective: 'reporting',
+      affiliation: { org: 'apple', relationship: 'employed' },
+    }
+
+    expect(retrieveItem(value)).toEqual(expected)
+  })
+
+  it('should parse item with only perspective', () => {
+    const value = {
+      'byline:perspective': 'personal',
+    }
+    const expected = {
+      perspective: 'personal',
+    }
+
+    expect(retrieveItem(value)).toEqual(expected)
+  })
+
+  it('should return undefined for empty object', () => {
+    expect(retrieveItem({})).toBeUndefined()
+  })
+
+  it('should return undefined for non-object inputs', () => {
+    expect(retrieveItem(null)).toBeUndefined()
+    expect(retrieveItem(undefined)).toBeUndefined()
+    expect(retrieveItem('string')).toBeUndefined()
+  })
+})

--- a/src/namespaces/byline/parse/utils.ts
+++ b/src/namespaces/byline/parse/utils.ts
@@ -1,0 +1,136 @@
+import type { ParsePartialUtil } from '../../../common/types.js'
+import {
+  isObject,
+  parseArrayOf,
+  parseSingularOf,
+  parseString,
+  retrieveText,
+  trimObject,
+} from '../../../common/utils.js'
+import type { BylineNs } from '../common/types.js'
+
+export const parseProfile: ParsePartialUtil<BylineNs.Profile> = (value) => {
+  if (!isObject(value)) {
+    return
+  }
+
+  const profile = {
+    href: parseString(value['@href']),
+    rel: parseString(value['@rel']),
+  }
+
+  return trimObject(profile)
+}
+
+export const parseTheme: ParsePartialUtil<BylineNs.Theme> = (value) => {
+  if (!isObject(value)) {
+    return
+  }
+
+  const theme = {
+    color: parseString(value['@color']),
+    accent: parseString(value['@accent']),
+    style: parseString(value['@style']),
+  }
+
+  return trimObject(theme)
+}
+
+export const parsePerson: ParsePartialUtil<BylineNs.Person> = (value) => {
+  if (!isObject(value)) {
+    return
+  }
+
+  const person = {
+    id: parseString(value['@id']),
+    name: parseSingularOf(value['byline:name'], (value) => parseString(retrieveText(value))),
+    context: parseSingularOf(value['byline:context'], (value) => parseString(retrieveText(value))),
+    urls: parseArrayOf(value['byline:url'], (value) => parseString(retrieveText(value))),
+    avatar: parseSingularOf(value['byline:avatar'], (value) => parseString(retrieveText(value))),
+    profiles: parseArrayOf(value['byline:profile'], parseProfile),
+    now: parseSingularOf(value['byline:now'], (value) => parseString(retrieveText(value))),
+    uses: parseSingularOf(value['byline:uses'], (value) => parseString(retrieveText(value))),
+    theme: parseSingularOf(value['byline:theme'], parseTheme),
+  }
+
+  return trimObject(person)
+}
+
+export const parseOrg: ParsePartialUtil<BylineNs.Org> = (value) => {
+  if (!isObject(value)) {
+    return
+  }
+
+  const org = {
+    id: parseString(value['@id']),
+    name: parseSingularOf(value['byline:name'], (value) => parseString(retrieveText(value))),
+    url: parseSingularOf(value['byline:url'], (value) => parseString(retrieveText(value))),
+    type: parseSingularOf(value['byline:type'], (value) => parseString(retrieveText(value))),
+    theme: parseSingularOf(value['byline:theme'], parseTheme),
+  }
+
+  return trimObject(org)
+}
+
+export const parseAuthor: ParsePartialUtil<BylineNs.Author> = (value) => {
+  if (!isObject(value)) {
+    return
+  }
+
+  const author = {
+    ref: parseString(value['@ref']),
+    person: parseSingularOf(value['byline:person'], parsePerson),
+  }
+
+  return trimObject(author)
+}
+
+export const parseAffiliation: ParsePartialUtil<BylineNs.Affiliation> = (value) => {
+  if (!isObject(value)) {
+    return
+  }
+
+  const affiliation = {
+    org: parseSingularOf(value['byline:org-ref'], (value) => parseString(value?.['@ref'])),
+    relationship: parseSingularOf(value['byline:relationship'], (value) =>
+      parseString(retrieveText(value)),
+    ),
+    title: parseSingularOf(value['byline:title'], (value) => parseString(retrieveText(value))),
+  }
+
+  return trimObject(affiliation)
+}
+
+export const retrieveFeed: ParsePartialUtil<BylineNs.Feed> = (value) => {
+  if (!isObject(value)) {
+    return
+  }
+
+  const feed = {
+    contributors: parseSingularOf(value['byline:contributors'], (value) =>
+      isObject(value) ? parseArrayOf(value['byline:person'], parsePerson) : undefined,
+    ),
+    organizations: parseSingularOf(value['byline:organizations'], (value) =>
+      isObject(value) ? parseArrayOf(value['byline:org'], parseOrg) : undefined,
+    ),
+  }
+
+  return trimObject(feed)
+}
+
+export const retrieveItem: ParsePartialUtil<BylineNs.Item> = (value) => {
+  if (!isObject(value)) {
+    return
+  }
+
+  const item = {
+    author: parseSingularOf(value['byline:author'], parseAuthor),
+    role: parseSingularOf(value['byline:role'], (value) => parseString(retrieveText(value))),
+    perspective: parseSingularOf(value['byline:perspective'], (value) =>
+      parseString(retrieveText(value)),
+    ),
+    affiliation: parseSingularOf(value['byline:affiliation'], parseAffiliation),
+  }
+
+  return trimObject(item)
+}


### PR DESCRIPTION
Adds support for the [Byline namespace](https://www.bylinespec.org/) (`<byline:*>`), an extension vocabulary that adds structured author identity, context, and content perspective to feeds: addressing "content collapse" in unified streams.

### Scope
- **RSS** and **Atom** parsing + generating.
- Feed level: `byline:contributors` (wraps `byline:person`) and `byline:organizations` (wraps `byline:org`).
- Item/entry level: `byline:author` (`@ref` or inline person), `byline:role`, `byline:perspective`, `byline:affiliation`.

### Notes
- Follows the spec's **example files** for structure: persons/orgs are grouped in `byline:contributors`/`byline:organizations` containers. The `SPEC.md` prose omits these containers (shows bare `byline:person`/`byline:org`): a spec/examples mismatch raised in [tgodier/byline#1](https://github.com/tgodier/byline/issues/1). The examples are treated as the de-facto structure.
- Byline is a **`0.1.0` draft**; field names/structure may still change.
- **JSON Feed (`_byline`) is intentionally deferred** to a follow-up, gated on the generic `extraFields` mechanism in #233.

### Coverage
- New source files at 100% line coverage.
