### PR TITLE
feat: Add RFC 6721 Atom Tombstones (at) namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ Feedsmith aims to fully support all major feed formats and namespaces in complet
 | [Creative Commons](https://feedsmith.dev/reference/namespaces/creativecommons) | `<creativeCommons:*>` | RSS, Atom | ✅ | ✅ |
 | [Atom Threading](https://feedsmith.dev/reference/namespaces/thr) | `<thr:*>` | RSS, Atom | ✅ | ✅ |
 | [Atom Publishing Protocol](https://feedsmith.dev/reference/namespaces/app) | `<app:*>` | Atom | ✅ | ✅ |
+| [Atom Tombstones](https://feedsmith.dev/reference/namespaces/at) | `<at:*>` | Atom | ✅ | ✅ |
 | [Comment API](https://feedsmith.dev/reference/namespaces/wfw) | `<wfw:*>` | RSS, Atom, RDF | ✅ | ✅ |
 | [Administrative](https://feedsmith.dev/reference/namespaces/admin) | `<admin:*>` | RSS, Atom, RDF | ✅ | ✅ |
 | [Pingback](https://feedsmith.dev/reference/namespaces/pingback) | `<pingback:*>` | RSS, Atom | ✅ | ✅ |

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -132,6 +132,7 @@ export default defineConfig({
               { text: 'Creative Commons', link: '/reference/namespaces/creativecommons' },
               { text: 'Atom Threading', link: '/reference/namespaces/thr' },
               { text: 'Atom Publishing Protocol', link: '/reference/namespaces/app' },
+              { text: 'Atom Tombstones', link: '/reference/namespaces/at' },
               { text: 'Comment API', link: '/reference/namespaces/wfw' },
               { text: 'Administrative', link: '/reference/namespaces/admin' },
               { text: 'Pingback', link: '/reference/namespaces/pingback' },

--- a/docs/index.md
+++ b/docs/index.md
@@ -84,6 +84,7 @@ Feedsmith aims to fully support all major feed formats and namespaces in complet
 | [Creative Commons](/reference/namespaces/creativecommons) | `<creativeCommons:*>` | RSS, Atom | ✅ | ✅ |
 | [Atom Threading](/reference/namespaces/thr) | `<thr:*>` | RSS, Atom | ✅ | ✅ |
 | [Atom Publishing Protocol](/reference/namespaces/app) | `<app:*>` | Atom | ✅ | ✅ |
+| [Atom Tombstones](/reference/namespaces/at) | `<at:*>` | Atom | ✅ | ✅ |
 | [Comment API](/reference/namespaces/wfw) | `<wfw:*>` | RSS, Atom, RDF | ✅ | ✅ |
 | [Administrative](/reference/namespaces/admin) | `<admin:*>` | RSS, Atom, RDF | ✅ | ✅ |
 | [Pingback](/reference/namespaces/pingback) | `<pingback:*>` | RSS, Atom | ✅ | ✅ |

--- a/docs/reference/namespaces/at.md
+++ b/docs/reference/namespaces/at.md
@@ -1,0 +1,45 @@
+---
+title: "Reference: Atom Tombstones Namespace"
+---
+
+# Atom Tombstones Namespace Reference
+
+The Atom Tombstones namespace ([RFC 6721](https://www.rfc-editor.org/rfc/rfc6721.html)) provides the `<at:deleted-entry>` element for signaling that a previously published entry has been removed from an Atom feed, along with metadata about when, by whom, and why it was deleted.
+
+<table>
+  <tbody>
+    <tr>
+      <th>Namespace URI</th>
+      <td><code>http://purl.org/atompub/tombstones/1.0</code></td>
+    </tr>
+    <tr>
+      <th>Specification</th>
+      <td><a href="https://www.rfc-editor.org/rfc/rfc6721.html" target="_blank">RFC 6721: The Atom "deleted-entry" Element</a></td>
+    </tr>
+    <tr>
+      <th>Prefix</th>
+      <td><code>&lt;at:*&gt;</code></td>
+    </tr>
+    <tr>
+      <th>Available in</th>
+      <td>
+        <a href="/reference/feeds/atom">Atom</a>
+      </td>
+    </tr>
+    <tr>
+      <th>Property</th>
+      <td><code>at</code></td>
+    </tr>
+  </tbody>
+</table>
+
+## Types
+
+> [!INFO]
+> For details on type parameters (`TDate`, `TStrict`) and `Requirable<T>` markers, see [TypeScript Reference](/reference/typescript#tdate).
+
+<<< @/../src/namespaces/at/common/types.ts#reference
+
+## Related
+
+- **[Parsing Namespaces](/parsing/namespaces)** - How namespace parsing works

--- a/src/common/config.ts
+++ b/src/common/config.ts
@@ -12,6 +12,7 @@ import {
   stopNodes as arxivStopNodes,
   uris as arxivUris,
 } from '../namespaces/arxiv/common/config.js'
+import { uris as atUris } from '../namespaces/at/common/config.js'
 import { uris as atomUris } from '../namespaces/atom/common/config.js'
 import {
   stopNodes as blogchannelStopNodes,
@@ -166,6 +167,7 @@ export const namespaceUris = {
   trackback: trackbackUris,
   prism: prismUris,
   acast: acastUris,
+  at: atUris,
 }
 
 export const namespacePrefixes = Object.entries(namespaceUris).reduce(

--- a/src/feeds/atom/common/types.ts
+++ b/src/feeds/atom/common/types.ts
@@ -9,6 +9,7 @@ import type {
 import type { AdminNs } from '../../../namespaces/admin/common/types.js'
 import type { AppNs } from '../../../namespaces/app/common/types.js'
 import type { ArxivNs } from '../../../namespaces/arxiv/common/types.js'
+import type { AtNs } from '../../../namespaces/at/common/types.js'
 import type { CcNs } from '../../../namespaces/cc/common/types.js'
 import type { CreativeCommonsNs } from '../../../namespaces/creativecommons/common/types.js'
 import type { DcNs } from '../../../namespaces/dc/common/types.js'
@@ -181,6 +182,7 @@ export namespace AtomFeed {
       admin?: AdminNs.Feed
       pingback?: PingbackNs.Feed
       xml?: XmlNs.ItemOrFeed
+      at?: AtNs.Feed<TDate, TStrict>
     },
     TStrict
   >

--- a/src/feeds/atom/generate/index.test.ts
+++ b/src/feeds/atom/generate/index.test.ts
@@ -1476,4 +1476,59 @@ describe('generate with app namespace', () => {
 
     expect(generate(value)).toEqual(expected)
   })
+
+  it('should generate Atom feed with at namespace', () => {
+    const value = {
+      id: 'https://example.com/feed',
+      title: { value: 'Feed with Tombstones' },
+      updated: new Date('2024-01-10T12:00:00Z'),
+      at: {
+        deletedEntries: [
+          {
+            ref: 'tag:example.org,2005:/entries/2',
+            when: new Date('2005-11-29T12:11:12Z'),
+            by: {
+              name: 'John Doe',
+              email: 'jdoe@example.com',
+            },
+            comment: 'Removed due to copyright claim.',
+            links: [
+              {
+                href: 'https://example.com/entries/2',
+              },
+            ],
+          },
+        ],
+      },
+      entries: [
+        {
+          id: 'https://example.com/entry/1',
+          title: { value: 'Entry title' },
+          updated: new Date('2024-01-05T10:30:00Z'),
+        },
+      ],
+    }
+    const expected = `<?xml version="1.0" encoding="utf-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom" xmlns:at="http://purl.org/atompub/tombstones/1.0">
+  <id>https://example.com/feed</id>
+  <title>Feed with Tombstones</title>
+  <updated>2024-01-10T12:00:00.000Z</updated>
+  <at:deleted-entry ref="tag:example.org,2005:/entries/2" when="2005-11-29T12:11:12.000Z">
+    <at:by>
+      <name>John Doe</name>
+      <email>jdoe@example.com</email>
+    </at:by>
+    <at:comment>Removed due to copyright claim.</at:comment>
+    <link href="https://example.com/entries/2"/>
+  </at:deleted-entry>
+  <entry>
+    <id>https://example.com/entry/1</id>
+    <title>Entry title</title>
+    <updated>2024-01-05T10:30:00.000Z</updated>
+  </entry>
+</feed>
+`
+
+    expect(generate(value)).toEqual(expected)
+  })
 })

--- a/src/feeds/atom/generate/utils.test.ts
+++ b/src/feeds/atom/generate/utils.test.ts
@@ -1736,6 +1736,59 @@ describe('generateFeed', () => {
     expect(generateFeed(value)).toEqual(expected)
   })
 
+  it('should generate Atom feed with at namespace properties', () => {
+    const value = {
+      id: 'https://example.com/feed',
+      title: { value: 'Feed with Tombstones' },
+      updated: new Date('2024-01-10T12:00:00Z'),
+      at: {
+        deletedEntries: [
+          {
+            ref: 'tag:example.org,2005:/entries/2',
+            when: new Date('2005-11-29T12:11:12Z'),
+            by: {
+              name: 'John Doe',
+              email: 'jdoe@example.com',
+            },
+            comment: 'Removed due to copyright claim.',
+            links: [
+              {
+                href: 'https://example.com/entries/2',
+              },
+            ],
+          },
+        ],
+      },
+    }
+    const expected = {
+      feed: {
+        '@xmlns': 'http://www.w3.org/2005/Atom',
+        '@xmlns:at': 'http://purl.org/atompub/tombstones/1.0',
+        id: 'https://example.com/feed',
+        title: { '#text': 'Feed with Tombstones' },
+        updated: '2024-01-10T12:00:00.000Z',
+        'at:deleted-entry': [
+          {
+            '@ref': 'tag:example.org,2005:/entries/2',
+            '@when': '2005-11-29T12:11:12.000Z',
+            'at:by': {
+              name: 'John Doe',
+              email: 'jdoe@example.com',
+            },
+            'at:comment': 'Removed due to copyright claim.',
+            link: [
+              {
+                '@href': 'https://example.com/entries/2',
+              },
+            ],
+          },
+        ],
+      },
+    }
+
+    expect(generateFeed(value)).toEqual(expected)
+  })
+
   it('should generate Atom feed with arxiv namespace properties', () => {
     const value = {
       id: 'http://arxiv.org/api/query',

--- a/src/feeds/atom/generate/utils.ts
+++ b/src/feeds/atom/generate/utils.ts
@@ -17,6 +17,7 @@ import {
   generateAuthor as generateArxivAuthor,
   generateEntry as generateArxivEntry,
 } from '../../../namespaces/arxiv/generate/utils.js'
+import { generateFeed as generateAtFeed } from '../../../namespaces/at/generate/utils.js'
 import { generateItemOrFeed as generateCc } from '../../../namespaces/cc/generate/utils.js'
 import { generateItemOrFeed as generateCreativeCommonsItemOrFeed } from '../../../namespaces/creativecommons/generate/utils.js'
 import { generateItemOrFeed as generateDcItemOrFeed } from '../../../namespaces/dc/generate/utils.js'
@@ -294,6 +295,7 @@ export const generateFeed: GenerateUtil<AtomFeed.Feed<DateLike>> = (feed, option
     ...generateAdminFeed(feed.admin),
     ...generatePingbackFeed(feed.pingback),
     ...generateXmlItemOrFeed(feed.xml),
+    ...generateAtFeed(feed.at),
     ...valueEntries,
   }
 

--- a/src/feeds/atom/parse/utils.ts
+++ b/src/feeds/atom/parse/utils.ts
@@ -17,6 +17,7 @@ import {
   retrieveAuthor as retrieveArxivAuthor,
   retrieveEntry as retrieveArxivEntry,
 } from '../../../namespaces/arxiv/parse/utils.js'
+import { retrieveFeed as retrieveAtFeed } from '../../../namespaces/at/parse/utils.js'
 import { retrieveItemOrFeed as retrieveCc } from '../../../namespaces/cc/parse/utils.js'
 import { retrieveItemOrFeed as retrieveCreativeCommonsItemOrFeed } from '../../../namespaces/creativecommons/parse/utils.js'
 import { retrieveItemOrFeed as retrieveDcItemOrFeed } from '../../../namespaces/dc/parse/utils.js'
@@ -352,6 +353,7 @@ export const parseFeed: ParseUtilPartial<AtomFeed.Feed<DateAny>> = (value, optio
     admin: namespaces?.has('admin') ? retrieveAdminFeed(value) : undefined,
     pingback: namespaces?.has('pingback') ? retrievePingbackFeed(value) : undefined,
     xml: options?.asNamespace ? undefined : retrieveXmlItemOrFeed(value),
+    at: namespaces?.has('at') ? retrieveAtFeed(value, options) : undefined,
   }
 
   return trimObject(feed)

--- a/src/feeds/atom/references/atom-ns.json
+++ b/src/feeds/atom/references/atom-ns.json
@@ -1213,5 +1213,23 @@
     "elev": 360,
     "floor": 4,
     "radius": 50000
+  },
+  "at": {
+    "deletedEntries": [
+      {
+        "ref": "tag:example.org,2005:/entries/2",
+        "when": "2005-11-29T12:11:12Z",
+        "by": {
+          "name": "John Doe",
+          "email": "jdoe@example.com"
+        },
+        "comment": "Removed due to copyright claim.",
+        "links": [
+          {
+            "href": "https://example.com/entries/2"
+          }
+        ]
+      }
+    ]
   }
 }

--- a/src/feeds/atom/references/atom-ns.xml
+++ b/src/feeds/atom/references/atom-ns.xml
@@ -22,6 +22,7 @@
       xmlns:georss="http://www.georss.org/georss"
       xmlns:geo="http://www.w3.org/2003/01/geo/wgs84_pos#"
       xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+      xmlns:at="http://purl.org/atompub/tombstones/1.0"
 >
   <id>example-feed</id>
   <title>Example Feed</title>
@@ -287,6 +288,16 @@
   <!-- YouTube Namespace: Feed Level Tags -->
   <yt:channelId>UCuAXFkgsw1L7xaCfnd5JJOw</yt:channelId>
   <yt:playlistId>PLrAXtmErZgOeiKm4sgNOknGvNjby9efdf</yt:playlistId>
+
+  <!-- Atom Tombstones Namespace: Feed Level Tags -->
+  <at:deleted-entry ref="tag:example.org,2005:/entries/2" when="2005-11-29T12:11:12Z">
+    <at:by>
+      <name>John Doe</name>
+      <email>jdoe@example.com</email>
+    </at:by>
+    <at:comment>Removed due to copyright claim.</at:comment>
+    <link href="https://example.com/entries/2"/>
+  </at:deleted-entry>
 
   <entry>
     <id>example-entry</id>

--- a/src/namespaces/at/common/config.ts
+++ b/src/namespaces/at/common/config.ts
@@ -1,0 +1,6 @@
+export const uris = [
+  'http://purl.org/atompub/tombstones/1.0', // Official URI.
+  'https://purl.org/atompub/tombstones/1.0',
+  'http://purl.org/atompub/tombstones/1.0/',
+  'https://purl.org/atompub/tombstones/1.0/',
+]

--- a/src/namespaces/at/common/types.ts
+++ b/src/namespaces/at/common/types.ts
@@ -1,0 +1,41 @@
+import type { Requirable, Strict } from '../../../common/types.js'
+
+// #region reference
+export namespace AtNs {
+  export type Person<TStrict extends boolean = false> = Strict<
+    {
+      name: Requirable<string> // Required in spec.
+      uri?: string
+      email?: string
+    },
+    TStrict
+  >
+
+  export type Link<TStrict extends boolean = false> = Strict<
+    {
+      href: Requirable<string> // Required in spec.
+      rel?: string
+      type?: string
+      hreflang?: string
+      title?: string
+      length?: number
+    },
+    TStrict
+  >
+
+  export type DeletedEntry<TDate, TStrict extends boolean = false> = Strict<
+    {
+      ref: Requirable<string> // Required in spec.
+      when: Requirable<TDate> // Required in spec.
+      by?: Person<TStrict>
+      comment?: string
+      links?: Array<Link<TStrict>>
+    },
+    TStrict
+  >
+
+  export type Feed<TDate, TStrict extends boolean = false> = {
+    deletedEntries?: Array<DeletedEntry<TDate, TStrict>>
+  }
+}
+// #endregion reference

--- a/src/namespaces/at/generate/utils.test.ts
+++ b/src/namespaces/at/generate/utils.test.ts
@@ -1,0 +1,179 @@
+import { describe, expect, it } from 'bun:test'
+import { generateDeletedEntry, generateFeed, generateLink, generatePerson } from './utils.js'
+
+describe('generatePerson', () => {
+  it('should generate person with all properties', () => {
+    const value = {
+      name: 'John Doe',
+      uri: 'https://example.com/john',
+      email: 'jdoe@example.com',
+    }
+    const expected = {
+      name: 'John Doe',
+      uri: 'https://example.com/john',
+      email: 'jdoe@example.com',
+    }
+
+    expect(generatePerson(value)).toEqual(expected)
+  })
+
+  it('should generate person with only name', () => {
+    const value = {
+      name: 'John Doe',
+    }
+    const expected = {
+      name: 'John Doe',
+    }
+
+    expect(generatePerson(value)).toEqual(expected)
+  })
+
+  it('should handle undefined input', () => {
+    expect(generatePerson(undefined)).toBeUndefined()
+  })
+})
+
+describe('generateLink', () => {
+  it('should generate link with all properties', () => {
+    const value = {
+      href: 'https://example.com/entries/1',
+      rel: 'alternate',
+      type: 'text/html',
+      hreflang: 'en',
+      title: 'Removed entry',
+      length: 1024,
+    }
+    const expected = {
+      '@href': 'https://example.com/entries/1',
+      '@rel': 'alternate',
+      '@type': 'text/html',
+      '@hreflang': 'en',
+      '@title': 'Removed entry',
+      '@length': 1024,
+    }
+
+    expect(generateLink(value)).toEqual(expected)
+  })
+
+  it('should generate link with only href', () => {
+    const value = {
+      href: 'https://example.com/entries/1',
+    }
+    const expected = {
+      '@href': 'https://example.com/entries/1',
+    }
+
+    expect(generateLink(value)).toEqual(expected)
+  })
+
+  it('should handle undefined input', () => {
+    expect(generateLink(undefined)).toBeUndefined()
+  })
+})
+
+describe('generateDeletedEntry', () => {
+  it('should generate deleted-entry with all properties', () => {
+    const value = {
+      ref: 'tag:example.org,2005:/entries/2',
+      when: new Date('2005-11-29T12:11:12Z'),
+      by: {
+        name: 'John Doe',
+        email: 'jdoe@example.com',
+      },
+      comment: 'Removed due to copyright claim.',
+      links: [
+        {
+          href: 'https://example.com/entries/2',
+        },
+      ],
+    }
+    const expected = {
+      '@ref': 'tag:example.org,2005:/entries/2',
+      '@when': '2005-11-29T12:11:12.000Z',
+      'at:by': {
+        name: 'John Doe',
+        email: 'jdoe@example.com',
+      },
+      'at:comment': 'Removed due to copyright claim.',
+      link: [
+        {
+          '@href': 'https://example.com/entries/2',
+        },
+      ],
+    }
+
+    expect(generateDeletedEntry(value)).toEqual(expected)
+  })
+
+  it('should generate deleted-entry with only ref and when', () => {
+    const value = {
+      ref: 'tag:example.org,2005:/entries/2',
+      when: new Date('2005-11-29T12:11:12Z'),
+    }
+    const expected = {
+      '@ref': 'tag:example.org,2005:/entries/2',
+      '@when': '2005-11-29T12:11:12.000Z',
+    }
+
+    expect(generateDeletedEntry(value)).toEqual(expected)
+  })
+
+  it('should handle undefined input', () => {
+    expect(generateDeletedEntry(undefined)).toBeUndefined()
+  })
+})
+
+describe('generateFeed', () => {
+  it('should generate feed with deleted-entries', () => {
+    const value = {
+      deletedEntries: [
+        {
+          ref: 'tag:example.org,2005:/entries/2',
+          when: new Date('2005-11-29T12:11:12Z'),
+        },
+        {
+          ref: 'tag:example.org,2005:/entries/3',
+          comment: 'Spam.',
+        },
+      ],
+    }
+    const expected = {
+      'at:deleted-entry': [
+        {
+          '@ref': 'tag:example.org,2005:/entries/2',
+          '@when': '2005-11-29T12:11:12.000Z',
+        },
+        {
+          '@ref': 'tag:example.org,2005:/entries/3',
+          'at:comment': 'Spam.',
+        },
+      ],
+    }
+
+    expect(generateFeed(value)).toEqual(expected)
+  })
+
+  it('should filter out invalid deleted-entries', () => {
+    const value = {
+      deletedEntries: [
+        {
+          ref: 'tag:example.org,2005:/entries/2',
+        },
+        {},
+      ],
+    }
+    const expected = {
+      'at:deleted-entry': [
+        {
+          '@ref': 'tag:example.org,2005:/entries/2',
+        },
+      ],
+    }
+
+    expect(generateFeed(value)).toEqual(expected)
+  })
+
+  it('should handle undefined input', () => {
+    expect(generateFeed(undefined)).toBeUndefined()
+  })
+})

--- a/src/namespaces/at/generate/utils.ts
+++ b/src/namespaces/at/generate/utils.ts
@@ -1,0 +1,70 @@
+import type { DateLike, GenerateUtil } from '../../../common/types.js'
+import {
+  generateCdataString,
+  generateNumber,
+  generatePlainString,
+  generateRfc3339Date,
+  isObject,
+  trimArray,
+  trimObject,
+} from '../../../common/utils.js'
+import type { AtNs } from '../common/types.js'
+
+export const generatePerson: GenerateUtil<AtNs.Person> = (person) => {
+  if (!isObject(person)) {
+    return
+  }
+
+  const value = {
+    name: generateCdataString(person.name),
+    uri: generateCdataString(person.uri),
+    email: generateCdataString(person.email),
+  }
+
+  return trimObject(value)
+}
+
+export const generateLink: GenerateUtil<AtNs.Link> = (link) => {
+  if (!isObject(link)) {
+    return
+  }
+
+  const value = {
+    '@href': generatePlainString(link.href),
+    '@rel': generatePlainString(link.rel),
+    '@type': generatePlainString(link.type),
+    '@hreflang': generatePlainString(link.hreflang),
+    '@title': generatePlainString(link.title),
+    '@length': generateNumber(link.length),
+  }
+
+  return trimObject(value)
+}
+
+export const generateDeletedEntry: GenerateUtil<AtNs.DeletedEntry<DateLike>> = (deletedEntry) => {
+  if (!isObject(deletedEntry)) {
+    return
+  }
+
+  const value = {
+    '@ref': generatePlainString(deletedEntry.ref),
+    '@when': generateRfc3339Date(deletedEntry.when),
+    'at:by': generatePerson(deletedEntry.by),
+    'at:comment': generateCdataString(deletedEntry.comment),
+    link: trimArray(deletedEntry.links, generateLink),
+  }
+
+  return trimObject(value)
+}
+
+export const generateFeed: GenerateUtil<AtNs.Feed<DateLike>> = (feed) => {
+  if (!isObject(feed)) {
+    return
+  }
+
+  const value = {
+    'at:deleted-entry': trimArray(feed.deletedEntries, generateDeletedEntry),
+  }
+
+  return trimObject(value)
+}

--- a/src/namespaces/at/parse/utils.test.ts
+++ b/src/namespaces/at/parse/utils.test.ts
@@ -1,0 +1,283 @@
+import { describe, expect, it } from 'bun:test'
+import { parseDeletedEntry, parseLink, parsePerson, retrieveFeed } from './utils.js'
+
+describe('parsePerson', () => {
+  it('should parse complete person object', () => {
+    const value = {
+      name: 'John Doe',
+      uri: 'https://example.com/john',
+      email: 'jdoe@example.com',
+    }
+    const expected = {
+      name: 'John Doe',
+      uri: 'https://example.com/john',
+      email: 'jdoe@example.com',
+    }
+
+    expect(parsePerson(value)).toEqual(expected)
+  })
+
+  it('should parse person with only name', () => {
+    const value = {
+      name: 'John Doe',
+    }
+    const expected = {
+      name: 'John Doe',
+    }
+
+    expect(parsePerson(value)).toEqual(expected)
+  })
+
+  it('should handle text nodes', () => {
+    const value = {
+      name: { '#text': 'John Doe' },
+      email: { '#text': 'jdoe@example.com' },
+    }
+    const expected = {
+      name: 'John Doe',
+      email: 'jdoe@example.com',
+    }
+
+    expect(parsePerson(value)).toEqual(expected)
+  })
+
+  it('should return undefined for empty object', () => {
+    const value = {}
+
+    expect(parsePerson(value)).toBeUndefined()
+  })
+
+  it('should return undefined for unsupported input', () => {
+    expect(parsePerson('not an object')).toBeUndefined()
+    expect(parsePerson(undefined)).toBeUndefined()
+    expect(parsePerson(null)).toBeUndefined()
+    expect(parsePerson([])).toBeUndefined()
+  })
+})
+
+describe('parseLink', () => {
+  it('should parse complete link object', () => {
+    const value = {
+      '@href': 'https://example.com/entries/1',
+      '@rel': 'alternate',
+      '@type': 'text/html',
+      '@hreflang': 'en',
+      '@title': 'Removed entry',
+      '@length': 1024,
+    }
+    const expected = {
+      href: 'https://example.com/entries/1',
+      rel: 'alternate',
+      type: 'text/html',
+      hreflang: 'en',
+      title: 'Removed entry',
+      length: 1024,
+    }
+
+    expect(parseLink(value)).toEqual(expected)
+  })
+
+  it('should parse link with only href', () => {
+    const value = {
+      '@href': 'https://example.com/entries/1',
+    }
+    const expected = {
+      href: 'https://example.com/entries/1',
+    }
+
+    expect(parseLink(value)).toEqual(expected)
+  })
+
+  it('should handle coercible values', () => {
+    const value = {
+      '@href': 'https://example.com/entries/1',
+      '@length': '1024',
+    }
+    const expected = {
+      href: 'https://example.com/entries/1',
+      length: 1024,
+    }
+
+    expect(parseLink(value)).toEqual(expected)
+  })
+
+  it('should return undefined for empty object', () => {
+    const value = {}
+
+    expect(parseLink(value)).toBeUndefined()
+  })
+
+  it('should return undefined for unsupported input', () => {
+    expect(parseLink('not an object')).toBeUndefined()
+    expect(parseLink(undefined)).toBeUndefined()
+    expect(parseLink(null)).toBeUndefined()
+    expect(parseLink([])).toBeUndefined()
+  })
+})
+
+describe('parseDeletedEntry', () => {
+  it('should parse complete deleted-entry with all properties', () => {
+    const value = {
+      '@ref': 'tag:example.org,2005:/entries/2',
+      '@when': '2005-11-29T12:11:12Z',
+      'at:by': {
+        name: 'John Doe',
+        email: 'jdoe@example.com',
+      },
+      'at:comment': 'Removed due to copyright claim.',
+      link: {
+        '@href': 'https://example.com/entries/2',
+      },
+    }
+    const expected = {
+      ref: 'tag:example.org,2005:/entries/2',
+      when: '2005-11-29T12:11:12Z',
+      by: {
+        name: 'John Doe',
+        email: 'jdoe@example.com',
+      },
+      comment: 'Removed due to copyright claim.',
+      links: [
+        {
+          href: 'https://example.com/entries/2',
+        },
+      ],
+    }
+
+    expect(parseDeletedEntry(value)).toEqual(expected)
+  })
+
+  it('should parse deleted-entry with only ref and when', () => {
+    const value = {
+      '@ref': 'tag:example.org,2005:/entries/2',
+      '@when': '2005-11-29T12:11:12Z',
+    }
+    const expected = {
+      ref: 'tag:example.org,2005:/entries/2',
+      when: '2005-11-29T12:11:12Z',
+    }
+
+    expect(parseDeletedEntry(value)).toEqual(expected)
+  })
+
+  it('should parse multiple links', () => {
+    const value = {
+      '@ref': 'tag:example.org,2005:/entries/2',
+      link: [
+        { '@href': 'https://example.com/entries/2' },
+        { '@href': 'https://example.com/entries/2/mirror', '@rel': 'alternate' },
+      ],
+    }
+    const expected = {
+      ref: 'tag:example.org,2005:/entries/2',
+      links: [
+        { href: 'https://example.com/entries/2' },
+        { href: 'https://example.com/entries/2/mirror', rel: 'alternate' },
+      ],
+    }
+
+    expect(parseDeletedEntry(value)).toEqual(expected)
+  })
+
+  it('should handle HTML entities in comment', () => {
+    const value = {
+      '@ref': 'tag:example.org,2005:/entries/2',
+      'at:comment': { '#text': 'Removed &amp; archived' },
+    }
+    const expected = {
+      ref: 'tag:example.org,2005:/entries/2',
+      comment: 'Removed & archived',
+    }
+
+    expect(parseDeletedEntry(value)).toEqual(expected)
+  })
+
+  it('should handle CDATA sections in comment', () => {
+    const value = {
+      '@ref': 'tag:example.org,2005:/entries/2',
+      'at:comment': { '#text': '<![CDATA[Removed]]>' },
+    }
+    const expected = {
+      ref: 'tag:example.org,2005:/entries/2',
+      comment: 'Removed',
+    }
+
+    expect(parseDeletedEntry(value)).toEqual(expected)
+  })
+
+  it('should return undefined for empty object', () => {
+    const value = {}
+
+    expect(parseDeletedEntry(value)).toBeUndefined()
+  })
+
+  it('should return undefined for unsupported input', () => {
+    expect(parseDeletedEntry('not an object')).toBeUndefined()
+    expect(parseDeletedEntry(undefined)).toBeUndefined()
+    expect(parseDeletedEntry(null)).toBeUndefined()
+    expect(parseDeletedEntry([])).toBeUndefined()
+  })
+})
+
+describe('retrieveFeed', () => {
+  it('should parse feed with a single deleted-entry', () => {
+    const value = {
+      'at:deleted-entry': {
+        '@ref': 'tag:example.org,2005:/entries/2',
+        '@when': '2005-11-29T12:11:12Z',
+      },
+    }
+    const expected = {
+      deletedEntries: [
+        {
+          ref: 'tag:example.org,2005:/entries/2',
+          when: '2005-11-29T12:11:12Z',
+        },
+      ],
+    }
+
+    expect(retrieveFeed(value)).toEqual(expected)
+  })
+
+  it('should parse feed with multiple deleted-entries', () => {
+    const value = {
+      'at:deleted-entry': [
+        {
+          '@ref': 'tag:example.org,2005:/entries/2',
+          '@when': '2005-11-29T12:11:12Z',
+        },
+        {
+          '@ref': 'tag:example.org,2005:/entries/3',
+          'at:comment': 'Spam.',
+        },
+      ],
+    }
+    const expected = {
+      deletedEntries: [
+        {
+          ref: 'tag:example.org,2005:/entries/2',
+          when: '2005-11-29T12:11:12Z',
+        },
+        {
+          ref: 'tag:example.org,2005:/entries/3',
+          comment: 'Spam.',
+        },
+      ],
+    }
+
+    expect(retrieveFeed(value)).toEqual(expected)
+  })
+
+  it('should return undefined for empty object', () => {
+    const value = {}
+
+    expect(retrieveFeed(value)).toBeUndefined()
+  })
+
+  it('should return undefined for unsupported input', () => {
+    expect(retrieveFeed('not an object')).toBeUndefined()
+    expect(retrieveFeed(undefined)).toBeUndefined()
+    expect(retrieveFeed(null)).toBeUndefined()
+    expect(retrieveFeed([])).toBeUndefined()
+  })
+})

--- a/src/namespaces/at/parse/utils.ts
+++ b/src/namespaces/at/parse/utils.ts
@@ -1,0 +1,79 @@
+import type { DateAny, ParseMainOptions, ParseUtilPartial } from '../../../common/types.js'
+import {
+  isObject,
+  parseArrayOf,
+  parseDate,
+  parseNumber,
+  parseSingularOf,
+  parseString,
+  retrieveText,
+  trimObject,
+} from '../../../common/utils.js'
+import type { AtNs } from '../common/types.js'
+
+export const parsePerson: ParseUtilPartial<AtNs.Person> = (value) => {
+  if (!isObject(value)) {
+    return
+  }
+
+  const person = {
+    name: parseSingularOf(value.name, (value) => parseString(retrieveText(value))),
+    uri: parseSingularOf(value.uri, (value) => parseString(retrieveText(value))),
+    email: parseSingularOf(value.email, (value) => parseString(retrieveText(value))),
+  }
+
+  return trimObject(person)
+}
+
+export const parseLink: ParseUtilPartial<AtNs.Link> = (value) => {
+  if (!isObject(value)) {
+    return
+  }
+
+  const link = {
+    href: parseString(value['@href']),
+    rel: parseString(value['@rel']),
+    type: parseString(value['@type']),
+    hreflang: parseString(value['@hreflang']),
+    title: parseString(value['@title']),
+    length: parseNumber(value['@length']),
+  }
+
+  return trimObject(link)
+}
+
+export const parseDeletedEntry: ParseUtilPartial<
+  AtNs.DeletedEntry<DateAny>,
+  ParseMainOptions<DateAny>
+> = (value, options) => {
+  if (!isObject(value)) {
+    return
+  }
+
+  const deletedEntry = {
+    ref: parseString(value['@ref']),
+    when: parseDate(value['@when'], options?.parseDateFn),
+    by: parseSingularOf(value['at:by'], parsePerson),
+    comment: parseSingularOf(value['at:comment'], (value) => parseString(retrieveText(value))),
+    links: parseArrayOf(value.link, parseLink),
+  }
+
+  return trimObject(deletedEntry)
+}
+
+export const retrieveFeed: ParseUtilPartial<AtNs.Feed<DateAny>, ParseMainOptions<DateAny>> = (
+  value,
+  options,
+) => {
+  if (!isObject(value)) {
+    return
+  }
+
+  const feed = {
+    deletedEntries: parseArrayOf(value['at:deleted-entry'], (value) =>
+      parseDeletedEntry(value, options),
+    ),
+  }
+
+  return trimObject(feed)
+}


### PR DESCRIPTION
Adds support for the [RFC 6721](https://www.rfc-editor.org/rfc/rfc6721.html) Atom Tombstones namespace (`http://purl.org/atompub/tombstones/1.0`, prefix `at`). It lets an Atom feed signal that an entry was removed, with who/why/when metadata.

## Motivation

Prompted by [kurtmckee/feedparser#149: "Parsing deleted-entry (RFC 6721)"](https://github.com/kurtmckee/feedparser/issues/149). The namespace is niche, but it's a stable IETF standard and maps cleanly onto Feedsmith's namespace model, so it's cheap to support well.

## Scope

- New namespace at `src/namespaces/at/`, wired into the **Atom** feed format at **feed level only** (`<at:deleted-entry>` is a sibling of `<entry>`). Rides the existing additive-namespace machinery: no changes to entry parsing.
- Public API: `feed.at.deletedEntries` (`AtNs.Feed`).
- Element model: `ref` + `when` attributes, plus `at:by` (person), `at:comment` (text), and `atom:link[]`.

## Known omissions (documented)

- `atom:source` inside `deleted-entry` is not modeled (rare; would require duplicating the Atom Source construct under the namespace layering constraint).
- A prefixed `atom:` namespace on the nested `link`/`name`/`email` children (instead of the default Atom namespace) is not handled: the common default-namespace case is.