### PR TITLE
docs: fix namespace specification links

### DIFF
--- a/docs/reference/namespaces/creativecommons.md
+++ b/docs/reference/namespaces/creativecommons.md
@@ -14,7 +14,7 @@ The Creative Commons namespace provides elements for specifying the license unde
     </tr>
     <tr>
       <th>Specification</th>
-      <td><a href="http://cyber.law.harvard.edu/rss/creativeCommonsRssModule.html" target="_blank">Creative Commons RSS Module Specification</a></td>
+      <td><a href="https://www.rssboard.org/creative-commons" target="_blank">Creative Commons RSS Module Specification</a></td>
     </tr>
     <tr>
       <th>Prefix</th>

--- a/docs/reference/namespaces/georss.md
+++ b/docs/reference/namespaces/georss.md
@@ -14,7 +14,7 @@ The GeoRSS Simple namespace enables geographic tagging of RSS feeds and items, a
     </tr>
     <tr>
       <th>Specification</th>
-      <td><a href="http://www.georss.org/georss" target="_blank">GeoRSS Specification</a></td>
+      <td><a href="https://www.ogc.org/standards/georss/" target="_blank">GeoRSS Specification</a></td>
     </tr>
     <tr>
       <th>Prefix</th>

--- a/docs/reference/namespaces/wfw.md
+++ b/docs/reference/namespaces/wfw.md
@@ -14,7 +14,7 @@ The Comment API namespace provides elements for linking to comment feeds and com
     </tr>
     <tr>
       <th>Specification</th>
-      <td><a href="http://wellformedweb.org/CommentAPI/" target="_blank">Well Formed Web Comment API</a></td>
+      <td>Well Formed Web Comment API</td>
     </tr>
     <tr>
       <th>Prefix</th>


### PR DESCRIPTION
## Summary

- update the Creative Commons namespace specification link to the current RSS Advisory Board page
- update the GeoRSS specification link to the OGC GeoRSS standards page
- remove the dead Well Formed Web Comment API hyperlink while keeping the namespace URI text unchanged

Closes #305.

## Validation

- `Invoke-WebRequest -Method Head` returned `200` for `https://www.rssboard.org/creative-commons`
- `Invoke-WebRequest -Method Head` returned `200` for `https://www.ogc.org/standards/georss/`
- `npm run docs:build`
- `npm run build`
- `git diff --check`
- `rg 'href="http://wellformedweb.org/CommentAPI/|href="http://www.georss.org/georss|href="http://cyber.law.harvard.edu/rss/creativeCommonsRssModule.html' docs` returned no matches

## Notes

This only changes human-readable specification links in the docs. The XML namespace URI rows are intentionally unchanged.