### PR TITLE
test: Align tests with shared conventions and expand coverage

### DIFF
--- a/src/common/errors.test.ts
+++ b/src/common/errors.test.ts
@@ -14,6 +14,12 @@ describe('DetectError', () => {
     expect(error).toBeInstanceOf(Error)
   })
 
+  it('should be instance of DetectError', () => {
+    const error = new DetectError('Test error')
+
+    expect(error).toBeInstanceOf(DetectError)
+  })
+
   it('should have name set to DetectError', () => {
     const error = new DetectError('Test error')
 
@@ -32,6 +38,12 @@ describe('GenerateError', () => {
     const error = new GenerateError('Test error')
 
     expect(error).toBeInstanceOf(Error)
+  })
+
+  it('should be instance of GenerateError', () => {
+    const error = new GenerateError('Test error')
+
+    expect(error).toBeInstanceOf(GenerateError)
   })
 
   it('should have name set to GenerateError', () => {
@@ -54,6 +66,12 @@ describe('MalformedError', () => {
     expect(error).toBeInstanceOf(Error)
   })
 
+  it('should be instance of MalformedError', () => {
+    const error = new MalformedError('Test error')
+
+    expect(error).toBeInstanceOf(MalformedError)
+  })
+
   it('should have name set to MalformedError', () => {
     const error = new MalformedError('Test error')
 
@@ -72,6 +90,12 @@ describe('ParseError', () => {
     const error = new ParseError('Test error')
 
     expect(error).toBeInstanceOf(Error)
+  })
+
+  it('should be instance of ParseError', () => {
+    const error = new ParseError('Test error')
+
+    expect(error).toBeInstanceOf(ParseError)
   })
 
   it('should have name set to ParseError', () => {

--- a/src/common/parse.test.ts
+++ b/src/common/parse.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'bun:test'
 import { locales } from './config.js'
 import { DetectError } from './errors.js'
-import { parse } from './parse.js'
+import { type AnyFeed, parse } from './parse.js'
 
 describe('parse', () => {
   it('should parse valid Atom feed', () => {
@@ -12,8 +12,8 @@ describe('parse', () => {
         <id>example-feed</id>
       </feed>
     `
-    const expected = {
-      format: 'atom' as const,
+    const expected: AnyFeed = {
+      format: 'atom',
       feed: {
         title: { value: 'Feed' },
         id: 'example-feed',
@@ -42,8 +42,8 @@ describe('parse', () => {
         },
       ],
     }
-    const expected = {
-      format: 'json' as const,
+    const expected: AnyFeed = {
+      format: 'json',
       feed: {
         title: 'My Example Feed',
         home_page_url: 'https://example.com/',
@@ -79,8 +79,8 @@ describe('parse', () => {
         },
       ],
     })
-    const expected = {
-      format: 'json' as const,
+    const expected: AnyFeed = {
+      format: 'json',
       feed: {
         title: 'My Example Feed',
         home_page_url: 'https://example.com/',
@@ -104,8 +104,8 @@ describe('parse', () => {
       items: [{ id: '1', content_text: 'Test' }],
     })
     const value = `  ${json}`
-    const expected = {
-      format: 'json' as const,
+    const expected: AnyFeed = {
+      format: 'json',
       feed: {
         title: 'Feed with whitespace',
         items: [{ id: '1', content_text: 'Test' }],
@@ -122,8 +122,8 @@ describe('parse', () => {
       items: [{ id: '1', content_text: 'Test' }],
     })
     const value = `${json}  `
-    const expected = {
-      format: 'json' as const,
+    const expected: AnyFeed = {
+      format: 'json',
       feed: {
         title: 'Feed with whitespace',
         items: [{ id: '1', content_text: 'Test' }],
@@ -140,8 +140,8 @@ describe('parse', () => {
       items: [{ id: '1', content_text: 'Test' }],
     })
     const value = `  ${json}  `
-    const expected = {
-      format: 'json' as const,
+    const expected: AnyFeed = {
+      format: 'json',
       feed: {
         title: 'Feed with whitespace',
         items: [{ id: '1', content_text: 'Test' }],
@@ -153,14 +153,16 @@ describe('parse', () => {
 
   it('should reject malformed JSON string', () => {
     const value = '{"version":"https://jsonfeed.org/version/1.1","title":"Malformed'
+    const throwing = () => parse(value)
 
-    expect(() => parse(value)).toThrowError(locales.unrecognizedFeedFormat)
+    expect(throwing).toThrowError(locales.unrecognizedFeedFormat)
   })
 
   it('should reject JSON array string', () => {
     const value = '[{"version":"https://jsonfeed.org/version/1.1"}]'
+    const throwing = () => parse(value)
 
-    expect(() => parse(value)).toThrowError(locales.unrecognizedFeedFormat)
+    expect(throwing).toThrowError(locales.unrecognizedFeedFormat)
   })
 
   it('should parse valid RSS feed', () => {
@@ -174,8 +176,8 @@ describe('parse', () => {
         </channel>
       </rss>
     `
-    const expected = {
-      format: 'rss' as const,
+    const expected: AnyFeed = {
+      format: 'rss',
       feed: {
         title: 'Feed',
         link: 'https://example.com/feed',
@@ -203,8 +205,8 @@ describe('parse', () => {
         </item>
       </rdf:RDF>
     `
-    const expected = {
-      format: 'rdf' as const,
+    const expected: AnyFeed = {
+      format: 'rdf',
       feed: {
         title: 'Example Feed',
         link: 'http://example.org',
@@ -223,31 +225,51 @@ describe('parse', () => {
   })
 
   it('should throw error for invalid input', () => {
-    expect(() => parse('not a feed')).toThrowError(locales.unrecognizedFeedFormat)
+    const throwing = () => parse('not a feed')
+
+    expect(throwing).toThrowError(locales.unrecognizedFeedFormat)
+  })
+
+  it('should throw error for empty string input', () => {
+    const throwing = () => parse('')
+
+    expect(throwing).toThrowError(locales.unrecognizedFeedFormat)
+  })
+
+  it('should throw error for whitespace-only string input', () => {
+    const throwing = () => parse('   ')
+
+    expect(throwing).toThrowError(locales.unrecognizedFeedFormat)
   })
 
   it('should handle null input', () => {
-    expect(() => parse(null)).toThrowError(locales.unrecognizedFeedFormat)
+    const throwing = () => parse(null)
+
+    expect(throwing).toThrowError(locales.unrecognizedFeedFormat)
   })
 
   it('should handle undefined input', () => {
-    expect(() => parse(undefined)).toThrowError(locales.unrecognizedFeedFormat)
+    const throwing = () => parse(undefined)
+
+    expect(throwing).toThrowError(locales.unrecognizedFeedFormat)
   })
 
   it('should handle array input', () => {
-    expect(() => parse([])).toThrowError(locales.unrecognizedFeedFormat)
+    const throwing = () => parse([])
+
+    expect(throwing).toThrowError(locales.unrecognizedFeedFormat)
   })
 
   it('should handle empty object input', () => {
-    expect(() => parse({})).toThrowError(locales.unrecognizedFeedFormat)
-  })
+    const throwing = () => parse({})
 
-  it('should handle string input', () => {
-    expect(() => parse('not a feed')).toThrowError(locales.unrecognizedFeedFormat)
+    expect(throwing).toThrowError(locales.unrecognizedFeedFormat)
   })
 
   it('should handle number input', () => {
-    expect(() => parse(123)).toThrowError(locales.unrecognizedFeedFormat)
+    const throwing = () => parse(123)
+
+    expect(throwing).toThrowError(locales.unrecognizedFeedFormat)
   })
 
   describe('error types', () => {
@@ -272,8 +294,8 @@ describe('parse', () => {
           </channel>
         </rss>
       `
-      const expected = {
-        format: 'rss' as const,
+      const expected: AnyFeed = {
+        format: 'rss',
         feed: {
           title: 'Feed',
           link: 'https://example.com/feed',
@@ -297,8 +319,8 @@ describe('parse', () => {
           </channel>
         </rss>
       `
-      const expected = {
-        format: 'rss' as const,
+      const expected: AnyFeed = {
+        format: 'rss',
         feed: {
           title: 'Feed',
           link: 'https://example.com/feed',
@@ -320,8 +342,8 @@ describe('parse', () => {
           <id>example-feed</id>
         </feed>
       `
-      const expected = {
-        format: 'atom' as const,
+      const expected: AnyFeed = {
+        format: 'atom',
         feed: {
           title: { value: 'Feed' },
           id: 'example-feed',
@@ -351,8 +373,8 @@ describe('parse', () => {
           </item>
         </rdf:RDF>
       `
-      const expected = {
-        format: 'rdf' as const,
+      const expected: AnyFeed = {
+        format: 'rdf',
         feed: {
           title: 'Example Feed',
           link: 'http://example.org',
@@ -382,8 +404,8 @@ describe('parse', () => {
           </channel>
         </rss>
       `
-      const expected = {
-        format: 'rss' as const,
+      const expected: AnyFeed = {
+        format: 'rss',
         feed: {
           title: 'Feed',
           link: 'https://example.com/feed',
@@ -406,8 +428,8 @@ describe('parse', () => {
         </rss>
         Warning: Cannot modify header information - headers already sent in /var/www/html/wp-includes/pluggable.php on line 1234
       `
-      const expected = {
-        format: 'rss' as const,
+      const expected: AnyFeed = {
+        format: 'rss',
         feed: {
           title: 'Feed',
           link: 'https://example.com/feed',
@@ -428,8 +450,8 @@ describe('parse', () => {
 
         Notice: Undefined index: cache_key in /var/www/html/wp-content/plugins/plugin.php on line 56
       `
-      const expected = {
-        format: 'atom' as const,
+      const expected: AnyFeed = {
+        format: 'atom',
         feed: {
           title: { value: 'Feed' },
           id: 'example-feed',
@@ -451,16 +473,32 @@ describe('parse', () => {
           </channel>
         </rss>
       `
-      const result = parse(value, { parseDateFn: (raw) => new Date(raw) })
-      const expected = {
-        format: 'rss' as const,
+      const expected: AnyFeed<Date> = {
+        format: 'rss',
         feed: {
           title: 'Test',
           pubDate: new Date('Wed, 15 Mar 2023 12:00:00 GMT'),
         },
       }
 
-      expect(result).toEqual(expected)
+      expect(parse(value, { parseDateFn: (raw) => new Date(raw) })).toEqual(expected)
     })
+  })
+
+  it.todo('should prefer earlier formats in detection order for ambiguous input', () => {
+    // parse() runs the rss, atom, rdf and json detectors in that order.
+    // Craft an input that matches more than one detector and pin which format wins.
+  })
+
+  it.todo('should parse feed with a BOM prefix', () => {
+    // Prepend the BOM character (U+FEFF) to a valid RSS string.
+    // Expected: detection still succeeds and the parsed result matches the same feed without
+    // the BOM.
+  })
+
+  it.todo('should pass maxItems option through to the format parser', () => {
+    // Parse an RSS feed with three items and maxItems: 2.
+    // Expected: only the first two items are returned, proving options beyond parseDateFn reach
+    // the underlying format parser.
   })
 })

--- a/src/common/utils.test.ts
+++ b/src/common/utils.test.ts
@@ -5,6 +5,7 @@ import type { ParseUtilExact } from './types.js'
 import {
   createNamespaceNormalizator,
   detectNamespaces,
+  expandStopNodes,
   generateBoolean,
   generateCdataString,
   generateCsvOf,
@@ -14,6 +15,7 @@ import {
   generateRdfResource,
   generateRfc822Date,
   generateRfc3339Date,
+  generateTextOrCdataString,
   generateXml,
   generateXmlStylesheet,
   generateYesNoBoolean,
@@ -159,6 +161,10 @@ describe('isObject', () => {
     expect(isObject(new RegExp('.'))).toBe(false)
     expect(isObject(new ArrayBuffer(10))).toBe(false)
   })
+
+  it('should return false for objects with null prototype', () => {
+    expect(isObject(Object.create(null))).toBe(false)
+  })
 })
 
 describe('isNonEmptyString', () => {
@@ -179,6 +185,12 @@ describe('isNonEmptyString', () => {
   it('should return false for empty strings', () => {
     expect(isNonEmptyString('')).toBe(false)
     expect(isNonEmptyString(' ')).toBe(false)
+  })
+
+  it('should return false for unicode whitespace-only strings', () => {
+    expect(isNonEmptyString('\u00a0')).toBe(false)
+    expect(isNonEmptyString('\u2002\u2003')).toBe(false)
+    expect(isNonEmptyString('\u3000')).toBe(false)
   })
 
   it('should return false for number', () => {
@@ -303,9 +315,10 @@ describe('retrieveText', () => {
 
     expect(retrieveText(value)).toEqual(value)
   })
+
   it('should return #text property even if it has falsy value (except null/undefined)', () => {
     expect(retrieveText({ '#text': '' })).toBe('')
-    expect(retrieveText({ '#text': 0 })).toEqual(0)
+    expect(retrieveText({ '#text': 0 })).toBe(0)
     expect(retrieveText({ '#text': false })).toBe(false)
   })
 
@@ -327,11 +340,13 @@ describe('retrieveText', () => {
 
   it('should work with arrays', () => {
     const array = [1, 2, 3]
+
     expect(retrieveText(array)).toEqual(array)
   })
 
   it('should work with dates', () => {
     const date = new Date()
+
     expect(retrieveText(date)).toEqual(date)
   })
 
@@ -355,7 +370,7 @@ describe('retrieveText', () => {
 
   it('should return primitive values as is', () => {
     expect(retrieveText('string value')).toBe('string value')
-    expect(retrieveText(42)).toEqual(42)
+    expect(retrieveText(42)).toBe(42)
     expect(retrieveText(true)).toBe(true)
     expect(retrieveText(false)).toBe(false)
   })
@@ -501,6 +516,45 @@ describe('retrieveRdfResourceOrText', () => {
         '@rdf:resource': '  https://example.com/license  ',
       }
       const expected = 'https://example.com/license'
+
+      expect(retrieveRdfResourceOrText(value, parseString)).toBe(expected)
+    })
+
+    it('should extract value from @resource attribute', () => {
+      const value = {
+        '@resource': 'https://creativecommons.org/licenses/by/4.0/',
+      }
+      const expected = 'https://creativecommons.org/licenses/by/4.0/'
+
+      expect(retrieveRdfResourceOrText(value, parseString)).toBe(expected)
+    })
+
+    it('should prefer @rdf:resource over @resource when both present', () => {
+      const value = {
+        '@rdf:resource': 'https://creativecommons.org/licenses/by/4.0/',
+        '@resource': 'https://example.com/other-license',
+      }
+      const expected = 'https://creativecommons.org/licenses/by/4.0/'
+
+      expect(retrieveRdfResourceOrText(value, parseString)).toBe(expected)
+    })
+
+    it('should fall back to @resource when @rdf:resource is empty', () => {
+      const value = {
+        '@rdf:resource': '',
+        '@resource': 'https://creativecommons.org/licenses/by/4.0/',
+      }
+      const expected = 'https://creativecommons.org/licenses/by/4.0/'
+
+      expect(retrieveRdfResourceOrText(value, parseString)).toBe(expected)
+    })
+
+    it('should prefer @resource over #text when both present', () => {
+      const value = {
+        '@resource': 'https://creativecommons.org/licenses/by/4.0/',
+        '#text': 'https://example.com/other-license',
+      }
+      const expected = 'https://creativecommons.org/licenses/by/4.0/'
 
       expect(retrieveRdfResourceOrText(value, parseString)).toBe(expected)
     })
@@ -672,12 +726,22 @@ describe('trimArray', () => {
     expect(trimArray(value)).toEqual(expected)
   })
 
-  it('should preserve empty arrays', () => {
+  it('should return undefined for empty arrays', () => {
     expect(trimArray([])).toBeUndefined()
   })
 
   it('should handle arrays with only nullish values', () => {
     expect(trimArray([null, undefined, null])).toBeUndefined()
+  })
+
+  it('should return undefined for non-array inputs', () => {
+    expect(trimArray(undefined)).toBeUndefined()
+    // @ts-expect-error: This is for testing purposes.
+    expect(trimArray('not an array')).toBeUndefined()
+    // @ts-expect-error: This is for testing purposes.
+    expect(trimArray({ 0: 'first', 1: 'second' })).toBeUndefined()
+    // @ts-expect-error: This is for testing purposes.
+    expect(trimArray(42)).toBeUndefined()
   })
 
   describe('with parsing function', () => {
@@ -955,24 +1019,6 @@ describe('parseString', () => {
     expect(parseString(value)).toBe(expected)
   })
 
-  it('Should handle entities #10', () => {
-    // Decode escaped script tag with entities in non-CDATA content.
-    const value =
-      '&lt;script&gt;function test() { if (x &lt; y &amp;&amp; z &gt; 0) { alert(&quot;Hello!&quot;); } }&lt;/script&gt;'
-    const expected = '<script>function test() { if (x < y && z > 0) { alert("Hello!"); } }</script>'
-
-    expect(parseString(value)).toBe(expected)
-  })
-
-  it('Should handle entities #11', () => {
-    // Preserve script tag content inside CDATA sections.
-    const value =
-      '<![CDATA[<script>function test() { if (x < y && z > 0) { alert("Hello!"); } }</script>]]>'
-    const expected = '<script>function test() { if (x < y && z > 0) { alert("Hello!"); } }</script>'
-
-    expect(parseString(value)).toBe(expected)
-  })
-
   it('should preserve HTML entities inside CDATA (content:encoded scenario)', () => {
     const value = '<![CDATA[<p>Use <code>&lt;link rel="alternate"&gt;</code> in your HTML.</p>]]>'
     const expected = '<p>Use <code>&lt;link rel="alternate"&gt;</code> in your HTML.</p>'
@@ -998,18 +1044,6 @@ describe('parseString', () => {
     const value = '<![CDATA[content &amp; more'
 
     expect(parseString(value)).toBe('<![CDATA[content & more')
-  })
-
-  it('Should handle empty string in CDATA', () => {
-    const value = '<![CDATA[        ]]>'
-
-    expect(parseString(value)).toBeUndefined()
-  })
-
-  it('Should trim string in CDATA', () => {
-    const value = '<![CDATA[    test    ]]>'
-
-    expect(parseString(value)).toBe('test')
   })
 
   it('should strip XML comments from text', () => {
@@ -1083,7 +1117,6 @@ describe('parseString', () => {
   })
 
   describe('XML spec compliance', () => {
-    // XML §4.1: Character and Entity References (outside CDATA)
     describe('entity references outside CDATA (XML §4.1)', () => {
       const cases = [
         { value: '&lt;', expected: '<', name: '&lt; to <' },
@@ -1102,7 +1135,6 @@ describe('parseString', () => {
       }
     })
 
-    // Single-decode behavior (prevents double-decoding data corruption)
     describe('single-decode behavior (no double-decoding)', () => {
       const cases = [
         { value: '&amp;lt;', expected: '&lt;', name: '&amp;lt; to &lt; (not <)' },
@@ -1119,7 +1151,6 @@ describe('parseString', () => {
       }
     })
 
-    // XML §2.7: CDATA Sections (verbatim passthrough)
     describe('CDATA verbatim passthrough (XML §2.7)', () => {
       const cases = [
         { value: '<![CDATA[&lt;]]>', expected: '&lt;', name: '&lt; inside CDATA' },
@@ -1137,7 +1168,6 @@ describe('parseString', () => {
       }
     })
 
-    // Mixed content: outside decoded, inside verbatim
     describe('mixed content (CDATA + regular text)', () => {
       const cases = [
         {
@@ -1169,7 +1199,6 @@ describe('parseString', () => {
       }
     })
 
-    // Real-world feed examples (from feed-parser issue #209)
     describe('real-world feed examples', () => {
       const cases = [
         {
@@ -1177,7 +1206,7 @@ describe('parseString', () => {
             '<![CDATA[<pre class="code-block"><code>&lt;div&gt;\n  &lt;a&gt;1&lt;/a&gt;\n&lt;/div&gt;</code></pre>]]>',
           expected:
             '<pre class="code-block"><code>&lt;div&gt;\n  &lt;a&gt;1&lt;/a&gt;\n&lt;/div&gt;</code></pre>',
-          name: 'CSS-Tricks: code block with escaped HTML inside CDATA',
+          name: 'Tech blog: code block with escaped HTML inside CDATA',
         },
         {
           value:
@@ -1189,7 +1218,7 @@ describe('parseString', () => {
           value:
             '&lt;li&gt;&lt;code&gt;&amp;lt;bluesky-likes&amp;gt;&lt;/code&gt; — displays likes&lt;/li&gt;',
           expected: '<li><code>&lt;bluesky-likes&gt;</code> — displays likes</li>',
-          name: 'Lea Verou: double-escaped custom element',
+          name: 'Personal blog: double-escaped custom element',
         },
         {
           value:
@@ -1207,7 +1236,7 @@ describe('parseString', () => {
         {
           value: 'Learn about &amp;lt;template&amp;gt; and &amp;lt;slot&amp;gt; elements',
           expected: 'Learn about &lt;template&gt; and &lt;slot&gt; elements',
-          name: 'WordPress: double-encoded HTML tags',
+          name: 'CMS blog: double-encoded HTML tags',
         },
         {
           value: '<![CDATA[<p>Use <code>&lt;script type="module"&gt;</code> for ES modules</p>]]>',
@@ -1318,7 +1347,7 @@ describe('parseNumber', () => {
   it('should handle numeric string', () => {
     const value = '36.6'
 
-    expect(parseNumber(value)).toEqual(36.6)
+    expect(parseNumber(value)).toBe(36.6)
   })
 
   it('should handle empty string', () => {
@@ -1336,7 +1365,7 @@ describe('parseNumber', () => {
   it('should return number', () => {
     const value = 420
 
-    expect(parseNumber(value)).toEqual(value)
+    expect(parseNumber(value)).toBe(value)
   })
 
   it('should return boolean', () => {
@@ -1404,6 +1433,11 @@ describe('parseBoolean', () => {
     const value = 'javascript'
 
     expect(parseBoolean(value)).toBeUndefined()
+  })
+
+  it('should return undefined for "yes" and "no" strings', () => {
+    expect(parseBoolean('yes')).toBeUndefined()
+    expect(parseBoolean('no')).toBeUndefined()
   })
 
   it('should return number', () => {
@@ -1699,13 +1733,13 @@ describe('generateYesNoBoolean', () => {
 
 describe('parseSingular', () => {
   it('should return the first element of an array', () => {
-    expect(parseSingular([1, 2, 3])).toEqual(1)
+    expect(parseSingular([1, 2, 3])).toBe(1)
     expect(parseSingular(['a', 'b', 'c'])).toBe('a')
     expect(parseSingular([{ key: 'value' }, { another: 'object' }])).toEqual({ key: 'value' })
   })
 
   it('should return the value itself when not an array', () => {
-    expect(parseSingular(42)).toEqual(42)
+    expect(parseSingular(42)).toBe(42)
     expect(parseSingular('string')).toBe('string')
     expect(parseSingular(true)).toBe(true)
     expect(parseSingular({ key: 'value' })).toEqual({ key: 'value' })
@@ -1751,7 +1785,7 @@ describe('parseSingularOf', () => {
 
   it('should apply parse function to non-array values', () => {
     expect(parseSingularOf(42, parseString)).toBe('42')
-    expect(parseSingularOf('123', parseNumber)).toEqual(123)
+    expect(parseSingularOf('123', parseNumber)).toBe(123)
     expect(parseSingularOf('true', parseBoolean)).toBe(true)
   })
 
@@ -1798,7 +1832,7 @@ describe('parseSingularOf', () => {
 
 describe('parseArray', () => {
   it('should handle arrays', () => {
-    const value1 = [] as Array<string>
+    const value1: Array<string> = []
     const value2 = [1, 2, 3]
     const value3 = new Array(5)
 
@@ -1823,7 +1857,7 @@ describe('parseArray', () => {
     expect(parseArray(value2)).toEqual([undefined, undefined, undefined])
   })
 
-  it('should return false for non-sequential or non-zero-indexed objects', () => {
+  it('should return undefined for non-sequential or non-zero-indexed objects', () => {
     const value1 = { 1: 'a', 2: 'b' }
     const value2 = { 0: 'a', 2: 'b' }
     const value3 = { a: 1, b: 2 }
@@ -1835,7 +1869,7 @@ describe('parseArray', () => {
     expect(parseArray(value4)).toBeUndefined()
   })
 
-  it('should return false for primitive types', () => {
+  it('should return undefined for primitive types', () => {
     const value1 = null
     const value2 = undefined
     const value3 = 42
@@ -1853,7 +1887,7 @@ describe('parseArray', () => {
     expect(parseArray(value7)).toBeUndefined()
   })
 
-  it('should return false for other object types', () => {
+  it('should return undefined for other object types', () => {
     const value1 = {}
     const value2 = new Set([1, 2, 3])
     const value3 = new Map()
@@ -1902,6 +1936,26 @@ describe('parseArrayOf', () => {
     const value = 420
 
     expect(parseArrayOf(value, parser)).toEqual(['420'])
+  })
+
+  it('should limit number of items when limit is provided', () => {
+    const value = ['John', 'Jane', 'Jack']
+    const expected = ['John', 'Jane']
+
+    expect(parseArrayOf(value, parser, 2)).toEqual(expected)
+  })
+
+  it('should return all items when limit exceeds array length', () => {
+    const value = ['John', 'Jane']
+    const expected = ['John', 'Jane']
+
+    expect(parseArrayOf(value, parser, 10)).toEqual(expected)
+  })
+
+  it('should return undefined when limit is 0', () => {
+    const value = ['John', 'Jane', 'Jack']
+
+    expect(parseArrayOf(value, parser, 0)).toBeUndefined()
   })
 
   it('should handle boolean', () => {
@@ -2075,12 +2129,6 @@ describe('parseCsvOf', () => {
     expect(parseCsvOf(value, parseNumber)).toBeUndefined()
   })
 
-  it('should handle empty string', () => {
-    const value = ''
-
-    expect(parseCsvOf(value, parseNumber)).toBeUndefined()
-  })
-
   it('should handle empty keywords (just commas)', () => {
     const value = ',,'
 
@@ -2113,42 +2161,42 @@ describe('generateCsvOf', () => {
     const value = ['podcast', 'technology', 'programming']
     const expected = 'podcast,technology,programming'
 
-    expect(generateCsvOf(value)).toEqual(expected)
+    expect(generateCsvOf(value)).toBe(expected)
   })
 
   it('should generate comma-separated string from numbers', () => {
     const value = [1, 2, 3, 4, 5]
     const expected = '1,2,3,4,5'
 
-    expect(generateCsvOf(value)).toEqual(expected)
+    expect(generateCsvOf(value)).toBe(expected)
   })
 
   it('should handle single item array', () => {
     const value = ['podcast']
     const expected = 'podcast'
 
-    expect(generateCsvOf(value)).toEqual(expected)
+    expect(generateCsvOf(value)).toBe(expected)
   })
 
   it('should handle mixed types', () => {
     const value = [1, 'podcast', true, null]
     const expected = '1,podcast,true'
 
-    expect(generateCsvOf(value)).toEqual(expected)
+    expect(generateCsvOf(value)).toBe(expected)
   })
 
   it('should use generate function when provided', () => {
     const value = ['  podcast  ', '  technology  ', '  programming  ']
     const expected = 'podcast,technology,programming'
 
-    expect(generateCsvOf(value, parseString)).toEqual(expected)
+    expect(generateCsvOf(value, parseString)).toBe(expected)
   })
 
   it('should filter out undefined values with generate function', () => {
     const value = ['1', 'invalid', '2', 'also invalid', '3']
     const expected = '1,2,3'
 
-    expect(generateCsvOf(value, parseNumber)).toEqual(expected)
+    expect(generateCsvOf(value, parseNumber)).toBe(expected)
   })
 
   it('should return undefined for empty array', () => {
@@ -2173,12 +2221,12 @@ describe('generateCsvOf', () => {
     const value = [0, '', false]
     const expected = '0,,false'
 
-    expect(generateCsvOf(value)).toEqual(expected)
+    expect(generateCsvOf(value)).toBe(expected)
   })
 })
 
 describe('generateXmlStylesheet', () => {
-  describe('Required attributes', () => {
+  describe('required attributes', () => {
     it('should generate stylesheet with only required attributes', () => {
       const value = {
         type: 'text/xsl',
@@ -2200,7 +2248,7 @@ describe('generateXmlStylesheet', () => {
     })
   })
 
-  describe('Optional attributes', () => {
+  describe('optional attributes', () => {
     it('should include title when provided', () => {
       const value = {
         type: 'text/xsl',
@@ -2221,6 +2269,17 @@ describe('generateXmlStylesheet', () => {
       }
       const expected =
         '<?xml-stylesheet type="text/css" href="/styles/mobile.css" media="screen and (max-width: 768px)"?>'
+
+      expect(generateXmlStylesheet(value)).toBe(expected)
+    })
+
+    it('should include alternate="yes" when alternate is true', () => {
+      const value = {
+        type: 'text/xsl',
+        href: '/styles/feed.xsl',
+        alternate: true,
+      }
+      const expected = '<?xml-stylesheet type="text/xsl" href="/styles/feed.xsl" alternate="yes"?>'
 
       expect(generateXmlStylesheet(value)).toBe(expected)
     })
@@ -2256,7 +2315,7 @@ describe('generateXmlStylesheet', () => {
     })
   })
 
-  describe('Special characters', () => {
+  describe('special characters', () => {
     it('should handle URLs with query parameters', () => {
       const value = {
         type: 'text/xsl',
@@ -2281,7 +2340,7 @@ describe('generateXmlStylesheet', () => {
     })
   })
 
-  describe('Edge cases', () => {
+  describe('edge cases', () => {
     it('should return undefined when all fields are empty strings', () => {
       const value = {
         type: '',
@@ -2325,28 +2384,28 @@ describe('generateXml', () => {
     const value = 'test content'
     const expected = '<?xml version="1.0" encoding="utf-8"?>\n<root>test content</root>'
 
-    expect(generateXml(mockBuilder, value)).toEqual(expected)
+    expect(generateXml(mockBuilder, value)).toBe(expected)
   })
 
   it('should replace single apostrophe entity', () => {
     const value = 'don&apos;t'
     const expected = '<?xml version="1.0" encoding="utf-8"?>\n<root>don\'t</root>'
 
-    expect(generateXml(mockBuilder, value)).toEqual(expected)
+    expect(generateXml(mockBuilder, value)).toBe(expected)
   })
 
   it('should replace multiple apostrophe entities', () => {
     const value = 'don&apos;t worry, it&apos;s fine'
     const expected = '<?xml version="1.0" encoding="utf-8"?>\n<root>don\'t worry, it\'s fine</root>'
 
-    expect(generateXml(mockBuilder, value)).toEqual(expected)
+    expect(generateXml(mockBuilder, value)).toBe(expected)
   })
 
   it('should handle empty value input', () => {
     const value = ''
     const expected = '<?xml version="1.0" encoding="utf-8"?>\n<root></root>'
 
-    expect(generateXml(mockBuilder, value)).toEqual(expected)
+    expect(generateXml(mockBuilder, value)).toBe(expected)
   })
 
   it('should include single stylesheet when provided', () => {
@@ -2357,7 +2416,7 @@ describe('generateXml', () => {
     const expected =
       '<?xml version="1.0" encoding="utf-8"?>\n<?xml-stylesheet type="text/xsl" href="/styles/feed.xsl"?>\n<root>test content</root>'
 
-    expect(generateXml(mockBuilder, value, options)).toEqual(expected)
+    expect(generateXml(mockBuilder, value, options)).toBe(expected)
   })
 
   it('should include multiple stylesheets when provided', () => {
@@ -2371,7 +2430,7 @@ describe('generateXml', () => {
     const expected =
       '<?xml version="1.0" encoding="utf-8"?>\n<?xml-stylesheet type="text/xsl" href="/styles/feed.xsl"?>\n<?xml-stylesheet type="text/css" href="/styles/feed.css" media="screen"?>\n<root>test content</root>'
 
-    expect(generateXml(mockBuilder, value, options)).toEqual(expected)
+    expect(generateXml(mockBuilder, value, options)).toBe(expected)
   })
 
   it('should generate XML without stylesheets when array is empty', () => {
@@ -2381,7 +2440,7 @@ describe('generateXml', () => {
     }
     const expected = '<?xml version="1.0" encoding="utf-8"?>\n<root>test content</root>'
 
-    expect(generateXml(mockBuilder, value, options)).toEqual(expected)
+    expect(generateXml(mockBuilder, value, options)).toBe(expected)
   })
 
   it('should generate XML without stylesheets when stylesheets is undefined', () => {
@@ -2389,14 +2448,14 @@ describe('generateXml', () => {
     const options = {}
     const expected = '<?xml version="1.0" encoding="utf-8"?>\n<root>test content</root>'
 
-    expect(generateXml(mockBuilder, value, options)).toEqual(expected)
+    expect(generateXml(mockBuilder, value, options)).toBe(expected)
   })
 
   it('should generate XML without stylesheets when options parameter is undefined', () => {
     const value = 'test content'
     const expected = '<?xml version="1.0" encoding="utf-8"?>\n<root>test content</root>'
 
-    expect(generateXml(mockBuilder, value, undefined)).toEqual(expected)
+    expect(generateXml(mockBuilder, value, undefined)).toBe(expected)
   })
 })
 
@@ -2405,66 +2464,67 @@ describe('generateRfc822Date', () => {
     const value = new Date('2023-03-15T12:00:00Z')
     const expected = 'Wed, 15 Mar 2023 12:00:00 GMT'
 
-    expect(generateRfc822Date(value)).toEqual(expected)
+    expect(generateRfc822Date(value)).toBe(expected)
   })
 
   it('should format valid date string to RFC822 string', () => {
     const value = '2023-03-15T12:00:00Z'
     const expected = 'Wed, 15 Mar 2023 12:00:00 GMT'
 
-    expect(generateRfc822Date(value)).toEqual(expected)
+    expect(generateRfc822Date(value)).toBe(expected)
   })
 
   it('should handle date string with milliseconds', () => {
     const value = '2023-05-17T15:02:07.123Z'
     const expected = 'Wed, 17 May 2023 15:02:07 GMT'
 
-    expect(generateRfc822Date(value)).toEqual(expected)
+    expect(generateRfc822Date(value)).toBe(expected)
   })
 
   it('should handle date string without milliseconds', () => {
     const value = '2023-05-17T15:02:07Z'
     const expected = 'Wed, 17 May 2023 15:02:07 GMT'
 
-    expect(generateRfc822Date(value)).toEqual(expected)
+    expect(generateRfc822Date(value)).toBe(expected)
   })
 
   it('should handle Date object with milliseconds', () => {
     const value = new Date('2023-05-17T15:02:07.123Z')
     const expected = 'Wed, 17 May 2023 15:02:07 GMT'
 
-    expect(generateRfc822Date(value)).toEqual(expected)
+    expect(generateRfc822Date(value)).toBe(expected)
   })
 
   it('should handle timezone conversion to UTC', () => {
     const value = new Date('2023-05-17T15:02:07.000+02:00')
     const expected = 'Wed, 17 May 2023 13:02:07 GMT'
 
-    expect(generateRfc822Date(value)).toEqual(expected)
+    expect(generateRfc822Date(value)).toBe(expected)
   })
 
   it('should handle edge case dates', () => {
     const unixEpoch = new Date('1970-01-01T00:00:00.000Z')
     const expected = 'Thu, 01 Jan 1970 00:00:00 GMT'
 
-    expect(generateRfc822Date(unixEpoch)).toEqual(expected)
+    expect(generateRfc822Date(unixEpoch)).toBe(expected)
   })
 
   it('should handle future dates', () => {
     const futureDate = new Date('2099-12-31T23:59:59.999Z')
     const expected = 'Thu, 31 Dec 2099 23:59:59 GMT'
 
-    expect(generateRfc822Date(futureDate)).toEqual(expected)
+    expect(generateRfc822Date(futureDate)).toBe(expected)
   })
 
   it('should return original string for invalid date string', () => {
-    expect(generateRfc822Date('not a date')).toEqual('not a date')
-    expect(generateRfc822Date('invalid date string')).toEqual('invalid date string')
-    expect(generateRfc822Date('2023-13-45')).toEqual('2023-13-45')
+    expect(generateRfc822Date('not a date')).toBe('not a date')
+    expect(generateRfc822Date('invalid date string')).toBe('invalid date string')
+    expect(generateRfc822Date('2023-13-45')).toBe('2023-13-45')
   })
 
   it('should return undefined for invalid Date object', () => {
     const invalidDate = new Date('invalid')
+
     expect(generateRfc822Date(invalidDate)).toBeUndefined()
   })
 
@@ -2482,66 +2542,67 @@ describe('generateRfc3339Date', () => {
     const value = new Date('2023-03-15T12:00:00Z')
     const expected = '2023-03-15T12:00:00.000Z'
 
-    expect(generateRfc3339Date(value)).toEqual(expected)
+    expect(generateRfc3339Date(value)).toBe(expected)
   })
 
   it('should format valid date string to RFC3339 string', () => {
     const value = '2023-03-15T12:00:00Z'
     const expected = '2023-03-15T12:00:00.000Z'
 
-    expect(generateRfc3339Date(value)).toEqual(expected)
+    expect(generateRfc3339Date(value)).toBe(expected)
   })
 
   it('should handle date string with milliseconds', () => {
     const value = '2023-05-17T15:02:07.123Z'
     const expected = '2023-05-17T15:02:07.123Z'
 
-    expect(generateRfc3339Date(value)).toEqual(expected)
+    expect(generateRfc3339Date(value)).toBe(expected)
   })
 
   it('should handle date string without milliseconds', () => {
     const value = '2023-05-17T15:02:07Z'
     const expected = '2023-05-17T15:02:07.000Z'
 
-    expect(generateRfc3339Date(value)).toEqual(expected)
+    expect(generateRfc3339Date(value)).toBe(expected)
   })
 
   it('should handle Date object with milliseconds', () => {
     const value = new Date('2023-05-17T15:02:07.123Z')
     const expected = '2023-05-17T15:02:07.123Z'
 
-    expect(generateRfc3339Date(value)).toEqual(expected)
+    expect(generateRfc3339Date(value)).toBe(expected)
   })
 
   it('should handle timezone conversion to UTC', () => {
     const value = new Date('2023-05-17T15:02:07.000+02:00')
     const expected = '2023-05-17T13:02:07.000Z'
 
-    expect(generateRfc3339Date(value)).toEqual(expected)
+    expect(generateRfc3339Date(value)).toBe(expected)
   })
 
   it('should handle edge case dates', () => {
     const unixEpoch = new Date('1970-01-01T00:00:00.000Z')
     const expected = '1970-01-01T00:00:00.000Z'
 
-    expect(generateRfc3339Date(unixEpoch)).toEqual(expected)
+    expect(generateRfc3339Date(unixEpoch)).toBe(expected)
   })
 
   it('should handle future dates', () => {
     const futureDate = new Date('2099-12-31T23:59:59.999Z')
     const expected = '2099-12-31T23:59:59.999Z'
 
-    expect(generateRfc3339Date(futureDate)).toEqual(expected)
+    expect(generateRfc3339Date(futureDate)).toBe(expected)
   })
 
   it('should return original string for invalid date string', () => {
-    expect(generateRfc3339Date('not a date')).toEqual('not a date')
-    expect(generateRfc3339Date('invalid date string')).toEqual('invalid date string')
-    expect(generateRfc3339Date('2023-13-45')).toEqual('2023-13-45')
+    expect(generateRfc3339Date('not a date')).toBe('not a date')
+    expect(generateRfc3339Date('invalid date string')).toBe('invalid date string')
+    expect(generateRfc3339Date('2023-13-45')).toBe('2023-13-45')
   })
 
   it('should return undefined for invalid Date object', () => {
     const invalidDate = new Date('invalid')
+
     expect(generateRfc3339Date(invalidDate)).toBeUndefined()
   })
 
@@ -2926,6 +2987,16 @@ describe('detectNamespaces', () => {
     expect(detectNamespaces(value, true)).toEqual(expectedRecursive)
   })
 
+  it('should return empty set for non-object input', () => {
+    const expected = new Set<string>()
+
+    expect(detectNamespaces(null)).toEqual(expected)
+    expect(detectNamespaces(undefined)).toEqual(expected)
+    expect(detectNamespaces('atom:link')).toEqual(expected)
+    expect(detectNamespaces(42)).toEqual(expected)
+    expect(detectNamespaces(true)).toEqual(expected)
+  })
+
   it('should respect seenKeys optimization in recursive mode', () => {
     const value = {
       'duplicate:key': 'value1',
@@ -3160,9 +3231,9 @@ describe('generateCdataString', () => {
     const expected2 = 'Text with numbers 123 and spaces'
     const expected3 = 'Text with special chars !@#$%^*()_+-='
 
-    expect(generateCdataString(value1)).toEqual(expected1)
-    expect(generateCdataString(value2)).toEqual(expected2)
-    expect(generateCdataString(value3)).toEqual(expected3)
+    expect(generateCdataString(value1)).toBe(expected1)
+    expect(generateCdataString(value2)).toBe(expected2)
+    expect(generateCdataString(value3)).toBe(expected3)
   })
 
   it('should handle empty string', () => {
@@ -3182,6 +3253,57 @@ describe('generateCdataString', () => {
   })
 })
 
+describe('generateTextOrCdataString', () => {
+  it('should wrap simple text in #text object', () => {
+    const value = 'Simple text content'
+    const expected = { '#text': 'Simple text content' }
+
+    expect(generateTextOrCdataString(value)).toEqual(expected)
+  })
+
+  it('should trim simple text before wrapping in #text object', () => {
+    const value = '  Text with spaces  '
+    const expected = { '#text': 'Text with spaces' }
+
+    expect(generateTextOrCdataString(value)).toEqual(expected)
+  })
+
+  it('should wrap HTML content in #cdata object', () => {
+    const value = '<p>HTML content</p>'
+    const expected = { '#cdata': '<p>HTML content</p>' }
+
+    expect(generateTextOrCdataString(value)).toEqual(expected)
+  })
+
+  it('should wrap content with ampersands in #cdata object', () => {
+    const value = 'Text with & ampersand'
+    const expected = { '#cdata': 'Text with & ampersand' }
+
+    expect(generateTextOrCdataString(value)).toEqual(expected)
+  })
+
+  it('should handle empty string', () => {
+    const value = ''
+
+    expect(generateTextOrCdataString(value)).toBeUndefined()
+  })
+
+  it('should handle string with only whitespace', () => {
+    const value = '   '
+
+    expect(generateTextOrCdataString(value)).toBeUndefined()
+  })
+
+  it('should handle non-string inputs', () => {
+    expect(generateTextOrCdataString(undefined)).toBeUndefined()
+  })
+
+  it.todo('should handle text containing a CDATA end marker', () => {
+    // A value containing ']]>' is wrapped verbatim in #cdata, which produces invalid XML.
+    // Decide whether the marker should be split across multiple CDATA sections and pin the output.
+  })
+})
+
 describe('generatePlainString', () => {
   it('should return trimmed string for simple text', () => {
     const value1 = 'Simple text content'
@@ -3191,9 +3313,9 @@ describe('generatePlainString', () => {
     const expected2 = 'Text with spaces'
     const expected3 = 'Text with special chars !@#$%^*()_+-='
 
-    expect(generatePlainString(value1)).toEqual(expected1)
-    expect(generatePlainString(value2)).toEqual(expected2)
-    expect(generatePlainString(value3)).toEqual(expected3)
+    expect(generatePlainString(value1)).toBe(expected1)
+    expect(generatePlainString(value2)).toBe(expected2)
+    expect(generatePlainString(value3)).toBe(expected3)
   })
 
   it('should return string even if it contains XML characters', () => {
@@ -3204,9 +3326,9 @@ describe('generatePlainString', () => {
     const expected2 = 'Text with & ampersand'
     const expected3 = 'Content with > greater than'
 
-    expect(generatePlainString(value1)).toEqual(expected1)
-    expect(generatePlainString(value2)).toEqual(expected2)
-    expect(generatePlainString(value3)).toEqual(expected3)
+    expect(generatePlainString(value1)).toBe(expected1)
+    expect(generatePlainString(value2)).toBe(expected2)
+    expect(generatePlainString(value3)).toBe(expected3)
   })
 
   it('should handle empty string', () => {
@@ -4334,6 +4456,13 @@ describe('parseJsonObject', () => {
     expect(parseJsonObject(value)).toBeUndefined()
   })
 
+  it('should parse empty JSON object string', () => {
+    const value = '{}'
+    const expected = {}
+
+    expect(parseJsonObject(value)).toEqual(expected)
+  })
+
   it('should return undefined for malformed JSON', () => {
     const value = '{"title":"Test"'
 
@@ -4352,5 +4481,63 @@ describe('parseJsonObject', () => {
     expect(parseJsonObject(null)).toBeUndefined()
     expect(parseJsonObject(undefined)).toBeUndefined()
     expect(parseJsonObject([1, 2, 3])).toBeUndefined()
+  })
+})
+
+describe('expandStopNodes', () => {
+  it('should expand wildcard stop nodes for each feed container path', () => {
+    const value = ['*.dc:creator']
+    const expected = ['rss.channel.dc:creator', 'rss.channel.item.dc:creator']
+
+    expect(expandStopNodes(value, ['rss.channel', 'rss.channel.item'])).toEqual(expected)
+  })
+
+  it('should expand stop nodes through namespace containers with the same prefix', () => {
+    const value = ['*.media:title']
+    const expected = [
+      'rss.channel.item.media:title',
+      'rss.channel.item.media:group.media:title',
+      'rss.channel.item.media:content.media:title',
+      'rss.channel.item.media:group.media:content.media:title',
+      'rss.channel.item.media:embed.media:title',
+    ]
+
+    expect(expandStopNodes(value, ['rss.channel.item'])).toEqual(expected)
+  })
+
+  it('should not cross namespace containers with a different prefix', () => {
+    const value = ['*.podcast:transcript']
+    const expected = [
+      'rss.channel.item.podcast:transcript',
+      'rss.channel.item.podcast:liveitem.podcast:transcript',
+    ]
+
+    expect(expandStopNodes(value, ['rss.channel.item'])).toEqual(expected)
+  })
+
+  it('should deduplicate repeated stop nodes', () => {
+    const value = ['*.dc:creator', '*.dc:creator']
+    const expected = ['rss.channel.dc:creator']
+
+    expect(expandStopNodes(value, ['rss.channel'])).toEqual(expected)
+  })
+
+  it('should return empty array for empty stop nodes', () => {
+    const value: Array<string> = []
+    const expected: Array<string> = []
+
+    expect(expandStopNodes(value, ['rss.channel'])).toEqual(expected)
+  })
+
+  it('should return empty array for empty feed container paths', () => {
+    const value = ['*.dc:creator']
+    const expected: Array<string> = []
+
+    expect(expandStopNodes(value, [])).toEqual(expected)
+  })
+
+  it.todo('should handle stop nodes without the *. wildcard prefix', () => {
+    // expandStopNodes slices the first two characters assuming a '*.' prefix.
+    // Pin the behavior for stop nodes given as explicit paths like 'rss.channel.dc:creator'.
   })
 })

--- a/src/feeds/atom/detect/index.test.ts
+++ b/src/feeds/atom/detect/index.test.ts
@@ -137,17 +137,11 @@ describe('detect', () => {
     expect(detect(wrongNamespace)).toBe(false)
   })
 
-  // it('return false for feed element in XML comments', () => {
-  //   const commentedFeed = `
-  //     <?xml version="1.0"?>
-  //     <root>
-  //       <!-- <feed xmlns="http://www.w3.org/2005/Atom"><title>Test</title></feed> -->
-  //       <content>Not a feed</content>
-  //     </root>
-  //   `
-
-  //   expect(detect(commentedFeed)).toBe(false)
-  // })
+  it.todo('should return false for feed element in XML comments', () => {
+    // A <feed> element placed inside an XML comment (<!-- <feed>...</feed> -->) currently yields
+    // a false positive because the regex-based detector does not strip comments. Expected: detect
+    // returns false once comment stripping is implemented.
+  })
 
   it('should return false for RSS feed', () => {
     const rssFeed = `

--- a/src/feeds/atom/generate/index.test.ts
+++ b/src/feeds/atom/generate/index.test.ts
@@ -1,26 +1,22 @@
 import { describe, expect, it } from 'bun:test'
 import { locales } from '../../../common/config.js'
 import { GenerateError } from '../../../common/errors.js'
+import type { DateLike } from '../../../common/types.js'
+import type { AtomFeed } from '../common/types.js'
 import { generate } from './index.js'
 
 describe('generate', () => {
-  const versions = {
-    // TODO: Enable reference tests once advanced features like Text fields being an object of
-    // { value: string, type: 'text' | 'html' | 'xhtml' }
-    // '10': '1.0',
-    // ns: 'with namespaces',
-  }
+  it.todo('should correctly generate Atom 1.0', () => {
+    // Generate from the references/atom-10.json fixture and compare against
+    // references/atom-10.xml. Blocked until text fields support objects of
+    // { value: string, type: 'text' | 'html' | 'xhtml' }.
+  })
 
-  for (const [key, label] of Object.entries(versions)) {
-    it(`should correctly generate Atom ${label}`, async () => {
-      const reference = `${import.meta.dir}/../references/atom-${key}`
-      const input = await Bun.file(`${reference}.json`).json()
-      const expectation = await Bun.file(`${reference}.xml`).text()
-      const result = generate(input)
-
-      expect(result).toEqual(expectation)
-    })
-  }
+  it.todo('should correctly generate Atom with namespaces', () => {
+    // Generate from the references/atom-ns.json fixture and compare against
+    // references/atom-ns.xml. Blocked until text fields support objects of
+    // { value: string, type: 'text' | 'html' | 'xhtml' }.
+  })
 
   it('should generate minimal valid Atom feed', () => {
     const value = {
@@ -593,7 +589,7 @@ describe('generate', () => {
   })
 
   it('should generate Atom feed with googleplay namespace', () => {
-    const value = {
+    const value: AtomFeed.Feed<DateLike> = {
       id: 'https://example.com/feed',
       title: { value: 'Feed with GooglePlay namespace' },
       updated: new Date('2023-03-15T12:00:00Z'),
@@ -608,7 +604,7 @@ describe('generate', () => {
           updated: new Date('2023-03-15T12:00:00Z'),
           googleplay: {
             author: 'Episode Author',
-            explicit: 'clean' as const,
+            explicit: 'clean',
           },
         },
       ],
@@ -952,7 +948,7 @@ describe('generate', () => {
           updated: new Date('2024-01-05T10:30:00Z'),
           pingback: {
             server: 'https://example.com/xmlrpc.php',
-            target: 'https://referenced-blog.com/article',
+            target: 'https://example.net/article',
           },
         },
       ],
@@ -968,7 +964,7 @@ describe('generate', () => {
     <title>Post with Pingback</title>
     <updated>2024-01-05T10:30:00.000Z</updated>
     <pingback:server>https://example.com/xmlrpc.php</pingback:server>
-    <pingback:target>https://referenced-blog.com/article</pingback:target>
+    <pingback:target>https://example.net/article</pingback:target>
   </entry>
 </feed>
 `
@@ -983,7 +979,7 @@ describe('generate', () => {
       updated: new Date('2024-01-10T12:00:00Z'),
       admin: {
         errorReportsTo: 'mailto:webmaster@example.com',
-        generatorAgent: 'http://www.movabletype.org/?v=3.2',
+        generatorAgent: 'https://example.com/generator?v=3.2',
       },
       entries: [
         {
@@ -999,7 +995,7 @@ describe('generate', () => {
   <title>Feed with Admin</title>
   <updated>2024-01-10T12:00:00.000Z</updated>
   <admin:errorReportsTo rdf:resource="mailto:webmaster@example.com"/>
-  <admin:generatorAgent rdf:resource="http://www.movabletype.org/?v=3.2"/>
+  <admin:generatorAgent rdf:resource="https://example.com/generator?v=3.2"/>
   <entry>
     <id>https://example.com/entry/1</id>
     <title>Entry title</title>
@@ -1023,7 +1019,7 @@ describe('generate', () => {
           updated: new Date('2024-01-05T10:30:00Z'),
           trackback: {
             ping: 'https://example.com/trackback/123',
-            abouts: ['https://blog1.com/trackback/456', 'https://blog2.com/trackback/789'],
+            abouts: ['https://example.net/trackback/456', 'https://example.org/trackback/789'],
           },
         },
       ],
@@ -1038,8 +1034,8 @@ describe('generate', () => {
     <title>Post with Trackback</title>
     <updated>2024-01-05T10:30:00.000Z</updated>
     <trackback:ping>https://example.com/trackback/123</trackback:ping>
-    <trackback:about>https://blog1.com/trackback/456</trackback:about>
-    <trackback:about>https://blog2.com/trackback/789</trackback:about>
+    <trackback:about>https://example.net/trackback/456</trackback:about>
+    <trackback:about>https://example.org/trackback/789</trackback:about>
   </entry>
 </feed>
 `
@@ -1145,300 +1141,6 @@ describe('generate', () => {
 
     expect(generate(value, options)).toEqual(expected)
   })
-})
-
-describe('strict mode', () => {
-  it('should require id, title, updated in strict mode', () => {
-    // @ts-expect-error: This is for testing purposes.
-    generate({ title: { value: 'Test' } }, { strict: true })
-  })
-
-  it('should accept feed with all required fields in strict mode', () => {
-    generate(
-      { id: 'https://example.com', title: { value: 'Test' }, updated: new Date() },
-      { strict: true },
-    )
-  })
-
-  it('should require entry fields in strict mode', () => {
-    generate(
-      {
-        id: 'https://example.com',
-        title: { value: 'Test' },
-        updated: new Date(),
-        // @ts-expect-error: This is for testing purposes.
-        entries: [{ id: 'https://example.com/1' }],
-      },
-      { strict: true },
-    )
-  })
-
-  it('should accept entries with all required fields in strict mode', () => {
-    generate(
-      {
-        id: 'https://example.com',
-        title: { value: 'Test' },
-        updated: new Date(),
-        entries: [{ id: 'https://example.com/1', title: { value: 'Entry' }, updated: new Date() }],
-      },
-      { strict: true },
-    )
-  })
-
-  it('should require nested type fields in strict mode', () => {
-    generate(
-      {
-        id: 'https://example.com',
-        title: { value: 'Test' },
-        updated: new Date(),
-        // @ts-expect-error: This is for testing purposes.
-        links: [{ rel: 'self' }],
-      },
-      { strict: true },
-    )
-  })
-
-  it('should accept nested types with all required fields in strict mode', () => {
-    generate(
-      {
-        id: 'https://example.com',
-        title: { value: 'Test' },
-        updated: new Date(),
-        links: [{ href: 'https://example.com/feed.xml', rel: 'self' }],
-        authors: [{ name: 'John Doe' }],
-        categories: [{ term: 'tech' }],
-      },
-      { strict: true },
-    )
-  })
-
-  it('should accept partial feed in lenient mode', () => {
-    generate({ title: { value: 'Test' } })
-  })
-})
-
-describe('generate edge cases', () => {
-  it('should accept partial feeds', () => {
-    const value = {
-      title: { value: 'Test Feed' },
-    }
-    const expected = `<?xml version="1.0" encoding="utf-8"?>
-<feed xmlns="http://www.w3.org/2005/Atom">
-  <title>Test Feed</title>
-</feed>
-`
-
-    expect(generate(value)).toEqual(expected)
-  })
-
-  it('should accept feeds with string dates', () => {
-    const value = {
-      id: 'https://example.com/feed',
-      title: { value: 'Test Feed' },
-      updated: '2023-01-01T00:00:00.000Z',
-    }
-    const expected = `<?xml version="1.0" encoding="utf-8"?>
-<feed xmlns="http://www.w3.org/2005/Atom">
-  <id>https://example.com/feed</id>
-  <title>Test Feed</title>
-  <updated>2023-01-01T00:00:00.000Z</updated>
-</feed>
-`
-
-    expect(generate(value)).toEqual(expected)
-  })
-
-  it('should preserve invalid date strings', () => {
-    const value = {
-      id: 'https://example.com/feed',
-      title: { value: 'Feed with Invalid Date' },
-      updated: 'not-a-valid-date',
-      entries: [
-        {
-          id: 'https://example.com/entry/1',
-          title: { value: 'Entry with invalid date' },
-          updated: 'also-invalid-date',
-        },
-      ],
-    }
-    const expected = `<?xml version="1.0" encoding="utf-8"?>
-<feed xmlns="http://www.w3.org/2005/Atom">
-  <id>https://example.com/feed</id>
-  <title>Feed with Invalid Date</title>
-  <updated>not-a-valid-date</updated>
-  <entry>
-    <id>https://example.com/entry/1</id>
-    <title>Entry with invalid date</title>
-    <updated>also-invalid-date</updated>
-  </entry>
-</feed>
-`
-
-    expect(generate(value)).toEqual(expected)
-  })
-
-  it('should handle mixed Date objects and string dates', () => {
-    const value = {
-      id: 'https://example.com/feed',
-      title: { value: 'Mixed Dates Feed' },
-      updated: new Date('2023-01-01T00:00:00.000Z'),
-      entries: [
-        {
-          id: 'https://example.com/entry/1',
-          title: { value: 'Entry with Date object' },
-          updated: new Date('2023-02-01T00:00:00.000Z'),
-        },
-        {
-          id: 'https://example.com/entry/2',
-          title: { value: 'Entry with string date' },
-          updated: '2023-03-01T00:00:00.000Z',
-        },
-      ],
-    }
-    const expected = `<?xml version="1.0" encoding="utf-8"?>
-<feed xmlns="http://www.w3.org/2005/Atom">
-  <id>https://example.com/feed</id>
-  <title>Mixed Dates Feed</title>
-  <updated>2023-01-01T00:00:00.000Z</updated>
-  <entry>
-    <id>https://example.com/entry/1</id>
-    <title>Entry with Date object</title>
-    <updated>2023-02-01T00:00:00.000Z</updated>
-  </entry>
-  <entry>
-    <id>https://example.com/entry/2</id>
-    <title>Entry with string date</title>
-    <updated>2023-03-01T00:00:00.000Z</updated>
-  </entry>
-</feed>
-`
-
-    expect(generate(value)).toEqual(expected)
-  })
-
-  it('should handle deeply nested partial objects', () => {
-    const value = {
-      id: 'https://example.com/feed',
-      title: { value: 'Feed with Nested Partials' },
-      entries: [
-        {
-          id: 'https://example.com/entry/1',
-          title: { value: 'Entry 1' },
-          author: [
-            {
-              name: 'John Doe',
-            },
-          ],
-          category: [
-            {
-              term: 'tech',
-              label: 'Technology',
-            },
-          ],
-        },
-        {
-          id: 'https://example.com/entry/2',
-          title: { value: 'Minimal Entry' },
-        },
-      ],
-    }
-    const expected = `<?xml version="1.0" encoding="utf-8"?>
-<feed xmlns="http://www.w3.org/2005/Atom">
-  <id>https://example.com/feed</id>
-  <title>Feed with Nested Partials</title>
-  <entry>
-    <id>https://example.com/entry/1</id>
-    <title>Entry 1</title>
-  </entry>
-  <entry>
-    <id>https://example.com/entry/2</id>
-    <title>Minimal Entry</title>
-  </entry>
-</feed>
-`
-
-    expect(generate(value)).toEqual(expected)
-  })
-})
-
-describe('generate with app namespace', () => {
-  it('should generate Atom feed with app namespace', () => {
-    const value = {
-      id: 'http://example.com/blog',
-      title: { value: 'My Blog' },
-      updated: new Date('2024-03-15T16:00:00Z'),
-      entries: [
-        {
-          id: 'http://example.com/blog/post/1',
-          title: { value: 'Article' },
-          updated: new Date('2024-03-15T16:00:00Z'),
-          app: {
-            edited: new Date('2024-03-15T14:30:00Z'),
-            control: {
-              draft: false,
-            },
-          },
-        },
-      ],
-    }
-    const expected = `<?xml version="1.0" encoding="utf-8"?>
-<feed xmlns="http://www.w3.org/2005/Atom" xmlns:app="http://www.w3.org/2007/app">
-  <id>http://example.com/blog</id>
-  <title>My Blog</title>
-  <updated>2024-03-15T16:00:00.000Z</updated>
-  <entry>
-    <id>http://example.com/blog/post/1</id>
-    <title>Article</title>
-    <updated>2024-03-15T16:00:00.000Z</updated>
-    <app:edited>2024-03-15T14:30:00.000Z</app:edited>
-    <app:control>
-      <app:draft>no</app:draft>
-    </app:control>
-  </entry>
-</feed>
-`
-
-    expect(generate(value)).toEqual(expected)
-  })
-
-  it('should generate Atom entry with draft status', () => {
-    const value = {
-      id: 'http://example.com/blog',
-      title: { value: 'Blog' },
-      updated: new Date('2024-03-15T16:00:00Z'),
-      entries: [
-        {
-          id: 'http://example.com/blog/draft',
-          title: { value: 'Draft Article' },
-          updated: new Date('2024-03-15T15:00:00Z'),
-          app: {
-            edited: new Date('2024-03-15T15:00:00Z'),
-            control: {
-              draft: true,
-            },
-          },
-        },
-      ],
-    }
-    const expected = `<?xml version="1.0" encoding="utf-8"?>
-<feed xmlns="http://www.w3.org/2005/Atom" xmlns:app="http://www.w3.org/2007/app">
-  <id>http://example.com/blog</id>
-  <title>Blog</title>
-  <updated>2024-03-15T16:00:00.000Z</updated>
-  <entry>
-    <id>http://example.com/blog/draft</id>
-    <title>Draft Article</title>
-    <updated>2024-03-15T15:00:00.000Z</updated>
-    <app:edited>2024-03-15T15:00:00.000Z</app:edited>
-    <app:control>
-      <app:draft>yes</app:draft>
-    </app:control>
-  </entry>
-</feed>
-`
-
-    expect(generate(value)).toEqual(expected)
-  })
 
   it('should generate Atom feed with xml namespace', () => {
     const value = {
@@ -1475,5 +1177,373 @@ describe('generate with app namespace', () => {
 `
 
     expect(generate(value)).toEqual(expected)
+  })
+
+  describe('strict mode', () => {
+    it('should require id, title, updated in strict mode', () => {
+      const value = { title: { value: 'Test' } }
+      const expected = `<?xml version="1.0" encoding="utf-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <title>Test</title>
+</feed>
+`
+
+      // @ts-expect-error: This is for testing purposes.
+      expect(generate(value, { strict: true })).toEqual(expected)
+    })
+
+    it('should accept feed with all required fields in strict mode', () => {
+      const value = {
+        id: 'https://example.com',
+        title: { value: 'Test' },
+        updated: new Date('2023-03-15T12:00:00Z'),
+      }
+      const expected = `<?xml version="1.0" encoding="utf-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <id>https://example.com</id>
+  <title>Test</title>
+  <updated>2023-03-15T12:00:00.000Z</updated>
+</feed>
+`
+
+      expect(generate(value, { strict: true })).toEqual(expected)
+    })
+
+    it('should require entry fields in strict mode', () => {
+      const value = {
+        id: 'https://example.com',
+        title: { value: 'Test' },
+        updated: new Date('2023-03-15T12:00:00Z'),
+        entries: [{ id: 'https://example.com/1' }],
+      }
+      const expected = `<?xml version="1.0" encoding="utf-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <id>https://example.com</id>
+  <title>Test</title>
+  <updated>2023-03-15T12:00:00.000Z</updated>
+  <entry>
+    <id>https://example.com/1</id>
+  </entry>
+</feed>
+`
+
+      // @ts-expect-error: This is for testing purposes.
+      expect(generate(value, { strict: true })).toEqual(expected)
+    })
+
+    it('should accept entries with all required fields in strict mode', () => {
+      const value = {
+        id: 'https://example.com',
+        title: { value: 'Test' },
+        updated: new Date('2023-03-15T12:00:00Z'),
+        entries: [
+          {
+            id: 'https://example.com/1',
+            title: { value: 'Entry' },
+            updated: new Date('2023-03-15T12:00:00Z'),
+          },
+        ],
+      }
+      const expected = `<?xml version="1.0" encoding="utf-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <id>https://example.com</id>
+  <title>Test</title>
+  <updated>2023-03-15T12:00:00.000Z</updated>
+  <entry>
+    <id>https://example.com/1</id>
+    <title>Entry</title>
+    <updated>2023-03-15T12:00:00.000Z</updated>
+  </entry>
+</feed>
+`
+
+      expect(generate(value, { strict: true })).toEqual(expected)
+    })
+
+    it('should require nested type fields in strict mode', () => {
+      const value = {
+        id: 'https://example.com',
+        title: { value: 'Test' },
+        updated: new Date('2023-03-15T12:00:00Z'),
+        links: [{ rel: 'self' }],
+      }
+      const expected = `<?xml version="1.0" encoding="utf-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <id>https://example.com</id>
+  <link rel="self"/>
+  <title>Test</title>
+  <updated>2023-03-15T12:00:00.000Z</updated>
+</feed>
+`
+
+      // @ts-expect-error: This is for testing purposes.
+      expect(generate(value, { strict: true })).toEqual(expected)
+    })
+
+    it('should accept nested types with all required fields in strict mode', () => {
+      const value = {
+        id: 'https://example.com',
+        title: { value: 'Test' },
+        updated: new Date('2023-03-15T12:00:00Z'),
+        links: [{ href: 'https://example.com/feed.xml', rel: 'self' }],
+        authors: [{ name: 'John Doe' }],
+        categories: [{ term: 'tech' }],
+      }
+      const expected = `<?xml version="1.0" encoding="utf-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <author>
+    <name>John Doe</name>
+  </author>
+  <category term="tech"/>
+  <id>https://example.com</id>
+  <link href="https://example.com/feed.xml" rel="self"/>
+  <title>Test</title>
+  <updated>2023-03-15T12:00:00.000Z</updated>
+</feed>
+`
+
+      expect(generate(value, { strict: true })).toEqual(expected)
+    })
+
+    it('should accept partial feed in lenient mode', () => {
+      const value = { title: { value: 'Test' } }
+      const expected = `<?xml version="1.0" encoding="utf-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <title>Test</title>
+</feed>
+`
+
+      expect(generate(value)).toEqual(expected)
+    })
+
+    it.todo('should produce identical output in strict and lenient modes', () => {
+      // The strict option only changes compile-time types. Assert that
+      // generate(value, { strict: true }) and generate(value) return byte-identical XML for a
+      // corpus of valid feeds.
+    })
+  })
+
+  describe('edge cases', () => {
+    it('should accept partial feeds', () => {
+      const value = {
+        title: { value: 'Test Feed' },
+      }
+      const expected = `<?xml version="1.0" encoding="utf-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <title>Test Feed</title>
+</feed>
+`
+
+      expect(generate(value)).toEqual(expected)
+    })
+
+    it('should accept feeds with string dates', () => {
+      const value = {
+        id: 'https://example.com/feed',
+        title: { value: 'Test Feed' },
+        updated: '2023-01-01T00:00:00.000Z',
+      }
+      const expected = `<?xml version="1.0" encoding="utf-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <id>https://example.com/feed</id>
+  <title>Test Feed</title>
+  <updated>2023-01-01T00:00:00.000Z</updated>
+</feed>
+`
+
+      expect(generate(value)).toEqual(expected)
+    })
+
+    it('should preserve invalid date strings', () => {
+      const value = {
+        id: 'https://example.com/feed',
+        title: { value: 'Feed with Invalid Date' },
+        updated: 'not-a-valid-date',
+        entries: [
+          {
+            id: 'https://example.com/entry/1',
+            title: { value: 'Entry with invalid date' },
+            updated: 'also-invalid-date',
+          },
+        ],
+      }
+      const expected = `<?xml version="1.0" encoding="utf-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <id>https://example.com/feed</id>
+  <title>Feed with Invalid Date</title>
+  <updated>not-a-valid-date</updated>
+  <entry>
+    <id>https://example.com/entry/1</id>
+    <title>Entry with invalid date</title>
+    <updated>also-invalid-date</updated>
+  </entry>
+</feed>
+`
+
+      expect(generate(value)).toEqual(expected)
+    })
+
+    it('should handle mixed Date objects and string dates', () => {
+      const value = {
+        id: 'https://example.com/feed',
+        title: { value: 'Mixed Dates Feed' },
+        updated: new Date('2023-01-01T00:00:00.000Z'),
+        entries: [
+          {
+            id: 'https://example.com/entry/1',
+            title: { value: 'Entry with Date object' },
+            updated: new Date('2023-02-01T00:00:00.000Z'),
+          },
+          {
+            id: 'https://example.com/entry/2',
+            title: { value: 'Entry with string date' },
+            updated: '2023-03-01T00:00:00.000Z',
+          },
+        ],
+      }
+      const expected = `<?xml version="1.0" encoding="utf-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <id>https://example.com/feed</id>
+  <title>Mixed Dates Feed</title>
+  <updated>2023-01-01T00:00:00.000Z</updated>
+  <entry>
+    <id>https://example.com/entry/1</id>
+    <title>Entry with Date object</title>
+    <updated>2023-02-01T00:00:00.000Z</updated>
+  </entry>
+  <entry>
+    <id>https://example.com/entry/2</id>
+    <title>Entry with string date</title>
+    <updated>2023-03-01T00:00:00.000Z</updated>
+  </entry>
+</feed>
+`
+
+      expect(generate(value)).toEqual(expected)
+    })
+
+    it('should ignore unrecognized entry properties and keep partial entries', () => {
+      const value = {
+        id: 'https://example.com/feed',
+        title: { value: 'Feed with Nested Partials' },
+        entries: [
+          {
+            id: 'https://example.com/entry/1',
+            title: { value: 'Entry 1' },
+            author: [
+              {
+                name: 'John Doe',
+              },
+            ],
+            category: [
+              {
+                term: 'tech',
+                label: 'Technology',
+              },
+            ],
+          },
+          {
+            id: 'https://example.com/entry/2',
+            title: { value: 'Minimal Entry' },
+          },
+        ],
+      }
+      const expected = `<?xml version="1.0" encoding="utf-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <id>https://example.com/feed</id>
+  <title>Feed with Nested Partials</title>
+  <entry>
+    <id>https://example.com/entry/1</id>
+    <title>Entry 1</title>
+  </entry>
+  <entry>
+    <id>https://example.com/entry/2</id>
+    <title>Minimal Entry</title>
+  </entry>
+</feed>
+`
+
+      expect(generate(value)).toEqual(expected)
+    })
+  })
+
+  describe('app namespace', () => {
+    it('should generate Atom feed with app namespace', () => {
+      const value = {
+        id: 'http://example.com/blog',
+        title: { value: 'My Blog' },
+        updated: new Date('2024-03-15T16:00:00Z'),
+        entries: [
+          {
+            id: 'http://example.com/blog/post/1',
+            title: { value: 'Article' },
+            updated: new Date('2024-03-15T16:00:00Z'),
+            app: {
+              edited: new Date('2024-03-15T14:30:00Z'),
+              control: {
+                draft: false,
+              },
+            },
+          },
+        ],
+      }
+      const expected = `<?xml version="1.0" encoding="utf-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom" xmlns:app="http://www.w3.org/2007/app">
+  <id>http://example.com/blog</id>
+  <title>My Blog</title>
+  <updated>2024-03-15T16:00:00.000Z</updated>
+  <entry>
+    <id>http://example.com/blog/post/1</id>
+    <title>Article</title>
+    <updated>2024-03-15T16:00:00.000Z</updated>
+    <app:edited>2024-03-15T14:30:00.000Z</app:edited>
+    <app:control>
+      <app:draft>no</app:draft>
+    </app:control>
+  </entry>
+</feed>
+`
+
+      expect(generate(value)).toEqual(expected)
+    })
+
+    it('should generate Atom entry with draft status', () => {
+      const value = {
+        id: 'http://example.com/blog',
+        title: { value: 'Blog' },
+        updated: new Date('2024-03-15T16:00:00Z'),
+        entries: [
+          {
+            id: 'http://example.com/blog/draft',
+            title: { value: 'Draft Article' },
+            updated: new Date('2024-03-15T15:00:00Z'),
+            app: {
+              edited: new Date('2024-03-15T15:00:00Z'),
+              control: {
+                draft: true,
+              },
+            },
+          },
+        ],
+      }
+      const expected = `<?xml version="1.0" encoding="utf-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom" xmlns:app="http://www.w3.org/2007/app">
+  <id>http://example.com/blog</id>
+  <title>Blog</title>
+  <updated>2024-03-15T16:00:00.000Z</updated>
+  <entry>
+    <id>http://example.com/blog/draft</id>
+    <title>Draft Article</title>
+    <updated>2024-03-15T15:00:00.000Z</updated>
+    <app:edited>2024-03-15T15:00:00.000Z</app:edited>
+    <app:control>
+      <app:draft>yes</app:draft>
+    </app:control>
+  </entry>
+</feed>
+`
+
+      expect(generate(value)).toEqual(expected)
+    })
   })
 })

--- a/src/feeds/atom/generate/utils.test.ts
+++ b/src/feeds/atom/generate/utils.test.ts
@@ -868,7 +868,7 @@ describe('generateEntry', () => {
       updated: new Date('2023-03-15T12:00:00Z'),
       pingback: {
         server: 'https://example.com/xmlrpc.php',
-        target: 'https://referenced-blog.com/article',
+        target: 'https://example.net/article',
       },
     }
     const expected = {
@@ -876,33 +876,10 @@ describe('generateEntry', () => {
       title: { '#text': 'Entry with Pingback namespace' },
       updated: '2023-03-15T12:00:00.000Z',
       'pingback:server': 'https://example.com/xmlrpc.php',
-      'pingback:target': 'https://referenced-blog.com/article',
+      'pingback:target': 'https://example.net/article',
     }
 
     expect(generateEntry(value)).toEqual(expected)
-  })
-
-  it('should generate feed with pingback namespace properties', () => {
-    const value = {
-      id: 'https://example.com/feed',
-      title: { value: 'Feed with Pingback namespace' },
-      updated: new Date('2023-03-15T12:00:00Z'),
-      pingback: {
-        to: 'https://example.com/pingback-service',
-      },
-    }
-    const expected = {
-      feed: {
-        '@xmlns': 'http://www.w3.org/2005/Atom',
-        '@xmlns:pingback': 'http://madskills.com/public/xml/rss/module/pingback/',
-        id: 'https://example.com/feed',
-        title: { '#text': 'Feed with Pingback namespace' },
-        updated: '2023-03-15T12:00:00.000Z',
-        'pingback:to': 'https://example.com/pingback-service',
-      },
-    }
-
-    expect(generateFeed(value)).toEqual(expected)
   })
 
   it('should generate entry with trackback namespace properties', () => {
@@ -912,7 +889,7 @@ describe('generateEntry', () => {
       updated: new Date('2023-03-15T12:00:00Z'),
       trackback: {
         ping: 'https://example.com/trackback/123',
-        abouts: ['https://blog1.com/trackback/456', 'https://blog2.com/trackback/789'],
+        abouts: ['https://example.net/trackback/456', 'https://example.org/trackback/789'],
       },
     }
     const expected = {
@@ -920,40 +897,10 @@ describe('generateEntry', () => {
       title: { '#text': 'Entry with Trackback namespace' },
       updated: '2023-03-15T12:00:00.000Z',
       'trackback:ping': 'https://example.com/trackback/123',
-      'trackback:about': ['https://blog1.com/trackback/456', 'https://blog2.com/trackback/789'],
+      'trackback:about': ['https://example.net/trackback/456', 'https://example.org/trackback/789'],
     }
 
     expect(generateEntry(value)).toEqual(expected)
-  })
-
-  it('should generate feed with admin namespace properties', () => {
-    const value = {
-      id: 'https://example.com/feed',
-      title: { value: 'Feed with Admin namespace' },
-      updated: new Date('2023-03-15T12:00:00Z'),
-      admin: {
-        errorReportsTo: 'mailto:webmaster@example.com',
-        generatorAgent: 'http://www.movabletype.org/?v=3.2',
-      },
-    }
-    const expected = {
-      feed: {
-        '@xmlns': 'http://www.w3.org/2005/Atom',
-        '@xmlns:admin': 'http://webns.net/mvcb/',
-        '@xmlns:rdf': 'http://www.w3.org/1999/02/22-rdf-syntax-ns#',
-        id: 'https://example.com/feed',
-        title: { '#text': 'Feed with Admin namespace' },
-        updated: '2023-03-15T12:00:00.000Z',
-        'admin:errorReportsTo': {
-          '@rdf:resource': 'mailto:webmaster@example.com',
-        },
-        'admin:generatorAgent': {
-          '@rdf:resource': 'http://www.movabletype.org/?v=3.2',
-        },
-      },
-    }
-
-    expect(generateFeed(value)).toEqual(expected)
   })
 
   it('should generate entry with ccREL namespace properties', () => {
@@ -1956,6 +1903,59 @@ describe('generateFeed', () => {
             '@xml:base': 'http://example.org/entry/1/',
           },
         ],
+      },
+    }
+
+    expect(generateFeed(value)).toEqual(expected)
+  })
+
+  it('should generate feed with pingback namespace properties', () => {
+    const value = {
+      id: 'https://example.com/feed',
+      title: { value: 'Feed with Pingback namespace' },
+      updated: new Date('2023-03-15T12:00:00Z'),
+      pingback: {
+        to: 'https://example.com/pingback-service',
+      },
+    }
+    const expected = {
+      feed: {
+        '@xmlns': 'http://www.w3.org/2005/Atom',
+        '@xmlns:pingback': 'http://madskills.com/public/xml/rss/module/pingback/',
+        id: 'https://example.com/feed',
+        title: { '#text': 'Feed with Pingback namespace' },
+        updated: '2023-03-15T12:00:00.000Z',
+        'pingback:to': 'https://example.com/pingback-service',
+      },
+    }
+
+    expect(generateFeed(value)).toEqual(expected)
+  })
+
+  it('should generate feed with admin namespace properties', () => {
+    const value = {
+      id: 'https://example.com/feed',
+      title: { value: 'Feed with Admin namespace' },
+      updated: new Date('2023-03-15T12:00:00Z'),
+      admin: {
+        errorReportsTo: 'mailto:webmaster@example.com',
+        generatorAgent: 'https://example.com/generator?v=3.2',
+      },
+    }
+    const expected = {
+      feed: {
+        '@xmlns': 'http://www.w3.org/2005/Atom',
+        '@xmlns:admin': 'http://webns.net/mvcb/',
+        '@xmlns:rdf': 'http://www.w3.org/1999/02/22-rdf-syntax-ns#',
+        id: 'https://example.com/feed',
+        title: { '#text': 'Feed with Admin namespace' },
+        updated: '2023-03-15T12:00:00.000Z',
+        'admin:errorReportsTo': {
+          '@rdf:resource': 'mailto:webmaster@example.com',
+        },
+        'admin:generatorAgent': {
+          '@rdf:resource': 'https://example.com/generator?v=3.2',
+        },
       },
     }
 

--- a/src/feeds/atom/parse/index.test.ts
+++ b/src/feeds/atom/parse/index.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'bun:test'
 import { locales, namespaceUris } from '../../../common/config.js'
 import { DetectError, MalformedError, ParseError } from '../../../common/errors.js'
+import type { AtomFeed } from '../common/types.js'
 import { parse } from './index.js'
 
 describe('parse', () => {
@@ -15,9 +16,8 @@ describe('parse', () => {
       const reference = `${import.meta.dir}/../references/atom-${key}`
       const input = await Bun.file(`${reference}.xml`).text()
       const expected = await Bun.file(`${reference}.json`).json()
-      const result = parse(input)
 
-      expect(result).toEqual(expected)
+      expect(parse(input)).toEqual(expected)
     })
   }
 
@@ -223,39 +223,59 @@ describe('parse', () => {
   })
 
   it('should throw error for invalid input', () => {
-    expect(() => parse('not a feed')).toThrowError(locales.invalidFeedFormat)
+    const throwing = () => parse('not a feed')
+
+    expect(throwing).toThrowError(locales.invalidFeedFormat)
   })
 
   it('should handle null input', () => {
-    expect(() => parse(null)).toThrowError(locales.invalidFeedFormat)
+    const throwing = () => parse(null)
+
+    expect(throwing).toThrowError(locales.invalidFeedFormat)
   })
 
   it('should handle undefined input', () => {
-    expect(() => parse(undefined)).toThrowError(locales.invalidFeedFormat)
+    const throwing = () => parse(undefined)
+
+    expect(throwing).toThrowError(locales.invalidFeedFormat)
   })
 
   it('should handle array input', () => {
-    expect(() => parse([])).toThrowError(locales.invalidFeedFormat)
+    const throwing = () => parse([])
+
+    expect(throwing).toThrowError(locales.invalidFeedFormat)
   })
 
   it('should handle empty object input', () => {
-    expect(() => parse({})).toThrowError(locales.invalidFeedFormat)
+    const throwing = () => parse({})
+
+    expect(throwing).toThrowError(locales.invalidFeedFormat)
   })
 
-  it('should handle string input', () => {
-    expect(() => parse('not a feed')).toThrowError(locales.invalidFeedFormat)
+  it('should handle empty string input', () => {
+    const throwing = () => parse('')
+
+    expect(throwing).toThrowError(locales.invalidFeedFormat)
+  })
+
+  it('should handle whitespace-only string input', () => {
+    const throwing = () => parse('   \n  ')
+
+    expect(throwing).toThrowError(locales.invalidFeedFormat)
   })
 
   it('should handle number input', () => {
-    expect(() => parse(123)).toThrowError(locales.invalidFeedFormat)
+    const throwing = () => parse(123)
+
+    expect(throwing).toThrowError(locales.invalidFeedFormat)
   })
 
   describe('error types', () => {
     it('should throw DetectError for non-feed input', () => {
       const throwing = () => parse('not a feed')
 
-      expect(throwing).toThrow(DetectError)
-      expect(throwing).toThrow(locales.invalidFeedFormat)
+      expect(throwing).toThrowError(DetectError)
+      expect(throwing).toThrowError(locales.invalidFeedFormat)
     })
 
     it('should throw MalformedError for malformed XML', () => {
@@ -267,16 +287,16 @@ describe('parse', () => {
       `
       const throwing = () => parse(value)
 
-      expect(throwing).toThrow(MalformedError)
-      expect(throwing).toThrow(locales.invalidFeedFormat)
+      expect(throwing).toThrowError(MalformedError)
+      expect(throwing).toThrowError(locales.invalidFeedFormat)
     })
 
     it('should throw ParseError for valid XML with invalid structure', () => {
       const value = '<feed xmlns="http://www.w3.org/2005/Atom"></feed>'
       const throwing = () => parse(value)
 
-      expect(throwing).toThrow(ParseError)
-      expect(throwing).toThrow(locales.invalidFeedFormat)
+      expect(throwing).toThrowError(ParseError)
+      expect(throwing).toThrowError(locales.invalidFeedFormat)
     })
   })
 
@@ -812,7 +832,7 @@ describe('parse', () => {
           </entry>
         </feed>
       `
-      const expected = {
+      const expected: AtomFeed.Feed<string> = {
         title: { value: 'Feed with GooglePlay' },
         id: 'urn:uuid:feed-id',
         updated: '2024-01-01T00:00:00Z',
@@ -827,7 +847,7 @@ describe('parse', () => {
             updated: '2024-01-01T00:00:00Z',
             googleplay: {
               author: 'Episode Author',
-              explicit: 'clean' as const,
+              explicit: 'clean',
             },
           },
         ],
@@ -1229,9 +1249,7 @@ describe('parse', () => {
         ],
       }
 
-      const result = parse(value, { parseDateFn: (raw) => new Date(raw) })
-
-      expect(result).toEqual(expected)
+      expect(parse(value, { parseDateFn: (raw) => new Date(raw) })).toEqual(expected)
     })
 
     it('should apply custom parseDateFn to dc namespace dates', () => {
@@ -1264,9 +1282,7 @@ describe('parse', () => {
           },
         ],
       }
-      const result = parse(value, { parseDateFn: (raw) => new Date(raw) })
-
-      expect(result).toEqual(expected)
+      expect(parse(value, { parseDateFn: (raw) => new Date(raw) })).toEqual(expected)
     })
 
     it('should apply custom parseDateFn to thr link dates', () => {
@@ -1306,9 +1322,7 @@ describe('parse', () => {
           },
         ],
       }
-      const result = parse(value, { parseDateFn: (raw) => new Date(raw) })
-
-      expect(result).toEqual(expected)
+      expect(parse(value, { parseDateFn: (raw) => new Date(raw) })).toEqual(expected)
     })
 
     it('should apply custom parseDateFn to app namespace dates', () => {
@@ -1341,9 +1355,51 @@ describe('parse', () => {
           },
         ],
       }
-      const result = parse(value, { parseDateFn: (raw) => new Date(raw) })
+      expect(parse(value, { parseDateFn: (raw) => new Date(raw) })).toEqual(expected)
+    })
 
-      expect(result).toEqual(expected)
+    it('should propagate error when parseDateFn throws', () => {
+      const value = `
+        <?xml version="1.0" encoding="UTF-8"?>
+        <feed xmlns="http://www.w3.org/2005/Atom">
+          <title>Test</title>
+          <id>urn:uuid:feed</id>
+          <updated>invalid</updated>
+        </feed>
+      `
+      const parseDateFn = () => {
+        throw new Error('Parse failed')
+      }
+      const throwing = () => parse(value, { parseDateFn })
+
+      expect(throwing).toThrowError('Parse failed')
+    })
+  })
+
+  describe.todo('real-world feeds', () => {
+    it.todo('should parse Atom feed with CDATA-wrapped titles and content', () => {
+      // Mirror the RSS real-world CDATA suite: <title><![CDATA[...]]></title> and CDATA-wrapped
+      // entry content should parse to the inner text.
+    })
+
+    it.todo('should parse Atom feed with named and numeric HTML entities', () => {
+      // Mirror the RSS real-world entity suite: &amp;, &#8217;, &#x2019; in titles and summaries
+      // should decode correctly.
+    })
+
+    it.todo('should parse Atom feed prefixed with a BOM', () => {
+      // A UTF-8 byte order mark before the XML declaration is common in real feeds and must not
+      // break detection or parsing.
+    })
+
+    it.todo('should parse Atom feed with a DOCTYPE declaration', () => {
+      // Some real feeds include a DOCTYPE before the root element. Parsing should ignore it
+      // instead of failing.
+    })
+
+    it.todo('should throw MalformedError for truncated Atom XML', () => {
+      // Mirror the RSS real-world truncation tests: a feed cut off mid-element should raise
+      // MalformedError rather than return a partial feed.
     })
   })
 })

--- a/src/feeds/atom/parse/utils.test.ts
+++ b/src/feeds/atom/parse/utils.test.ts
@@ -1758,7 +1758,7 @@ describe('parseFeed', () => {
         '@rdf:resource': 'mailto:webmaster@example.com',
       },
       'admin:generatoragent': {
-        '@rdf:resource': 'http://www.movabletype.org/?v=3.2',
+        '@rdf:resource': 'https://example.com/generator?v=3.2',
       },
     }
     const expected = {
@@ -1766,7 +1766,7 @@ describe('parseFeed', () => {
       title: { value: 'Example Feed' },
       admin: {
         errorReportsTo: 'mailto:webmaster@example.com',
-        generatorAgent: 'http://www.movabletype.org/?v=3.2',
+        generatorAgent: 'https://example.com/generator?v=3.2',
       },
     }
 
@@ -1905,5 +1905,10 @@ describe('retrieveFeed', () => {
     }
 
     expect(retrieveFeed(value)).toBeUndefined()
+  })
+
+  it('should return undefined for null and undefined inputs', () => {
+    expect(retrieveFeed(null)).toBeUndefined()
+    expect(retrieveFeed(undefined)).toBeUndefined()
   })
 })

--- a/src/feeds/json/detect/index.test.ts
+++ b/src/feeds/json/detect/index.test.ts
@@ -140,6 +140,36 @@ describe('detect', () => {
     expect(detect(json)).toBe(true)
   })
 
+  it('should detect JSON Feed with case-insensitive keys', () => {
+    const jsonFeed = {
+      VERSION: 'https://jsonfeed.org/version/1.1',
+      TITLE: 'Example Feed',
+      items: [],
+    }
+
+    expect(detect(jsonFeed)).toBe(true)
+  })
+
+  it('should fall back to structure checks when version is an empty string', () => {
+    const jsonFeed = {
+      version: '',
+      title: 'Example Feed',
+      items: [],
+    }
+
+    expect(detect(jsonFeed)).toBe(true)
+  })
+
+  it('should return false for whitespace-only string', () => {
+    expect(detect('   \n  ')).toBe(false)
+  })
+
+  it('should return false for XML content', () => {
+    const xml = '<feed xmlns="http://www.w3.org/2005/Atom"><title>Example Feed</title></feed>'
+
+    expect(detect(xml)).toBe(false)
+  })
+
   it('should return false for invalid JSON string', () => {
     expect(detect('{"title": "Not valid JSON')).toBe(false)
   })

--- a/src/feeds/json/generate/index.test.ts
+++ b/src/feeds/json/generate/index.test.ts
@@ -53,67 +53,111 @@ describe('generate', () => {
 
     expect(generate(value)).toEqual(expected)
   })
-})
 
-describe('strict mode', () => {
-  it('should require title and items in strict mode', () => {
-    // @ts-expect-error: This is for testing purposes.
-    generate({ title: 'Test' }, { strict: true })
+  it.todo('should correctly generate JSON Feed reference fixtures', () => {
+    // Add references/*.json fixture pairs (like the Atom and RSS reference suites) and compare
+    // the generate output against them wholesale.
   })
 
-  it('should accept feed with all required fields in strict mode', () => {
-    generate({ title: 'Test', items: [] }, { strict: true })
-  })
-
-  it('should require item id in strict mode', () => {
-    generate(
-      {
+  describe('strict mode', () => {
+    it('should require title and items in strict mode', () => {
+      const value = { title: 'Test' }
+      const expected = {
+        version: 'https://jsonfeed.org/version/1.1',
         title: 'Test',
-        // @ts-expect-error: This is for testing purposes.
+      }
+
+      // @ts-expect-error: This is for testing purposes.
+      expect(generate(value, { strict: true })).toEqual(expected)
+    })
+
+    it('should accept feed with all required fields in strict mode', () => {
+      const value = { title: 'Test', items: [] }
+      const expected = {
+        version: 'https://jsonfeed.org/version/1.1',
+        title: 'Test',
+      }
+
+      expect(generate(value, { strict: true })).toEqual(expected)
+    })
+
+    it('should require item id in strict mode', () => {
+      const value = { title: 'Test', items: [{ content_text: 'Hello' }] }
+      const expected = {
+        version: 'https://jsonfeed.org/version/1.1',
+        title: 'Test',
         items: [{ content_text: 'Hello' }],
-      },
-      { strict: true },
-    )
-  })
+      }
 
-  it('should accept items with content_html in strict mode', () => {
-    generate(
-      { title: 'Test', items: [{ id: '1', content_html: '<p>Hello</p>' }] },
-      { strict: true },
-    )
-  })
+      // @ts-expect-error: This is for testing purposes.
+      expect(generate(value, { strict: true })).toEqual(expected)
+    })
 
-  it('should accept items with content_text in strict mode', () => {
-    generate({ title: 'Test', items: [{ id: '1', content_text: 'Hello' }] }, { strict: true })
-  })
+    it('should accept items with content_html in strict mode', () => {
+      const value = { title: 'Test', items: [{ id: '1', content_html: '<p>Hello</p>' }] }
+      const expected = {
+        version: 'https://jsonfeed.org/version/1.1',
+        title: 'Test',
+        items: [{ id: '1', content_html: '<p>Hello</p>' }],
+      }
 
-  it('should accept items with both content fields in strict mode', () => {
-    generate(
-      { title: 'Test', items: [{ id: '1', content_html: '<p>Hello</p>', content_text: 'Hello' }] },
-      { strict: true },
-    )
-  })
+      expect(generate(value, { strict: true })).toEqual(expected)
+    })
 
-  it('should require nested type fields in strict mode', () => {
-    generate(
-      {
+    it('should accept items with content_text in strict mode', () => {
+      const value = { title: 'Test', items: [{ id: '1', content_text: 'Hello' }] }
+      const expected = {
+        version: 'https://jsonfeed.org/version/1.1',
+        title: 'Test',
+        items: [{ id: '1', content_text: 'Hello' }],
+      }
+
+      expect(generate(value, { strict: true })).toEqual(expected)
+    })
+
+    it('should accept items with both content fields in strict mode', () => {
+      const value = {
+        title: 'Test',
+        items: [{ id: '1', content_html: '<p>Hello</p>', content_text: 'Hello' }],
+      }
+      const expected = {
+        version: 'https://jsonfeed.org/version/1.1',
+        title: 'Test',
+        items: [{ id: '1', content_html: '<p>Hello</p>', content_text: 'Hello' }],
+      }
+
+      expect(generate(value, { strict: true })).toEqual(expected)
+    })
+
+    it('should require nested type fields in strict mode', () => {
+      const value = {
         title: 'Test',
         items: [
           {
             id: '1',
             content_html: '<p>Hello</p>',
-            // @ts-expect-error: This is for testing purposes.
             attachments: [{ url: 'https://example.com/file.mp3' }],
           },
         ],
-      },
-      { strict: true },
-    )
-  })
+      }
+      const expected = {
+        version: 'https://jsonfeed.org/version/1.1',
+        title: 'Test',
+        items: [
+          {
+            id: '1',
+            content_html: '<p>Hello</p>',
+            attachments: [{ url: 'https://example.com/file.mp3' }],
+          },
+        ],
+      }
 
-  it('should accept nested types with all required fields in strict mode', () => {
-    generate(
-      {
+      // @ts-expect-error: This is for testing purposes.
+      expect(generate(value, { strict: true })).toEqual(expected)
+    })
+
+    it('should accept nested types with all required fields in strict mode', () => {
+      const value = {
         title: 'Test',
         items: [
           {
@@ -123,78 +167,128 @@ describe('strict mode', () => {
           },
         ],
         hubs: [{ type: 'websub', url: 'https://example.com/hub' }],
-      },
-      { strict: true },
-    )
+      }
+      const expected = {
+        version: 'https://jsonfeed.org/version/1.1',
+        title: 'Test',
+        items: [
+          {
+            id: '1',
+            content_html: '<p>Hello</p>',
+            attachments: [{ url: 'https://example.com/file.mp3', mime_type: 'audio/mpeg' }],
+          },
+        ],
+        hubs: [{ type: 'websub', url: 'https://example.com/hub' }],
+      }
+
+      expect(generate(value, { strict: true })).toEqual(expected)
+    })
+
+    it('should accept partial feed in lenient mode', () => {
+      const value = { title: 'Test' }
+      const expected = {
+        version: 'https://jsonfeed.org/version/1.1',
+        title: 'Test',
+      }
+
+      expect(generate(value)).toEqual(expected)
+    })
+
+    it.todo('should produce identical output in strict and lenient modes', () => {
+      // The strict option only changes compile-time types. Assert that
+      // generate(value, { strict: true }) and generate(value) return identical objects for a
+      // corpus of valid feeds.
+    })
   })
 
-  it('should accept partial feed in lenient mode', () => {
-    generate({ title: 'Test' })
-  })
-})
+  describe('error types', () => {
+    it('should throw GenerateError for invalid input', () => {
+      const throwing = () => generate({})
 
-describe('error types', () => {
-  it('should throw GenerateError for invalid input', () => {
-    const throwing = () => generate({})
-
-    expect(throwing).toThrow(GenerateError)
-    expect(throwing).toThrow(locales.invalidInputJson)
-  })
-})
-
-describe('generate edge cases', () => {
-  it('should accept partial feeds', () => {
-    const value = {
-      title: 'Test Feed',
-    }
-    const expected = {
-      version: 'https://jsonfeed.org/version/1.1',
-      title: 'Test Feed',
-    }
-
-    expect(generate(value)).toEqual(expected)
+      expect(throwing).toThrowError(GenerateError)
+      expect(throwing).toThrowError(locales.invalidInputJson)
+    })
   })
 
-  it('should accept feeds with string dates', () => {
-    const value = {
-      title: 'Test Feed',
-      date_published: '2023-01-01T00:00:00.000Z',
-      items: [
-        {
-          id: '1',
-          title: 'Test Item',
-          date_published: '2023-01-02T00:00:00.000Z',
-        },
-      ],
-    }
-    const expected = {
-      version: 'https://jsonfeed.org/version/1.1',
-      title: 'Test Feed',
-      date_published: '2023-01-01T00:00:00.000Z',
-      items: [
-        {
-          id: '1',
-          title: 'Test Item',
-          date_published: '2023-01-02T00:00:00.000Z',
-        },
-      ],
-    }
+  describe('edge cases', () => {
+    it('should accept partial feeds', () => {
+      const value = {
+        title: 'Test Feed',
+      }
+      const expected = {
+        version: 'https://jsonfeed.org/version/1.1',
+        title: 'Test Feed',
+      }
 
-    expect(generate(value)).toEqual(expected)
-  })
+      expect(generate(value)).toEqual(expected)
+    })
 
-  it('should preserve invalid date strings', () => {
-    const value = {
-      title: 'Test Feed',
-      date_published: 'not-a-valid-date',
-      items: [],
-    }
-    const expected = {
-      version: 'https://jsonfeed.org/version/1.1',
-      title: 'Test Feed',
-      date_published: 'not-a-valid-date',
-    }
+    it('should accept feeds with string dates', () => {
+      const value = {
+        title: 'Test Feed',
+        date_published: '2023-01-01T00:00:00.000Z',
+        items: [
+          {
+            id: '1',
+            title: 'Test Item',
+            date_published: '2023-01-02T00:00:00.000Z',
+          },
+        ],
+      }
+      const expected = {
+        version: 'https://jsonfeed.org/version/1.1',
+        title: 'Test Feed',
+        date_published: '2023-01-01T00:00:00.000Z',
+        items: [
+          {
+            id: '1',
+            title: 'Test Item',
+            date_published: '2023-01-02T00:00:00.000Z',
+          },
+        ],
+      }
 
-    expect(generate(value)).toEqual(expected)
+      expect(generate(value)).toEqual(expected)
+    })
+
+    it('should preserve invalid date strings', () => {
+      const value = {
+        title: 'Test Feed',
+        date_published: 'not-a-valid-date',
+        items: [],
+      }
+      const expected = {
+        version: 'https://jsonfeed.org/version/1.1',
+        title: 'Test Feed',
+        date_published: 'not-a-valid-date',
+      }
+
+      expect(generate(value)).toEqual(expected)
+    })
+
+    it('should omit invalid Date objects from items', () => {
+      const value = {
+        title: 'Test Feed',
+        items: [
+          {
+            id: '1',
+            title: 'Test Item',
+            date_published: new Date('invalid-date'),
+          },
+        ],
+      }
+      const expected = {
+        version: 'https://jsonfeed.org/version/1.1',
+        title: 'Test Feed',
+        items: [
+          {
+            id: '1',
+            title: 'Test Item',
+          },
+        ],
+      }
+
+      expect(generate(value)).toEqual(expected)
+    })
   })
 })

--- a/src/feeds/json/generate/utils.test.ts
+++ b/src/feeds/json/generate/utils.test.ts
@@ -61,7 +61,7 @@ describe('generateItem', () => {
     const value = {
       id: '1',
       url: 'https://example.com/item/1',
-      external_url: 'https://external.com/item/1',
+      external_url: 'https://example.net/item/1',
       title: 'Test Item',
       content_html: '<p>HTML content</p>',
       content_text: 'Plain text content',
@@ -78,7 +78,7 @@ describe('generateItem', () => {
     const expected = {
       id: '1',
       url: 'https://example.com/item/1',
-      external_url: 'https://external.com/item/1',
+      external_url: 'https://example.net/item/1',
       title: 'Test Item',
       content_html: '<p>HTML content</p>',
       content_text: 'Plain text content',

--- a/src/feeds/json/parse/index.test.ts
+++ b/src/feeds/json/parse/index.test.ts
@@ -171,8 +171,9 @@ describe('parse', () => {
 
   it('should handle malformed JSON string', () => {
     const value = '{"version":"https://jsonfeed.org/version/1.1","title":"Malformed'
+    const throwing = () => parse(value)
 
-    expect(() => parse(value)).toThrowError(locales.invalidFeedFormat)
+    expect(throwing).toThrowError(locales.invalidFeedFormat)
   })
 
   it('should parse feed with invalid URLs', () => {
@@ -235,39 +236,59 @@ describe('parse', () => {
   })
 
   it('should throw error for invalid input', () => {
-    expect(() => parse('not a feed')).toThrowError(locales.invalidFeedFormat)
+    const throwing = () => parse('not a feed')
+
+    expect(throwing).toThrowError(locales.invalidFeedFormat)
   })
 
   it('should handle null input', () => {
-    expect(() => parse(null)).toThrowError(locales.invalidFeedFormat)
+    const throwing = () => parse(null)
+
+    expect(throwing).toThrowError(locales.invalidFeedFormat)
   })
 
   it('should handle undefined input', () => {
-    expect(() => parse(undefined)).toThrowError(locales.invalidFeedFormat)
+    const throwing = () => parse(undefined)
+
+    expect(throwing).toThrowError(locales.invalidFeedFormat)
   })
 
   it('should handle array input', () => {
-    expect(() => parse([])).toThrowError(locales.invalidFeedFormat)
+    const throwing = () => parse([])
+
+    expect(throwing).toThrowError(locales.invalidFeedFormat)
   })
 
   it('should handle empty object input', () => {
-    expect(() => parse({})).toThrowError(locales.invalidFeedFormat)
+    const throwing = () => parse({})
+
+    expect(throwing).toThrowError(locales.invalidFeedFormat)
   })
 
-  it('should handle string input', () => {
-    expect(() => parse('not a feed')).toThrowError(locales.invalidFeedFormat)
+  it('should handle empty string input', () => {
+    const throwing = () => parse('')
+
+    expect(throwing).toThrowError(locales.invalidFeedFormat)
+  })
+
+  it('should handle whitespace-only string input', () => {
+    const throwing = () => parse('   \n  ')
+
+    expect(throwing).toThrowError(locales.invalidFeedFormat)
   })
 
   it('should handle number input', () => {
-    expect(() => parse(123)).toThrowError(locales.invalidFeedFormat)
+    const throwing = () => parse(123)
+
+    expect(throwing).toThrowError(locales.invalidFeedFormat)
   })
 
   describe('error types', () => {
     it('should throw DetectError for non-feed input', () => {
       const throwing = () => parse({})
 
-      expect(throwing).toThrow(DetectError)
-      expect(throwing).toThrow(locales.invalidFeedFormat)
+      expect(throwing).toThrowError(DetectError)
+      expect(throwing).toThrowError(locales.invalidFeedFormat)
     })
 
     it('should throw ParseError for detected but invalid feed', () => {
@@ -276,8 +297,8 @@ describe('parse', () => {
       }
       const throwing = () => parse(value)
 
-      expect(throwing).toThrow(ParseError)
-      expect(throwing).toThrow(locales.invalidFeedFormat)
+      expect(throwing).toThrowError(ParseError)
+      expect(throwing).toThrowError(locales.invalidFeedFormat)
     })
   })
 
@@ -373,9 +394,43 @@ describe('parse', () => {
           },
         ],
       }
-      const result = parse(value, { parseDateFn: (raw) => new Date(raw) })
+      expect(parse(value, { parseDateFn: (raw) => new Date(raw) })).toEqual(expected)
+    })
 
-      expect(result).toEqual(expected)
+    it('should propagate error when parseDateFn throws', () => {
+      const value = {
+        version: 'https://jsonfeed.org/version/1.1',
+        title: 'Test',
+        items: [
+          {
+            id: '1',
+            date_published: 'invalid',
+          },
+        ],
+      }
+      const parseDateFn = () => {
+        throw new Error('Parse failed')
+      }
+      const throwing = () => parse(value, { parseDateFn })
+
+      expect(throwing).toThrowError('Parse failed')
+    })
+  })
+
+  describe.todo('real-world feeds', () => {
+    it.todo('should parse JSON Feed string prefixed with a BOM', () => {
+      // A UTF-8 byte order mark before the opening brace is common in real exports. Expected:
+      // the BOM is ignored and the feed parses normally.
+    })
+
+    it.todo('should parse JSON Feed with escaped unicode sequences in text fields', () => {
+      // Titles and content with \u-escaped characters (emoji, accented letters) should decode to
+      // the actual characters.
+    })
+
+    it.todo('should parse JSON Feed with HTML entities preserved in content_html', () => {
+      // Entities like &amp; and &lt; inside content_html are part of the HTML payload and must be
+      // passed through unchanged, not decoded.
     })
   })
 })

--- a/src/feeds/json/parse/utils.test.ts
+++ b/src/feeds/json/parse/utils.test.ts
@@ -51,7 +51,7 @@ describe('createCaseInsensitiveGetter', () => {
     expect(get('KEY')).toBe('uppercase value')
   })
 
-  it('should handle non-string key lookups by coercing to string', () => {
+  it('should handle numeric-like and boolean-like string keys', () => {
     const value = {
       '123': 'numeric key',
       true: 'boolean key',
@@ -229,6 +229,15 @@ describe('retrieveAuthors', () => {
   it('should handle author when no authors present', () => {
     const value = {
       authors: undefined,
+      author: { name: 'Jane' },
+    }
+
+    expect(retrieveAuthors(value)).toEqual([{ name: 'Jane' }])
+  })
+
+  it('should fall back to author when authors parses to an empty array', () => {
+    const value = {
+      authors: [],
       author: { name: 'Jane' },
     }
 
@@ -429,7 +438,7 @@ describe('parseItem', () => {
   const expectedFull = {
     id: 'item-123',
     url: 'https://example.com/article',
-    external_url: 'https://external-source.com/article',
+    external_url: 'https://example.net/article',
     title: 'Test Article',
     content_html: '<p>HTML Content</p>',
     content_text: 'Plain text content',
@@ -464,10 +473,7 @@ describe('parseItem', () => {
     const value = {
       id: ['item-123', 'item-456'],
       url: ['https://example.com/article', 'https://example.com/alternate-article'],
-      external_url: [
-        'https://external-source.com/article',
-        'https://external-source.com/alternate-article',
-      ],
+      external_url: ['https://example.net/article', 'https://example.net/alternate-article'],
       title: ['Test Article', 'Alternative Test Article'],
       content_html: ['<p>HTML Content</p>', '<p>Alternative HTML Content</p>'],
       content_text: ['Plain text content', 'Alternative plain text content'],
@@ -609,13 +615,13 @@ describe('parseItem', () => {
       attachments: [
         true,
         { not_url: 'missing url field' },
-        { url: 'https://valid.com/attachment.pdf', mime_type: 'application/pdf' },
+        { url: 'https://example.com/attachment.pdf', mime_type: 'application/pdf' },
       ],
     }
     const expected = {
       id: 'item-invalid-props',
       content_text: 'Minimal text content',
-      attachments: [{ url: 'https://valid.com/attachment.pdf', mime_type: 'application/pdf' }],
+      attachments: [{ url: 'https://example.com/attachment.pdf', mime_type: 'application/pdf' }],
     }
 
     expect(parseItem(value)).toEqual(expected)

--- a/src/feeds/rdf/detect/index.test.ts
+++ b/src/feeds/rdf/detect/index.test.ts
@@ -120,6 +120,12 @@ describe('detect', () => {
     expect(detect(rdfFeed)).toBe(true)
   })
 
+  it.todo('should return false for RDF element in XML comments', () => {
+    // An <rdf:RDF> element placed inside an XML comment (<!-- <rdf:RDF>...</rdf:RDF> -->)
+    // currently yields a false positive because the regex-based detector does not strip comments.
+    // Expected: detect returns false once comment stripping is implemented.
+  })
+
   it('should return false for RDF element in CDATA', () => {
     const cdataFeed = `
       <?xml version="1.0"?>

--- a/src/feeds/rdf/parse/index.test.ts
+++ b/src/feeds/rdf/parse/index.test.ts
@@ -14,10 +14,9 @@ describe('parse', () => {
     it(`should correctly parse RDF ${label}`, async () => {
       const reference = `${import.meta.dir}/../references/rdf-${key}`
       const input = await Bun.file(`${reference}.xml`).text()
-      const expectation = await Bun.file(`${reference}.json`).json()
-      const result = parse(input)
+      const expected = await Bun.file(`${reference}.json`).json()
 
-      expect(result).toEqual(expectation)
+      expect(parse(input)).toEqual(expected)
     })
   }
 
@@ -30,66 +29,86 @@ describe('parse', () => {
         xmlns="http://channel.netscape.com/rdf/simple/0.9/"
       >
         <CHANNEL>
-          <title>Mozilla Dot Org</title>
-          <LINK>http://www.mozilla.org</LINK>
-          <description>the Mozilla Organization web site</description>
+          <title>Example Dot Org</title>
+          <LINK>http://example.org</LINK>
+          <description>the Example Organization web site</description>
         </CHANNEL>
         <ItEM RDF:aBOUT="http://example.org/item1">
           <TITle>New Status Updates</TITle>
-          <link>http://www.mozilla.org/status/</link>
+          <link>http://example.org/status/</link>
         </ItEM>
       </RDF:rdf>
     `
-    const expectation = {
-      title: 'Mozilla Dot Org',
-      link: 'http://www.mozilla.org',
-      description: 'the Mozilla Organization web site',
+    const expected = {
+      title: 'Example Dot Org',
+      link: 'http://example.org',
+      description: 'the Example Organization web site',
       items: [
         {
           title: 'New Status Updates',
-          link: 'http://www.mozilla.org/status/',
+          link: 'http://example.org/status/',
           rdf: { about: 'http://example.org/item1' },
         },
       ],
     }
 
-    expect(parse(value)).toEqual(expectation)
+    expect(parse(value)).toEqual(expected)
   })
 
   it('should throw error for invalid input', () => {
-    expect(() => parse('not a feed')).toThrowError(locales.invalidFeedFormat)
+    const throwing = () => parse('not a feed')
+
+    expect(throwing).toThrowError(locales.invalidFeedFormat)
   })
 
   it('should handle null input', () => {
-    expect(() => parse(null)).toThrowError(locales.invalidFeedFormat)
+    const throwing = () => parse(null)
+
+    expect(throwing).toThrowError(locales.invalidFeedFormat)
   })
 
   it('should handle undefined input', () => {
-    expect(() => parse(undefined)).toThrowError(locales.invalidFeedFormat)
+    const throwing = () => parse(undefined)
+
+    expect(throwing).toThrowError(locales.invalidFeedFormat)
   })
 
   it('should handle array input', () => {
-    expect(() => parse([])).toThrowError(locales.invalidFeedFormat)
+    const throwing = () => parse([])
+
+    expect(throwing).toThrowError(locales.invalidFeedFormat)
   })
 
   it('should handle empty object input', () => {
-    expect(() => parse({})).toThrowError(locales.invalidFeedFormat)
+    const throwing = () => parse({})
+
+    expect(throwing).toThrowError(locales.invalidFeedFormat)
   })
 
-  it('should handle string input', () => {
-    expect(() => parse('not a feed')).toThrowError(locales.invalidFeedFormat)
+  it('should handle empty string input', () => {
+    const throwing = () => parse('')
+
+    expect(throwing).toThrowError(locales.invalidFeedFormat)
+  })
+
+  it('should handle whitespace-only string input', () => {
+    const throwing = () => parse('   \n  ')
+
+    expect(throwing).toThrowError(locales.invalidFeedFormat)
   })
 
   it('should handle number input', () => {
-    expect(() => parse(123)).toThrowError(locales.invalidFeedFormat)
+    const throwing = () => parse(123)
+
+    expect(throwing).toThrowError(locales.invalidFeedFormat)
   })
 
   describe('error types', () => {
     it('should throw DetectError for non-feed input', () => {
       const throwing = () => parse('not a feed')
 
-      expect(throwing).toThrow(DetectError)
-      expect(throwing).toThrow(locales.invalidFeedFormat)
+      expect(throwing).toThrowError(DetectError)
+      expect(throwing).toThrowError(locales.invalidFeedFormat)
     })
 
     it('should throw MalformedError for malformed XML', () => {
@@ -105,8 +124,8 @@ describe('parse', () => {
       `
       const throwing = () => parse(value)
 
-      expect(throwing).toThrow(MalformedError)
-      expect(throwing).toThrow(locales.invalidFeedFormat)
+      expect(throwing).toThrowError(MalformedError)
+      expect(throwing).toThrowError(locales.invalidFeedFormat)
     })
 
     it('should throw ParseError for valid XML with invalid structure', () => {
@@ -119,8 +138,8 @@ describe('parse', () => {
       `
       const throwing = () => parse(value)
 
-      expect(throwing).toThrow(ParseError)
-      expect(throwing).toThrow(locales.invalidFeedFormat)
+      expect(throwing).toThrowError(ParseError)
+      expect(throwing).toThrowError(locales.invalidFeedFormat)
     })
   })
 
@@ -1136,7 +1155,7 @@ describe('parse', () => {
           <link>http://example.com</link>
           <description>Test feed with Administrative namespace</description>
           <admin:errorReportsTo rdf:resource="mailto:webmaster@example.com"/>
-          <admin:generatorAgent rdf:resource="http://www.movabletype.org/?v=3.2"/>
+          <admin:generatorAgent rdf:resource="https://example.com/generator?v=3.2"/>
         </channel>
         <item rdf:about="http://example.com/item1">
           <title>Item title</title>
@@ -1150,7 +1169,7 @@ describe('parse', () => {
       description: 'Test feed with Administrative namespace',
       admin: {
         errorReportsTo: 'mailto:webmaster@example.com',
-        generatorAgent: 'http://www.movabletype.org/?v=3.2',
+        generatorAgent: 'https://example.com/generator?v=3.2',
       },
       rdf: { about: 'http://example.com' },
       items: [
@@ -1591,9 +1610,7 @@ describe('parse', () => {
           },
         ],
       }
-      const result = parse(value, { parseDateFn: (raw) => new Date(raw) })
-
-      expect(result).toEqual(expected)
+      expect(parse(value, { parseDateFn: (raw) => new Date(raw) })).toEqual(expected)
     })
 
     it('should apply custom parseDateFn to sy namespace dates', () => {
@@ -1619,9 +1636,56 @@ describe('parse', () => {
           updateBase: new Date('2023-03-15T12:00:00Z'),
         },
       }
-      const result = parse(value, { parseDateFn: (raw) => new Date(raw) })
+      expect(parse(value, { parseDateFn: (raw) => new Date(raw) })).toEqual(expected)
+    })
 
-      expect(result).toEqual(expected)
+    it('should propagate error when parseDateFn throws', () => {
+      const value = `
+        <?xml version="1.0" encoding="UTF-8"?>
+        <rdf:RDF
+          xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+          xmlns="http://purl.org/rss/1.0/"
+          xmlns:dc="http://purl.org/dc/elements/1.1/"
+        >
+          <channel rdf:about="http://example.com">
+            <title>Test</title>
+            <dc:date>invalid</dc:date>
+          </channel>
+        </rdf:RDF>
+      `
+      const parseDateFn = () => {
+        throw new Error('Parse failed')
+      }
+      const throwing = () => parse(value, { parseDateFn })
+
+      expect(throwing).toThrowError('Parse failed')
+    })
+  })
+
+  describe.todo('real-world feeds', () => {
+    it.todo('should parse RDF feed with CDATA-wrapped titles and descriptions', () => {
+      // Mirror the RSS real-world CDATA suite: <title><![CDATA[...]]></title> and CDATA-wrapped
+      // item descriptions should parse to the inner text.
+    })
+
+    it.todo('should parse RDF feed with named and numeric HTML entities', () => {
+      // Mirror the RSS real-world entity suite: &amp;, &#8217;, &#x2019; in titles and
+      // descriptions should decode correctly.
+    })
+
+    it.todo('should parse RDF feed prefixed with a BOM', () => {
+      // A UTF-8 byte order mark before the XML declaration is common in real feeds and must not
+      // break detection or parsing.
+    })
+
+    it.todo('should parse RDF feed with a DOCTYPE declaration', () => {
+      // Some real feeds include a DOCTYPE before the root element. Parsing should ignore it
+      // instead of failing.
+    })
+
+    it.todo('should throw MalformedError for truncated RDF XML', () => {
+      // Mirror the RSS real-world truncation tests: a feed cut off mid-element should raise
+      // MalformedError rather than return a partial feed.
     })
   })
 })

--- a/src/feeds/rdf/parse/utils.test.ts
+++ b/src/feeds/rdf/parse/utils.test.ts
@@ -739,23 +739,6 @@ describe('parseItem', () => {
 
     expect(parseItem(value)).toEqual(expected)
   })
-
-  it('should handle rdf:about attribute on item', () => {
-    const value = {
-      '@rdf:about': 'http://example.com/item/1',
-      title: { '#text': 'Example Entry' },
-      link: { '#text': 'http://example.com' },
-    }
-    const expected = {
-      title: 'Example Entry',
-      link: 'http://example.com',
-      rdf: {
-        about: 'http://example.com/item/1',
-      },
-    }
-
-    expect(parseItem(value)).toEqual(expected)
-  })
 })
 
 describe('retrieveItems', () => {
@@ -1049,45 +1032,6 @@ describe('retrieveItems', () => {
       },
       {
         title: 'Direct Item 2',
-      },
-    ]
-
-    expect(retrieveItems(value)).toEqual(expected)
-  })
-
-  it('should skip invalid ToC references and return only valid items', () => {
-    const value = {
-      channel: {
-        title: 'Test Feed',
-        items: {
-          seq: {
-            li: [
-              { '@resource': 'http://example.com/item1' },
-              { '@resource': 'http://example.com/missing' },
-              { '@resource': 'http://example.com/item2' },
-            ],
-          },
-        },
-      },
-      item: [
-        {
-          '@about': 'http://example.com/item1',
-          title: 'First Item',
-        },
-        {
-          '@about': 'http://example.com/item2',
-          title: 'Second Item',
-        },
-      ],
-    }
-    const expected = [
-      {
-        title: 'First Item',
-        rdf: { about: 'http://example.com/item1' },
-      },
-      {
-        title: 'Second Item',
-        rdf: { about: 'http://example.com/item2' },
       },
     ]
 
@@ -1733,7 +1677,7 @@ describe('parseFeed', () => {
           '@rdf:resource': 'mailto:webmaster@example.com',
         },
         'admin:generatoragent': {
-          '@rdf:resource': 'http://www.movabletype.org/?v=3.2',
+          '@rdf:resource': 'https://example.com/generator?v=3.2',
         },
       },
       item: [
@@ -1753,7 +1697,7 @@ describe('parseFeed', () => {
       ],
       admin: {
         errorReportsTo: 'mailto:webmaster@example.com',
-        generatorAgent: 'http://www.movabletype.org/?v=3.2',
+        generatorAgent: 'https://example.com/generator?v=3.2',
       },
     }
 

--- a/src/feeds/rss/detect/index.test.ts
+++ b/src/feeds/rss/detect/index.test.ts
@@ -73,6 +73,18 @@ describe('detect', () => {
     expect(detect(rssFeed)).toBe(true)
   })
 
+  it('should detect RSS feed with namespace prefix on root element', () => {
+    const prefixedFeed = '<ns:rss version="2.0"><channel><title>Test</title></channel></ns:rss>'
+
+    expect(detect(prefixedFeed)).toBe(true)
+  })
+
+  it.todo('should return false for RSS element in XML comments', () => {
+    // An <rss> element placed inside an XML comment (<!-- <rss>...</rss> -->) currently yields a
+    // false positive because the regex-based detector does not strip comments. Expected: detect
+    // returns false once comment stripping is implemented.
+  })
+
   it('should return false for RSS element in CDATA', () => {
     const cdataFeed = `
       <?xml version="1.0"?>

--- a/src/feeds/rss/generate/index.test.ts
+++ b/src/feeds/rss/generate/index.test.ts
@@ -8,19 +8,23 @@ import { generate } from './index.js'
 describe('generate', () => {
   const versions = {
     '20': '2.0',
-    // ns: 'with namespaces',
   }
 
   for (const [key, label] of Object.entries(versions)) {
     it(`should correctly generate RSS ${label}`, async () => {
       const reference = `${import.meta.dir}/../references/rss-${key}`
       const input = await Bun.file(`${reference}.json`).json()
-      const expectation = await Bun.file(`${reference}.xml`).text()
-      const result = generate(input)
+      const expected = await Bun.file(`${reference}.xml`).text()
 
-      expect(result).toEqual(expectation)
+      expect(generate(input)).toEqual(expected)
     })
   }
+
+  it.todo('should correctly generate RSS with namespaces', () => {
+    // Generate from the references/rss-ns.json fixture and compare against
+    // references/rss-ns.xml. Currently disabled because namespace generation does not yet
+    // reproduce the full reference output.
+  })
 
   it('should generate RSS with atom namespace', () => {
     const value = {
@@ -642,7 +646,7 @@ describe('generate', () => {
           title: 'First item',
           pingback: {
             server: 'https://example.com/xmlrpc.php',
-            target: 'https://referenced-blog.com/article',
+            target: 'https://example.net/article',
           },
         },
       ],
@@ -656,7 +660,7 @@ describe('generate', () => {
     <item>
       <title>First item</title>
       <pingback:server>https://example.com/xmlrpc.php</pingback:server>
-      <pingback:target>https://referenced-blog.com/article</pingback:target>
+      <pingback:target>https://example.net/article</pingback:target>
     </item>
   </channel>
 </rss>
@@ -674,7 +678,7 @@ describe('generate', () => {
           title: 'First item',
           trackback: {
             ping: 'https://example.com/trackback/123',
-            abouts: ['https://blog1.com/trackback/456', 'https://blog2.com/trackback/789'],
+            abouts: ['https://example.net/trackback/456', 'https://example.org/trackback/789'],
           },
         },
       ],
@@ -687,8 +691,8 @@ describe('generate', () => {
     <item>
       <title>First item</title>
       <trackback:ping>https://example.com/trackback/123</trackback:ping>
-      <trackback:about>https://blog1.com/trackback/456</trackback:about>
-      <trackback:about>https://blog2.com/trackback/789</trackback:about>
+      <trackback:about>https://example.net/trackback/456</trackback:about>
+      <trackback:about>https://example.org/trackback/789</trackback:about>
     </item>
   </channel>
 </rss>
@@ -752,7 +756,7 @@ describe('generate', () => {
       description: 'Test feed with blogChannel namespace',
       blogChannel: {
         blogRoll: 'http://example.com/blogroll.opml',
-        blink: 'http://recommended-site.com/',
+        blink: 'http://example.net/',
         mySubscriptions: 'http://example.com/subscriptions.opml',
       },
     }
@@ -762,7 +766,7 @@ describe('generate', () => {
     <title>Feed with blogChannel namespace</title>
     <description>Test feed with blogChannel namespace</description>
     <blogChannel:blogRoll>http://example.com/blogroll.opml</blogChannel:blogRoll>
-    <blogChannel:blink>http://recommended-site.com/</blogChannel:blink>
+    <blogChannel:blink>http://example.net/</blogChannel:blink>
     <blogChannel:mySubscriptions>http://example.com/subscriptions.opml</blogChannel:mySubscriptions>
   </channel>
 </rss>
@@ -856,7 +860,7 @@ describe('generate', () => {
       description: 'Test feed with admin namespace',
       admin: {
         errorReportsTo: 'mailto:webmaster@example.com',
-        generatorAgent: 'http://www.movabletype.org/?v=3.2',
+        generatorAgent: 'https://example.com/generator?v=3.2',
       },
       items: [
         {
@@ -870,7 +874,7 @@ describe('generate', () => {
     <title>Feed with admin namespace</title>
     <description>Test feed with admin namespace</description>
     <admin:errorReportsTo rdf:resource="mailto:webmaster@example.com"/>
-    <admin:generatorAgent rdf:resource="http://www.movabletype.org/?v=3.2"/>
+    <admin:generatorAgent rdf:resource="https://example.com/generator?v=3.2"/>
     <item>
       <title>Item title</title>
     </item>
@@ -1002,7 +1006,7 @@ describe('generate', () => {
   })
 
   it('should generate RSS feed with googleplay namespace', () => {
-    const value = {
+    const value: RssFeed.Feed<DateLike> = {
       title: 'Feed with GooglePlay namespace',
       description: 'Test feed with Google Play Podcasts namespace',
       googleplay: {
@@ -1015,7 +1019,7 @@ describe('generate', () => {
           description: 'Episode description',
           googleplay: {
             author: 'Episode Author',
-            explicit: 'clean' as const,
+            explicit: 'clean',
           },
         },
       ],
@@ -1141,21 +1145,39 @@ describe('generate', () => {
 
     expect(generate(value)).toEqual(expected)
   })
-})
 
-describe('strict mode', () => {
-  it('should require title, link, description in strict mode', () => {
-    // @ts-expect-error: This is for testing purposes.
-    generate({ title: 'Test' }, { strict: true })
-  })
+  describe('strict mode', () => {
+    it('should require title, link, description in strict mode', () => {
+      const value = { title: 'Test' }
+      const expected = `<?xml version="1.0" encoding="utf-8"?>
+<rss version="2.0">
+  <channel>
+    <title>Test</title>
+  </channel>
+</rss>
+`
 
-  it('should accept feed with all required fields in strict mode', () => {
-    generate({ title: 'Test', link: 'https://example.com', description: 'Desc' }, { strict: true })
-  })
+      // @ts-expect-error: This is for testing purposes.
+      expect(generate(value, { strict: true })).toEqual(expected)
+    })
 
-  it('should require nested type fields in strict mode', () => {
-    generate(
-      {
+    it('should accept feed with all required fields in strict mode', () => {
+      const value = { title: 'Test', link: 'https://example.com', description: 'Desc' }
+      const expected = `<?xml version="1.0" encoding="utf-8"?>
+<rss version="2.0">
+  <channel>
+    <title>Test</title>
+    <link>https://example.com</link>
+    <description>Desc</description>
+  </channel>
+</rss>
+`
+
+      expect(generate(value, { strict: true })).toEqual(expected)
+    })
+
+    it('should require nested type fields in strict mode', () => {
+      const value = {
         title: 'Test',
         link: 'https://example.com',
         description: 'Desc',
@@ -1163,18 +1185,31 @@ describe('strict mode', () => {
           {
             title: 'Item',
             description: 'Desc',
-            // @ts-expect-error: This is for testing purposes.
             enclosures: [{ url: 'https://example.com/file.mp3' }],
           },
         ],
-      },
-      { strict: true },
-    )
-  })
+      }
+      const expected = `<?xml version="1.0" encoding="utf-8"?>
+<rss version="2.0">
+  <channel>
+    <title>Test</title>
+    <link>https://example.com</link>
+    <description>Desc</description>
+    <item>
+      <title>Item</title>
+      <description>Desc</description>
+      <enclosure url="https://example.com/file.mp3"/>
+    </item>
+  </channel>
+</rss>
+`
 
-  it('should accept nested types with all required fields in strict mode', () => {
-    generate(
-      {
+      // @ts-expect-error: This is for testing purposes.
+      expect(generate(value, { strict: true })).toEqual(expected)
+    })
+
+    it('should accept nested types with all required fields in strict mode', () => {
+      const value = {
         title: 'Test',
         link: 'https://example.com',
         description: 'Desc',
@@ -1184,58 +1219,120 @@ describe('strict mode', () => {
             enclosures: [{ url: 'https://example.com/file.mp3', length: 1000, type: 'audio/mpeg' }],
           },
         ],
-      },
-      { strict: true },
-    )
-  })
+      }
+      const expected = `<?xml version="1.0" encoding="utf-8"?>
+<rss version="2.0">
+  <channel>
+    <title>Test</title>
+    <link>https://example.com</link>
+    <description>Desc</description>
+    <item>
+      <title>Item</title>
+      <enclosure url="https://example.com/file.mp3" length="1000" type="audio/mpeg"/>
+    </item>
+  </channel>
+</rss>
+`
 
-  it('should accept item with only title in strict mode', () => {
-    generate(
-      {
+      expect(generate(value, { strict: true })).toEqual(expected)
+    })
+
+    it('should accept item with only title in strict mode', () => {
+      const value = {
         title: 'Test',
         link: 'https://example.com',
         description: 'Desc',
         items: [{ title: 'Item Title' }],
-      },
-      { strict: true },
-    )
-  })
+      }
+      const expected = `<?xml version="1.0" encoding="utf-8"?>
+<rss version="2.0">
+  <channel>
+    <title>Test</title>
+    <link>https://example.com</link>
+    <description>Desc</description>
+    <item>
+      <title>Item Title</title>
+    </item>
+  </channel>
+</rss>
+`
 
-  it('should accept item with only description in strict mode', () => {
-    generate(
-      {
+      expect(generate(value, { strict: true })).toEqual(expected)
+    })
+
+    it('should accept item with only description in strict mode', () => {
+      const value = {
         title: 'Test',
         link: 'https://example.com',
         description: 'Desc',
         items: [{ description: 'Item Description' }],
-      },
-      { strict: true },
-    )
-  })
+      }
+      const expected = `<?xml version="1.0" encoding="utf-8"?>
+<rss version="2.0">
+  <channel>
+    <title>Test</title>
+    <link>https://example.com</link>
+    <description>Desc</description>
+    <item>
+      <description>Item Description</description>
+    </item>
+  </channel>
+</rss>
+`
 
-  it('should accept item with both title and description in strict mode', () => {
-    generate(
-      {
+      expect(generate(value, { strict: true })).toEqual(expected)
+    })
+
+    it('should accept item with both title and description in strict mode', () => {
+      const value = {
         title: 'Test',
         link: 'https://example.com',
         description: 'Desc',
         items: [{ title: 'Item Title', description: 'Item Description' }],
-      },
-      { strict: true },
-    )
+      }
+      const expected = `<?xml version="1.0" encoding="utf-8"?>
+<rss version="2.0">
+  <channel>
+    <title>Test</title>
+    <link>https://example.com</link>
+    <description>Desc</description>
+    <item>
+      <title>Item Title</title>
+      <description>Item Description</description>
+    </item>
+  </channel>
+</rss>
+`
+
+      expect(generate(value, { strict: true })).toEqual(expected)
+    })
+
+    it('should accept partial feed in lenient mode', () => {
+      const value = { title: 'Test' }
+      const expected = `<?xml version="1.0" encoding="utf-8"?>
+<rss version="2.0">
+  <channel>
+    <title>Test</title>
+  </channel>
+</rss>
+`
+
+      expect(generate(value)).toEqual(expected)
+    })
+
+    it.todo('should produce identical output in strict and lenient modes', () => {
+      // The strict option only changes compile-time types. Assert that
+      // generate(value, { strict: true }) and generate(value) return byte-identical XML for a
+      // corpus of valid feeds.
+    })
   })
 
-  it('should accept partial feed in lenient mode', () => {
-    generate({ title: 'Test' })
-  })
-})
-
-describe('generate edge cases', () => {
-  it('should accept partial feeds', () => {
-    const value: RssFeed.Feed<DateLike> = {
-      title: 'Test Feed',
-    }
-    const expected = `<?xml version="1.0" encoding="utf-8"?>
+  describe('edge cases', () => {
+    it('should accept partial feeds', () => {
+      const value: RssFeed.Feed<DateLike> = {
+        title: 'Test Feed',
+      }
+      const expected = `<?xml version="1.0" encoding="utf-8"?>
 <rss version="2.0">
   <channel>
     <title>Test Feed</title>
@@ -1243,22 +1340,22 @@ describe('generate edge cases', () => {
 </rss>
 `
 
-    expect(generate(value)).toEqual(expected)
-  })
+      expect(generate(value)).toEqual(expected)
+    })
 
-  it('should accept feeds with string dates', () => {
-    const value: RssFeed.Feed<DateLike> = {
-      title: 'Test Feed',
-      description: 'Test Description',
-      pubDate: '2023-01-01T00:00:00.000Z',
-      items: [
-        {
-          title: 'Test Item',
-          pubDate: 'Mon, 01 Jan 2023 12:00:00 GMT',
-        },
-      ],
-    }
-    const expected = `<?xml version="1.0" encoding="utf-8"?>
+    it('should accept feeds with string dates', () => {
+      const value: RssFeed.Feed<DateLike> = {
+        title: 'Test Feed',
+        description: 'Test Description',
+        pubDate: '2023-01-01T00:00:00.000Z',
+        items: [
+          {
+            title: 'Test Item',
+            pubDate: 'Mon, 01 Jan 2023 12:00:00 GMT',
+          },
+        ],
+      }
+      const expected = `<?xml version="1.0" encoding="utf-8"?>
 <rss version="2.0">
   <channel>
     <title>Test Feed</title>
@@ -1272,22 +1369,22 @@ describe('generate edge cases', () => {
 </rss>
 `
 
-    expect(generate(value)).toEqual(expected)
-  })
+      expect(generate(value)).toEqual(expected)
+    })
 
-  it('should preserve invalid date strings', () => {
-    const value: RssFeed.Feed<DateLike> = {
-      title: 'Test Feed',
-      description: 'Test Description',
-      pubDate: 'not-a-valid-date',
-      items: [
-        {
-          title: 'Test Item',
-          pubDate: 'also-invalid-date',
-        },
-      ],
-    }
-    const expected = `<?xml version="1.0" encoding="utf-8"?>
+    it('should preserve invalid date strings', () => {
+      const value: RssFeed.Feed<DateLike> = {
+        title: 'Test Feed',
+        description: 'Test Description',
+        pubDate: 'not-a-valid-date',
+        items: [
+          {
+            title: 'Test Item',
+            pubDate: 'also-invalid-date',
+          },
+        ],
+      }
+      const expected = `<?xml version="1.0" encoding="utf-8"?>
 <rss version="2.0">
   <channel>
     <title>Test Feed</title>
@@ -1301,27 +1398,27 @@ describe('generate edge cases', () => {
 </rss>
 `
 
-    expect(generate(value)).toEqual(expected)
-  })
+      expect(generate(value)).toEqual(expected)
+    })
 
-  it('should handle deeply nested partial objects', () => {
-    const value: RssFeed.Feed<DateLike> = {
-      title: 'Test Feed',
-      items: [
-        {
-          title: 'Item 1',
-          guid: {
-            value: 'guid-1',
+    it('should handle deeply nested partial objects', () => {
+      const value: RssFeed.Feed<DateLike> = {
+        title: 'Test Feed',
+        items: [
+          {
+            title: 'Item 1',
+            guid: {
+              value: 'guid-1',
+            },
           },
+        ],
+        image: {
+          url: 'https://example.com/image.png',
+          title: 'Image Title',
+          link: 'https://example.com',
         },
-      ],
-      image: {
-        url: 'https://example.com/image.png',
-        title: 'Image Title',
-        link: 'https://example.com',
-      },
-    }
-    const expected = `<?xml version="1.0" encoding="utf-8"?>
+      }
+      const expected = `<?xml version="1.0" encoding="utf-8"?>
 <rss version="2.0">
   <channel>
     <title>Test Feed</title>
@@ -1338,27 +1435,27 @@ describe('generate edge cases', () => {
 </rss>
 `
 
-    expect(generate(value)).toEqual(expected)
-  })
+      expect(generate(value)).toEqual(expected)
+    })
 
-  it('should handle mixed Date objects and string dates', () => {
-    const value: RssFeed.Feed<DateLike> = {
-      title: 'Mixed Dates Feed',
-      description: 'Feed with both Date objects and strings',
-      pubDate: new Date('2023-01-01T00:00:00.000Z'),
-      lastBuildDate: '2023-06-01T00:00:00.000Z',
-      items: [
-        {
-          title: 'Item with Date object',
-          pubDate: new Date('2023-02-01T00:00:00.000Z'),
-        },
-        {
-          title: 'Item with string date',
-          pubDate: '2023-03-01T00:00:00.000Z',
-        },
-      ],
-    }
-    const expected = `<?xml version="1.0" encoding="utf-8"?>
+    it('should handle mixed Date objects and string dates', () => {
+      const value: RssFeed.Feed<DateLike> = {
+        title: 'Mixed Dates Feed',
+        description: 'Feed with both Date objects and strings',
+        pubDate: new Date('2023-01-01T00:00:00.000Z'),
+        lastBuildDate: '2023-06-01T00:00:00.000Z',
+        items: [
+          {
+            title: 'Item with Date object',
+            pubDate: new Date('2023-02-01T00:00:00.000Z'),
+          },
+          {
+            title: 'Item with string date',
+            pubDate: '2023-03-01T00:00:00.000Z',
+          },
+        ],
+      }
+      const expected = `<?xml version="1.0" encoding="utf-8"?>
 <rss version="2.0">
   <channel>
     <title>Mixed Dates Feed</title>
@@ -1377,85 +1474,85 @@ describe('generate edge cases', () => {
 </rss>
 `
 
-    expect(generate(value)).toEqual(expected)
-  })
+      expect(generate(value)).toEqual(expected)
+    })
 
-  it('should generate RSS with acast namespace', () => {
-    const value = {
-      title: 'Feed with acast namespace',
-      description: 'Test feed with Acast namespace',
-      acast: {
-        showId: '664fde3eda02bb0012bad909',
-        showUrl: 'software-unscripted',
-        signature: {
-          key: 'EXAMPLE_KEY',
-          algorithm: 'aes-256-cbc',
-          value: 'wbG1Z7+6h9QOi+CR1Dv0uQ==',
-        },
-        settings: 'FYjHyZbXWHZ7gmX8Pp1rmTHg2/BXqPr07kkpFZ5JfhvEZqggcpunI6E1w81XpUaB',
-        network: {
-          id: '664fdd227c6b200013652ed6',
-          slug: 'richard-feldman-664fdd227c6b200013652ed6',
-          value: 'Richard Feldman',
-        },
-        importedFeed: 'https://feeds.resonaterecordings.com/software-unscripted',
-      },
-      items: [
-        {
-          title: 'Episode with Acast metadata',
-          acast: {
-            episodeId: '6918f06ee42e3466f29467f9',
-            showId: '664fde3eda02bb0012bad909',
-            episodeUrl: 'jonathan-blow-on-programming-language-design',
-            settings: 'FYjHyZbXWHZ7gmX8Pp1rmbKbhgrQiwYShz70Q9/ffXZMTtedvdcRQbP4eiLMjXzC',
+    it('should generate RSS with acast namespace', () => {
+      const value = {
+        title: 'Feed with acast namespace',
+        description: 'Test feed with Acast namespace',
+        acast: {
+          showId: '664fde3eda02bb0012bad909',
+          showUrl: 'example-show',
+          signature: {
+            key: 'EXAMPLE_KEY',
+            algorithm: 'aes-256-cbc',
+            value: 'wbG1Z7+6h9QOi+CR1Dv0uQ==',
           },
+          settings: 'FYjHyZbXWHZ7gmX8Pp1rmTHg2/BXqPr07kkpFZ5JfhvEZqggcpunI6E1w81XpUaB',
+          network: {
+            id: '664fdd227c6b200013652ed6',
+            slug: 'example-network-664fdd227c6b200013652ed6',
+            value: 'Example Network',
+          },
+          importedFeed: 'https://feeds.example.com/example-show',
         },
-      ],
-    }
-    const expected = `<?xml version="1.0" encoding="utf-8"?>
+        items: [
+          {
+            title: 'Episode with Acast metadata',
+            acast: {
+              episodeId: '6918f06ee42e3466f29467f9',
+              showId: '664fde3eda02bb0012bad909',
+              episodeUrl: 'example-episode-slug',
+              settings: 'FYjHyZbXWHZ7gmX8Pp1rmbKbhgrQiwYShz70Q9/ffXZMTtedvdcRQbP4eiLMjXzC',
+            },
+          },
+        ],
+      }
+      const expected = `<?xml version="1.0" encoding="utf-8"?>
 <rss version="2.0" xmlns:acast="https://schema.acast.com/1.0/">
   <channel>
     <title>Feed with acast namespace</title>
     <description>Test feed with Acast namespace</description>
     <acast:showId>664fde3eda02bb0012bad909</acast:showId>
-    <acast:showUrl>software-unscripted</acast:showUrl>
+    <acast:showUrl>example-show</acast:showUrl>
     <acast:signature key="EXAMPLE_KEY" algorithm="aes-256-cbc">wbG1Z7+6h9QOi+CR1Dv0uQ==</acast:signature>
     <acast:settings>FYjHyZbXWHZ7gmX8Pp1rmTHg2/BXqPr07kkpFZ5JfhvEZqggcpunI6E1w81XpUaB</acast:settings>
-    <acast:network id="664fdd227c6b200013652ed6" slug="richard-feldman-664fdd227c6b200013652ed6">Richard Feldman</acast:network>
-    <acast:importedFeed>https://feeds.resonaterecordings.com/software-unscripted</acast:importedFeed>
+    <acast:network id="664fdd227c6b200013652ed6" slug="example-network-664fdd227c6b200013652ed6">Example Network</acast:network>
+    <acast:importedFeed>https://feeds.example.com/example-show</acast:importedFeed>
     <item>
       <title>Episode with Acast metadata</title>
       <acast:episodeId>6918f06ee42e3466f29467f9</acast:episodeId>
       <acast:showId>664fde3eda02bb0012bad909</acast:showId>
-      <acast:episodeUrl>jonathan-blow-on-programming-language-design</acast:episodeUrl>
+      <acast:episodeUrl>example-episode-slug</acast:episodeUrl>
       <acast:settings>FYjHyZbXWHZ7gmX8Pp1rmbKbhgrQiwYShz70Q9/ffXZMTtedvdcRQbP4eiLMjXzC</acast:settings>
     </item>
   </channel>
 </rss>
 `
 
-    expect(generate(value)).toEqual(expected)
-  })
+      expect(generate(value)).toEqual(expected)
+    })
 
-  it('should generate RSS with xml namespace', () => {
-    const value = {
-      title: 'Feed with xml namespace',
-      description: 'Test feed with XML namespace attributes',
-      xml: {
-        lang: 'en',
-        base: 'http://example.org/',
-      },
-      items: [
-        {
-          title: 'Item with XML namespace',
-          xml: {
-            lang: 'en-US',
-            base: 'http://example.org/item/1/',
-          },
+    it('should generate RSS with xml namespace', () => {
+      const value = {
+        title: 'Feed with xml namespace',
+        description: 'Test feed with XML namespace attributes',
+        xml: {
+          lang: 'en',
+          base: 'http://example.org/',
         },
-      ],
-    }
-    const expected = `<?xml version="1.0" encoding="utf-8"?>
+        items: [
+          {
+            title: 'Item with XML namespace',
+            xml: {
+              lang: 'en-US',
+              base: 'http://example.org/item/1/',
+            },
+          },
+        ],
+      }
+      const expected = `<?xml version="1.0" encoding="utf-8"?>
 <rss version="2.0" xml:lang="en" xml:base="http://example.org/">
   <channel>
     <title>Feed with xml namespace</title>
@@ -1467,16 +1564,17 @@ describe('generate edge cases', () => {
 </rss>
 `
 
-    expect(generate(value)).toEqual(expected)
+      expect(generate(value)).toEqual(expected)
+    })
   })
-})
 
-describe('error types', () => {
-  it('should throw GenerateError for empty input', () => {
-    const value = {}
-    const throwing = () => generate(value)
+  describe('error types', () => {
+    it('should throw GenerateError for empty input', () => {
+      const value = {}
+      const throwing = () => generate(value)
 
-    expect(throwing).toThrow(GenerateError)
-    expect(throwing).toThrow(locales.invalidInputRss)
+      expect(throwing).toThrowError(GenerateError)
+      expect(throwing).toThrowError(locales.invalidInputRss)
+    })
   })
 })

--- a/src/feeds/rss/generate/utils.test.ts
+++ b/src/feeds/rss/generate/utils.test.ts
@@ -260,6 +260,12 @@ describe('generateImage', () => {
     expect(generateImage(value)).toBeUndefined()
   })
 
+  it('should handle empty object', () => {
+    const value = {}
+
+    expect(generateImage(value)).toBeUndefined()
+  })
+
   it('should handle non-object inputs gracefully', () => {
     expect(generateImage(undefined)).toBeUndefined()
   })
@@ -461,19 +467,6 @@ describe('generateGuid', () => {
 
 describe('generateSource', () => {
   it('should generate valid source object with all properties', () => {
-    const value = {
-      title: 'Example Source',
-      url: 'https://example.com/feed.xml',
-    }
-    const expected = {
-      '#text': 'Example Source',
-      '@url': 'https://example.com/feed.xml',
-    }
-
-    expect(generateSource(value)).toEqual(expected)
-  })
-
-  it('should generate source with all required properties', () => {
     const value = {
       title: 'Example Source',
       url: 'https://example.com/feed.xml',
@@ -876,13 +869,13 @@ describe('generateItem', () => {
       title: 'Item with pingback namespace',
       pingback: {
         server: 'https://example.com/xmlrpc.php',
-        target: 'https://referenced-blog.com/article',
+        target: 'https://example.net/article',
       },
     }
     const expected = {
       title: 'Item with pingback namespace',
       'pingback:server': 'https://example.com/xmlrpc.php',
-      'pingback:target': 'https://referenced-blog.com/article',
+      'pingback:target': 'https://example.net/article',
     }
 
     expect(generateItem(value)).toEqual(expected)
@@ -893,13 +886,13 @@ describe('generateItem', () => {
       title: 'Item with trackback namespace',
       trackback: {
         ping: 'https://example.com/trackback/123',
-        abouts: ['https://blog1.com/trackback/456', 'https://blog2.com/trackback/789'],
+        abouts: ['https://example.net/trackback/456', 'https://example.org/trackback/789'],
       },
     }
     const expected = {
       title: 'Item with trackback namespace',
       'trackback:ping': 'https://example.com/trackback/123',
-      'trackback:about': ['https://blog1.com/trackback/456', 'https://blog2.com/trackback/789'],
+      'trackback:about': ['https://example.net/trackback/456', 'https://example.org/trackback/789'],
     }
 
     expect(generateItem(value)).toEqual(expected)
@@ -1562,7 +1555,7 @@ describe('generateFeed', () => {
       description: 'A feed with blogChannel properties',
       blogChannel: {
         blogRoll: 'http://example.com/blogroll.opml',
-        blink: 'http://recommended-site.com/',
+        blink: 'http://example.net/',
         mySubscriptions: 'http://example.com/subscriptions.opml',
       },
     }
@@ -1574,7 +1567,7 @@ describe('generateFeed', () => {
           title: 'Feed with blogChannel namespace',
           description: 'A feed with blogChannel properties',
           'blogChannel:blogRoll': 'http://example.com/blogroll.opml',
-          'blogChannel:blink': 'http://recommended-site.com/',
+          'blogChannel:blink': 'http://example.net/',
           'blogChannel:mySubscriptions': 'http://example.com/subscriptions.opml',
         },
       },
@@ -1590,6 +1583,8 @@ describe('generateFeed', () => {
       cc: {
         license: 'https://creativecommons.org/licenses/by-nc-sa/4.0/',
         morePermissions: 'https://example.com/commercial-license',
+        attributionName: 'Example Publishing Company',
+        attributionURL: 'https://example.com/',
       },
     }
     const expected = {
@@ -1601,6 +1596,8 @@ describe('generateFeed', () => {
           description: 'A feed with ccREL license',
           'cc:license': 'https://creativecommons.org/licenses/by-nc-sa/4.0/',
           'cc:morePermissions': 'https://example.com/commercial-license',
+          'cc:attributionName': 'Example Publishing Company',
+          'cc:attributionURL': 'https://example.com/',
         },
       },
     }
@@ -1631,38 +1628,13 @@ describe('generateFeed', () => {
     expect(generateFeed(value)).toEqual(expected)
   })
 
-  it('should generate feedpress namespace properties and attributes for feed', () => {
-    const value = {
-      title: 'Feed with FeedPress namespace',
-      description: 'A feed with FeedPress properties',
-      feedpress: {
-        link: 'https://feed.press/example',
-        newsletterId: '12345',
-      },
-    }
-    const expected = {
-      rss: {
-        '@version': '2.0',
-        '@xmlns:feedpress': 'https://feed.press/xmlns',
-        channel: {
-          title: 'Feed with FeedPress namespace',
-          description: 'A feed with FeedPress properties',
-          'feedpress:link': 'https://feed.press/example',
-          'feedpress:newsletterId': '12345',
-        },
-      },
-    }
-
-    expect(generateFeed(value)).toEqual(expected)
-  })
-
   it('should generate admin namespace properties and attributes for feed', () => {
     const value = {
       title: 'Feed with admin namespace',
       description: 'A feed with admin properties',
       admin: {
         errorReportsTo: 'mailto:webmaster@example.com',
-        generatorAgent: 'http://www.movabletype.org/?v=3.2',
+        generatorAgent: 'https://example.com/generator?v=3.2',
       },
     }
     const expected = {
@@ -1677,47 +1649,8 @@ describe('generateFeed', () => {
             '@rdf:resource': 'mailto:webmaster@example.com',
           },
           'admin:generatorAgent': {
-            '@rdf:resource': 'http://www.movabletype.org/?v=3.2',
+            '@rdf:resource': 'https://example.com/generator?v=3.2',
           },
-        },
-      },
-    }
-
-    expect(generateFeed(value)).toEqual(expected)
-  })
-
-  it('should generate opensearch namespace properties for feed', () => {
-    const value = {
-      title: 'Search Results',
-      description: 'Search results feed',
-      opensearch: {
-        totalResults: 1000,
-        startIndex: 21,
-        itemsPerPage: 10,
-        queries: [
-          {
-            role: 'request',
-            searchTerms: 'quantum computing',
-          },
-        ],
-      },
-    }
-    const expected = {
-      rss: {
-        '@version': '2.0',
-        '@xmlns:opensearch': 'http://a9.com/-/spec/opensearch/1.1/',
-        channel: {
-          title: 'Search Results',
-          description: 'Search results feed',
-          'opensearch:totalResults': 1000,
-          'opensearch:startIndex': 21,
-          'opensearch:itemsPerPage': 10,
-          'opensearch:Query': [
-            {
-              '@role': 'request',
-              '@searchTerms': 'quantum computing',
-            },
-          ],
         },
       },
     }
@@ -1747,29 +1680,6 @@ describe('generateFeed', () => {
             '#text': 'TV-PG',
           },
           'rawvoice:frequency': 'weekly',
-        },
-      },
-    }
-
-    expect(generateFeed(value)).toEqual(expected)
-  })
-
-  it('should generate spotify namespace properties and attributes for feed', () => {
-    const value = {
-      title: 'Feed with Spotify namespace',
-      description: 'A feed with Spotify properties',
-      spotify: {
-        countryOfOrigin: 'US',
-      },
-    }
-    const expected = {
-      rss: {
-        '@version': '2.0',
-        '@xmlns:spotify': 'http://www.spotify.com/ns/rss',
-        channel: {
-          title: 'Feed with Spotify namespace',
-          description: 'A feed with Spotify properties',
-          'spotify:countryOfOrigin': 'US',
         },
       },
     }
@@ -1826,7 +1736,7 @@ describe('generateFeed', () => {
       description: 'A feed with Acast properties',
       acast: {
         showId: '664fde3eda02bb0012bad909',
-        showUrl: 'software-unscripted',
+        showUrl: 'example-show',
         signature: {
           key: 'EXAMPLE_KEY',
           algorithm: 'aes-256-cbc',
@@ -1835,10 +1745,10 @@ describe('generateFeed', () => {
         settings: 'FYjHyZbXWHZ7gmX8Pp1rmTHg2/BXqPr07kkpFZ5JfhvEZqggcpunI6E1w81XpUaB',
         network: {
           id: '664fdd227c6b200013652ed6',
-          slug: 'richard-feldman-664fdd227c6b200013652ed6',
-          value: 'Richard Feldman',
+          slug: 'example-network-664fdd227c6b200013652ed6',
+          value: 'Example Network',
         },
-        importedFeed: 'https://feeds.resonaterecordings.com/software-unscripted',
+        importedFeed: 'https://feeds.example.com/example-show',
       },
     }
     const expected = {
@@ -1849,7 +1759,7 @@ describe('generateFeed', () => {
           title: 'Feed with Acast namespace',
           description: 'A feed with Acast properties',
           'acast:showId': '664fde3eda02bb0012bad909',
-          'acast:showUrl': 'software-unscripted',
+          'acast:showUrl': 'example-show',
           'acast:signature': {
             '@key': 'EXAMPLE_KEY',
             '@algorithm': 'aes-256-cbc',
@@ -1858,10 +1768,10 @@ describe('generateFeed', () => {
           'acast:settings': 'FYjHyZbXWHZ7gmX8Pp1rmTHg2/BXqPr07kkpFZ5JfhvEZqggcpunI6E1w81XpUaB',
           'acast:network': {
             '@id': '664fdd227c6b200013652ed6',
-            '@slug': 'richard-feldman-664fdd227c6b200013652ed6',
-            '#text': 'Richard Feldman',
+            '@slug': 'example-network-664fdd227c6b200013652ed6',
+            '#text': 'Example Network',
           },
-          'acast:importedFeed': 'https://feeds.resonaterecordings.com/software-unscripted',
+          'acast:importedFeed': 'https://feeds.example.com/example-show',
         },
       },
     }
@@ -1879,7 +1789,7 @@ describe('generateFeed', () => {
           acast: {
             episodeId: '6918f06ee42e3466f29467f9',
             showId: '664fde3eda02bb0012bad909',
-            episodeUrl: 'jonathan-blow-on-programming-language-design',
+            episodeUrl: 'example-episode-slug',
             settings: 'FYjHyZbXWHZ7gmX8Pp1rmbKbhgrQiwYShz70Q9/ffXZMTtedvdcRQbP4eiLMjXzC',
           },
         },
@@ -1897,37 +1807,10 @@ describe('generateFeed', () => {
               title: 'Episode with Acast metadata',
               'acast:episodeId': '6918f06ee42e3466f29467f9',
               'acast:showId': '664fde3eda02bb0012bad909',
-              'acast:episodeUrl': 'jonathan-blow-on-programming-language-design',
+              'acast:episodeUrl': 'example-episode-slug',
               'acast:settings': 'FYjHyZbXWHZ7gmX8Pp1rmbKbhgrQiwYShz70Q9/ffXZMTtedvdcRQbP4eiLMjXzC',
             },
           ],
-        },
-      },
-    }
-
-    expect(generateFeed(value)).toEqual(expected)
-  })
-
-  it('should generate RSS feed with blogChannel namespace properties', () => {
-    const value = {
-      title: 'Blog Feed',
-      description: 'A feed with blogChannel properties',
-      blogChannel: {
-        blogRoll: 'http://example.com/blogroll.opml',
-        blink: 'http://recommended-site.com/',
-        mySubscriptions: 'http://example.com/subscriptions.opml',
-      },
-    }
-    const expected = {
-      rss: {
-        '@version': '2.0',
-        '@xmlns:blogChannel': 'http://backend.userland.com/blogChannelModule',
-        channel: {
-          title: 'Blog Feed',
-          description: 'A feed with blogChannel properties',
-          'blogChannel:blogRoll': 'http://example.com/blogroll.opml',
-          'blogChannel:blink': 'http://recommended-site.com/',
-          'blogChannel:mySubscriptions': 'http://example.com/subscriptions.opml',
         },
       },
     }
@@ -2062,56 +1945,6 @@ describe('generateFeed', () => {
             '@recentCount': 10,
           },
           'spotify:countryOfOrigin': 'US',
-        },
-      },
-    }
-
-    expect(generateFeed(value)).toEqual(expected)
-  })
-
-  it('should generate RSS feed with ccREL namespace properties', () => {
-    const value = {
-      title: 'Licensed Feed',
-      description: 'A feed with ccREL properties',
-      cc: {
-        license: 'https://creativecommons.org/licenses/by-nc-sa/4.0/',
-        attributionName: 'Example Publishing Company',
-        attributionURL: 'https://example.com/',
-      },
-    }
-    const expected = {
-      rss: {
-        '@version': '2.0',
-        '@xmlns:cc': 'http://creativecommons.org/ns#',
-        channel: {
-          title: 'Licensed Feed',
-          description: 'A feed with ccREL properties',
-          'cc:license': 'https://creativecommons.org/licenses/by-nc-sa/4.0/',
-          'cc:attributionName': 'Example Publishing Company',
-          'cc:attributionURL': 'https://example.com/',
-        },
-      },
-    }
-
-    expect(generateFeed(value)).toEqual(expected)
-  })
-
-  it('should generate RSS feed with creativecommons namespace properties', () => {
-    const value = {
-      title: 'Licensed Feed',
-      description: 'A feed with Creative Commons properties',
-      creativeCommons: {
-        licenses: ['http://creativecommons.org/licenses/by-nc-nd/2.0/'],
-      },
-    }
-    const expected = {
-      rss: {
-        '@version': '2.0',
-        '@xmlns:creativeCommons': 'http://backend.userland.com/creativeCommonsRssModule',
-        channel: {
-          title: 'Licensed Feed',
-          description: 'A feed with Creative Commons properties',
-          'creativeCommons:license': ['http://creativecommons.org/licenses/by-nc-nd/2.0/'],
         },
       },
     }

--- a/src/feeds/rss/parse/index.test.ts
+++ b/src/feeds/rss/parse/index.test.ts
@@ -18,10 +18,9 @@ describe('parse', () => {
     it(`should correctly parse RSS ${label}`, async () => {
       const reference = `${import.meta.dir}/../references/rss-${key}`
       const input = await Bun.file(`${reference}.xml`).text()
-      const expectation = await Bun.file(`${reference}.json`).json()
-      const result = parse(input)
+      const expected = await Bun.file(`${reference}.json`).json()
 
-      expect(result).toEqual(expectation)
+      expect(parse(input)).toEqual(expected)
     })
   }
 
@@ -49,7 +48,7 @@ describe('parse', () => {
         </ChAnNeL>
       </rSs>
     `
-    const expectation = {
+    const expected = {
       title: 'Mixed Case Feed',
       link: 'https://example.com/',
       description: 'A test feed with mixed case tags',
@@ -70,7 +69,7 @@ describe('parse', () => {
       ],
     }
 
-    expect(parse(value)).toEqual(expectation)
+    expect(parse(value)).toEqual(expected)
   })
 
   it('should handle alternating case items', () => {
@@ -93,14 +92,14 @@ describe('parse', () => {
         </channel>
       </rss>
     `
-    const expectation = {
+    const expected = {
       title: 'Test Feed',
       link: 'https://example.com',
       description: 'Testing alternating case items',
       items: [{ title: 'First' }, { title: 'Second' }, { title: 'Third' }],
     }
 
-    expect(parse(value)).toEqual(expectation)
+    expect(parse(value)).toEqual(expected)
   })
 
   it('should parse RSS feed with multiple enclosures per item', () => {
@@ -188,39 +187,59 @@ describe('parse', () => {
   })
 
   it('should throw error for invalid input', () => {
-    expect(() => parse('not a feed')).toThrowError(locales.invalidFeedFormat)
+    const throwing = () => parse('not a feed')
+
+    expect(throwing).toThrowError(locales.invalidFeedFormat)
   })
 
   it('should handle null input', () => {
-    expect(() => parse(null)).toThrowError(locales.invalidFeedFormat)
+    const throwing = () => parse(null)
+
+    expect(throwing).toThrowError(locales.invalidFeedFormat)
   })
 
   it('should handle undefined input', () => {
-    expect(() => parse(undefined)).toThrowError(locales.invalidFeedFormat)
+    const throwing = () => parse(undefined)
+
+    expect(throwing).toThrowError(locales.invalidFeedFormat)
   })
 
   it('should handle array input', () => {
-    expect(() => parse([])).toThrowError(locales.invalidFeedFormat)
+    const throwing = () => parse([])
+
+    expect(throwing).toThrowError(locales.invalidFeedFormat)
   })
 
   it('should handle empty object input', () => {
-    expect(() => parse({})).toThrowError(locales.invalidFeedFormat)
+    const throwing = () => parse({})
+
+    expect(throwing).toThrowError(locales.invalidFeedFormat)
   })
 
-  it('should handle string input', () => {
-    expect(() => parse('not a feed')).toThrowError(locales.invalidFeedFormat)
+  it('should handle empty string input', () => {
+    const throwing = () => parse('')
+
+    expect(throwing).toThrowError(locales.invalidFeedFormat)
+  })
+
+  it('should handle whitespace-only string input', () => {
+    const throwing = () => parse('   \n  ')
+
+    expect(throwing).toThrowError(locales.invalidFeedFormat)
   })
 
   it('should handle number input', () => {
-    expect(() => parse(123)).toThrowError(locales.invalidFeedFormat)
+    const throwing = () => parse(123)
+
+    expect(throwing).toThrowError(locales.invalidFeedFormat)
   })
 
   describe('error types', () => {
     it('should throw DetectError for non-feed input', () => {
       const throwing = () => parse('not a feed')
 
-      expect(throwing).toThrow(DetectError)
-      expect(throwing).toThrow(locales.invalidFeedFormat)
+      expect(throwing).toThrowError(DetectError)
+      expect(throwing).toThrowError(locales.invalidFeedFormat)
     })
 
     it('should throw MalformedError for malformed XML', () => {
@@ -234,16 +253,16 @@ describe('parse', () => {
       `
       const throwing = () => parse(value)
 
-      expect(throwing).toThrow(MalformedError)
-      expect(throwing).toThrow(locales.invalidFeedFormat)
+      expect(throwing).toThrowError(MalformedError)
+      expect(throwing).toThrowError(locales.invalidFeedFormat)
     })
 
     it('should throw ParseError for valid XML with invalid structure', () => {
       const value = '<rss version="2.0"></rss>'
       const throwing = () => parse(value)
 
-      expect(throwing).toThrow(ParseError)
-      expect(throwing).toThrow(locales.invalidFeedFormat)
+      expect(throwing).toThrowError(ParseError)
+      expect(throwing).toThrowError(locales.invalidFeedFormat)
     })
   })
 
@@ -888,7 +907,7 @@ describe('parse', () => {
 
   // Edge cases and quirks observed in feeds found in the wild.
   describe('real world feeds', () => {
-    it('RW-C01: should preserve HTML entities inside CDATA in content:encoded', () => {
+    it('should preserve HTML entities inside CDATA in content:encoded (RW-C01)', () => {
       const value = `
         <?xml version="1.0" encoding="UTF-8"?>
         <rss version="2.0" xmlns:content="http://purl.org/rss/1.0/modules/content/">
@@ -923,7 +942,7 @@ describe('parse', () => {
     })
 
     describe('author', () => {
-      it('RW-M03: should parse item author in RFC 2822 format', () => {
+      it('should parse item author in RFC 2822 format (RW-M03)', () => {
         const value = `
           <?xml version="1.0" encoding="UTF-8"?>
           <rss version="2.0">
@@ -953,7 +972,7 @@ describe('parse', () => {
         expect(parse(value)).toEqual(expected)
       })
 
-      it('RW-M03: should parse item author with nested name element', () => {
+      it('should parse item author with nested name element (RW-M03)', () => {
         const value = `
           <?xml version="1.0" encoding="UTF-8"?>
           <rss version="2.0">
@@ -985,7 +1004,7 @@ describe('parse', () => {
     })
 
     describe('character encoding', () => {
-      it('RW-E01: should decode HTML numeric character references in text', () => {
+      it('should decode HTML numeric character references in text (RW-E01)', () => {
         const value = `
           <?xml version="1.0" encoding="UTF-8"?>
           <rss version="2.0">
@@ -1009,7 +1028,7 @@ describe('parse', () => {
         expect(parse(value)).toEqual(expected)
       })
 
-      it('RW-E02: should decode hex numeric character references', () => {
+      it('should decode hex numeric character references (RW-E02)', () => {
         const value = `
           <?xml version="1.0" encoding="UTF-8"?>
           <rss version="2.0">
@@ -1033,7 +1052,7 @@ describe('parse', () => {
         expect(parse(value)).toEqual(expected)
       })
 
-      it('RW-E03: should decode named HTML entities in text', () => {
+      it('should decode named HTML entities in text (RW-E03)', () => {
         const value = `
           <?xml version="1.0" encoding="UTF-8"?>
           <rss version="2.0">
@@ -1057,7 +1076,7 @@ describe('parse', () => {
         expect(parse(value)).toEqual(expected)
       })
 
-      it('RW-E04: should single-decode double-encoded entities', () => {
+      it('should single-decode double-encoded entities (RW-E04)', () => {
         const value = `
           <?xml version="1.0" encoding="UTF-8"?>
           <rss version="2.0">
@@ -1081,7 +1100,7 @@ describe('parse', () => {
         expect(parse(value)).toEqual(expected)
       })
 
-      it('RW-E05: should decode multiple entity types in a single field', () => {
+      it('should decode multiple entity types in a single field (RW-E05)', () => {
         const value = `
           <?xml version="1.0" encoding="UTF-8"?>
           <rss version="2.0">
@@ -1107,7 +1126,7 @@ describe('parse', () => {
     })
 
     describe('cdata handling', () => {
-      it('RW-C05: should handle mixed CDATA and regular text in same element', () => {
+      it('should handle mixed CDATA and regular text in same element (RW-C05)', () => {
         const value = `
           <?xml version="1.0" encoding="UTF-8"?>
           <rss version="2.0">
@@ -1131,7 +1150,7 @@ describe('parse', () => {
         expect(parse(value)).toEqual(expected)
       })
 
-      it('RW-C02: should handle empty CDATA section', () => {
+      it('should handle empty CDATA section (RW-C02)', () => {
         const value = `
           <?xml version="1.0" encoding="UTF-8"?>
           <rss version="2.0">
@@ -1150,7 +1169,7 @@ describe('parse', () => {
         expect(parse(value)).toEqual(expected)
       })
 
-      it('RW-C02: should handle CDATA in title element', () => {
+      it('should handle CDATA in title element (RW-C02)', () => {
         const value = `
           <?xml version="1.0" encoding="UTF-8"?>
           <rss version="2.0">
@@ -1170,7 +1189,7 @@ describe('parse', () => {
         expect(parse(value)).toEqual(expected)
       })
 
-      it('RW-C12: should preserve HTML entities inside CDATA verbatim per XML spec', () => {
+      it('should preserve HTML entities inside CDATA verbatim per XML spec (RW-C12)', () => {
         const value = `
           <?xml version="1.0" encoding="UTF-8"?>
           <rss version="2.0">
@@ -1198,7 +1217,7 @@ describe('parse', () => {
         expect(parse(value)).toEqual(expected)
       })
 
-      it('RW-C11: should handle CDATA preceded by whitespace and newlines', () => {
+      it('should handle CDATA preceded by whitespace and newlines (RW-C11)', () => {
         const value = `
           <?xml version="1.0" encoding="UTF-8"?>
           <rss version="2.0">
@@ -1230,7 +1249,7 @@ describe('parse', () => {
         expect(parse(value)).toEqual(expected)
       })
 
-      it('RW-C01: should preserve entities inside CDATA without decoding', () => {
+      it('should preserve entities inside CDATA without decoding (RW-C01)', () => {
         const value = `
           <?xml version="1.0" encoding="UTF-8"?>
           <rss version="2.0" xmlns:content="http://purl.org/rss/1.0/modules/content/">
@@ -1262,7 +1281,7 @@ describe('parse', () => {
     })
 
     describe('escaped cdata', () => {
-      it('RW-C10: should preserve entity-escaped CDATA markers as literal text', () => {
+      it('should preserve entity-escaped CDATA markers as literal text (RW-C10)', () => {
         const value = `
           <?xml version="1.0" encoding="UTF-8"?>
           <rss version="2.0">
@@ -1294,7 +1313,7 @@ describe('parse', () => {
     })
 
     describe('content and description', () => {
-      it('RW-D01: should parse both content:encoded and description independently', () => {
+      it('should parse both content:encoded and description independently (RW-D01)', () => {
         const value = `
           <?xml version="1.0" encoding="UTF-8"?>
           <rss version="2.0" xmlns:content="http://purl.org/rss/1.0/modules/content/">
@@ -1326,7 +1345,7 @@ describe('parse', () => {
         expect(parse(value)).toEqual(expected)
       })
 
-      it('RW-D02: should handle empty self-closing description tag', () => {
+      it('should handle empty self-closing description tag (RW-D02)', () => {
         const value = `
           <?xml version="1.0" encoding="UTF-8"?>
           <rss version="2.0">
@@ -1345,7 +1364,7 @@ describe('parse', () => {
         expect(parse(value)).toEqual(expected)
       })
 
-      it('RW-D03: should handle whitespace-only description', () => {
+      it('should handle whitespace-only description (RW-D03)', () => {
         const value = `
           <?xml version="1.0" encoding="UTF-8"?>
           <rss version="2.0">
@@ -1364,7 +1383,7 @@ describe('parse', () => {
         expect(parse(value)).toEqual(expected)
       })
 
-      it('RW-D04: should decode escaped HTML in description', () => {
+      it('should decode escaped HTML in description (RW-D04)', () => {
         const value = `
           <?xml version="1.0" encoding="UTF-8"?>
           <rss version="2.0">
@@ -1396,7 +1415,7 @@ describe('parse', () => {
     })
 
     describe('link and URL handling', () => {
-      it('RW-L01: should preserve relative URLs as-is', () => {
+      it('should preserve relative URLs as-is (RW-L01)', () => {
         const value = `
           <?xml version="1.0" encoding="UTF-8"?>
           <rss version="2.0">
@@ -1426,7 +1445,7 @@ describe('parse', () => {
         expect(parse(value)).toEqual(expected)
       })
 
-      it('RW-L02: should handle URLs with encoded ampersands in query parameters', () => {
+      it('should handle URLs with encoded ampersands in query parameters (RW-L02)', () => {
         const value = `
           <?xml version="1.0" encoding="UTF-8"?>
           <rss version="2.0">
@@ -1456,7 +1475,7 @@ describe('parse', () => {
         expect(parse(value)).toEqual(expected)
       })
 
-      it('RW-L03: should parse atom:link in RSS feed', () => {
+      it('should parse atom:link in RSS feed (RW-L03)', () => {
         const value = `
           <?xml version="1.0" encoding="UTF-8"?>
           <rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
@@ -1482,7 +1501,7 @@ describe('parse', () => {
         expect(parse(value)).toEqual(expected)
       })
 
-      it('RW-L12: should parse plain link when mixed with attribute-only link elements', () => {
+      it('should parse plain link when mixed with attribute-only link elements (RW-L12)', () => {
         const value = `
           <?xml version="1.0" encoding="UTF-8"?>
           <rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
@@ -1519,7 +1538,7 @@ describe('parse', () => {
     })
 
     describe('multiple elements', () => {
-      it('RW-M01: should parse multiple enclosures', () => {
+      it('should parse multiple enclosures (RW-M01)', () => {
         const value = `
           <?xml version="1.0" encoding="UTF-8"?>
           <rss version="2.0">
@@ -1553,7 +1572,7 @@ describe('parse', () => {
         expect(parse(value)).toEqual(expected)
       })
 
-      it('RW-M02: should parse multiple categories with domains', () => {
+      it('should parse multiple categories with domains (RW-M02)', () => {
         const value = `
           <?xml version="1.0" encoding="UTF-8"?>
           <rss version="2.0">
@@ -1589,7 +1608,7 @@ describe('parse', () => {
         expect(parse(value)).toEqual(expected)
       })
 
-      it('RW-M03: should parse multiple authors', () => {
+      it('should parse multiple authors (RW-M03)', () => {
         const value = `
           <?xml version="1.0" encoding="UTF-8"?>
           <rss version="2.0">
@@ -1625,7 +1644,7 @@ describe('parse', () => {
     })
 
     describe('missing and empty elements', () => {
-      it('RW-N01: should parse feed with no items', () => {
+      it('should parse feed with no items (RW-N01)', () => {
         const value = `
           <?xml version="1.0" encoding="UTF-8"?>
           <rss version="2.0">
@@ -1645,7 +1664,7 @@ describe('parse', () => {
         expect(parse(value)).toEqual(expected)
       })
 
-      it('RW-N02: should parse item with only description', () => {
+      it('should parse item with only description (RW-N02)', () => {
         const value = `
           <?xml version="1.0" encoding="UTF-8"?>
           <rss version="2.0">
@@ -1669,7 +1688,7 @@ describe('parse', () => {
         expect(parse(value)).toEqual(expected)
       })
 
-      it('RW-N03: should handle self-closing empty tags gracefully', () => {
+      it('should handle self-closing empty tags gracefully (RW-N03)', () => {
         const value = `
           <?xml version="1.0" encoding="UTF-8"?>
           <rss version="2.0">
@@ -1695,7 +1714,7 @@ describe('parse', () => {
         expect(parse(value)).toEqual(expected)
       })
 
-      it('RW-N06: should parse feed with minimal channel info', () => {
+      it('should parse feed with minimal channel info (RW-N06)', () => {
         const value = `
           <?xml version="1.0" encoding="UTF-8"?>
           <rss version="2.0">
@@ -1711,18 +1730,19 @@ describe('parse', () => {
         expect(parse(value)).toEqual(expected)
       })
 
-      it('RW-N14: should throw for empty channel container', () => {
+      it('should throw for empty channel container (RW-N14)', () => {
         const value = `
           <?xml version="1.0" encoding="UTF-8"?>
           <rss version="2.0">
             <channel></channel>
           </rss>
         `
+        const throwing = () => parse(value)
 
-        expect(() => parse(value)).toThrow()
+        expect(throwing).toThrowError(ParseError)
       })
 
-      it('RW-N16: should parse RSS feed with no channel title', () => {
+      it('should parse RSS feed with no channel title (RW-N16)', () => {
         const value = `
           <?xml version="1.0" encoding="UTF-8"?>
           <rss version="2.0">
@@ -1744,7 +1764,7 @@ describe('parse', () => {
         expect(parse(value)).toEqual(expected)
       })
 
-      it('RW-N18: should treat empty guid element as absent', () => {
+      it('should treat empty guid element as absent (RW-N18)', () => {
         const value = `
           <?xml version="1.0" encoding="UTF-8"?>
           <rss version="2.0">
@@ -1771,7 +1791,7 @@ describe('parse', () => {
     })
 
     describe('attribute handling', () => {
-      it('RW-A01: should parse guid with isPermaLink false', () => {
+      it('should parse guid with isPermaLink false (RW-A01)', () => {
         const value = `
           <?xml version="1.0" encoding="UTF-8"?>
           <rss version="2.0">
@@ -1801,7 +1821,7 @@ describe('parse', () => {
         expect(parse(value)).toEqual(expected)
       })
 
-      it('RW-A02: should parse guid with uppercase isPermaLink value', () => {
+      it('should parse guid with uppercase isPermaLink value (RW-A02)', () => {
         const value = `
           <?xml version="1.0" encoding="UTF-8"?>
           <rss version="2.0">
@@ -1831,7 +1851,7 @@ describe('parse', () => {
         expect(parse(value)).toEqual(expected)
       })
 
-      it('RW-A03: should parse enclosure with all attributes', () => {
+      it('should parse enclosure with all attributes (RW-A03)', () => {
         const value = `
           <?xml version="1.0" encoding="UTF-8"?>
           <rss version="2.0">
@@ -1865,7 +1885,7 @@ describe('parse', () => {
     })
 
     describe('namespace edge cases', () => {
-      it('RW-NS01: should handle non-standard prefix for known namespace URI', () => {
+      it('should handle non-standard prefix for known namespace URI (RW-NS01)', () => {
         const value = `
           <?xml version="1.0" encoding="UTF-8"?>
           <rss version="2.0" xmlns:mydc="http://purl.org/dc/elements/1.1/">
@@ -1897,7 +1917,7 @@ describe('parse', () => {
         expect(parse(value)).toEqual(expected)
       })
 
-      it('RW-NS02: should handle multiple namespaces with non-standard prefixes', () => {
+      it('should handle multiple namespaces with non-standard prefixes (RW-NS02)', () => {
         const value = `
           <?xml version="1.0" encoding="UTF-8"?>
           <rss version="2.0"
@@ -1936,7 +1956,7 @@ describe('parse', () => {
         expect(parse(value)).toEqual(expected)
       })
 
-      it('RW-NS03: should handle namespace URI without trailing slash variant', () => {
+      it('should handle namespace URI without trailing slash variant (RW-NS03)', () => {
         const value = `
           <?xml version="1.0" encoding="UTF-8"?>
           <rss version="2.0" xmlns:dc="http://purl.org/dc/elements/1.1">
@@ -1968,7 +1988,7 @@ describe('parse', () => {
         expect(parse(value)).toEqual(expected)
       })
 
-      it('RW-NS12: should handle namespace declared inline on item element', () => {
+      it('should handle namespace declared inline on item element (RW-NS12)', () => {
         const value = `
           <?xml version="1.0" encoding="UTF-8"?>
           <rss version="2.0">
@@ -2002,7 +2022,7 @@ describe('parse', () => {
     })
 
     describe('feed-specific quirks', () => {
-      it('RW-Q02: should parse podcast feed with itunes namespace', () => {
+      it('should parse podcast feed with itunes namespace (RW-Q02)', () => {
         const value = `
           <?xml version="1.0" encoding="UTF-8"?>
           <rss version="2.0" xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd">
@@ -2040,7 +2060,7 @@ describe('parse', () => {
         expect(parse(value)).toEqual(expected)
       })
 
-      it('RW-Q03: should parse feed with source element on item', () => {
+      it('should parse feed with source element on item (RW-Q03)', () => {
         const value = `
           <?xml version="1.0" encoding="UTF-8"?>
           <rss version="2.0">
@@ -2050,7 +2070,7 @@ describe('parse', () => {
               <description>Aggregated feed</description>
               <item>
                 <title>Cross-posted Article</title>
-                <source url="https://original.com/feed.xml">Original Blog</source>
+                <source url="https://example.org/feed.xml">Original Blog</source>
               </item>
             </channel>
           </rss>
@@ -2062,7 +2082,7 @@ describe('parse', () => {
           items: [
             {
               title: 'Cross-posted Article',
-              source: { title: 'Original Blog', url: 'https://original.com/feed.xml' },
+              source: { title: 'Original Blog', url: 'https://example.org/feed.xml' },
             },
           ],
         }
@@ -2070,7 +2090,7 @@ describe('parse', () => {
         expect(parse(value)).toEqual(expected)
       })
 
-      it('RW-Q04: should parse feed with comments URL on item', () => {
+      it('should parse feed with comments URL on item (RW-Q04)', () => {
         const value = `
           <?xml version="1.0" encoding="UTF-8"?>
           <rss version="2.0">
@@ -2100,7 +2120,7 @@ describe('parse', () => {
         expect(parse(value)).toEqual(expected)
       })
 
-      it('RW-Q09: should parse RFC 2822 author email format into structured person', () => {
+      it('should parse RFC 2822 author email format into structured person (RW-Q09)', () => {
         const value = `
           <?xml version="1.0" encoding="UTF-8"?>
           <rss version="2.0">
@@ -2132,7 +2152,7 @@ describe('parse', () => {
     })
 
     describe('malformed XML resilience', () => {
-      it('RW-E10: should handle BOM at start of XML', () => {
+      it('should handle BOM at start of XML (RW-E10)', () => {
         const value = `\uFEFF<?xml version="1.0" encoding="UTF-8"?>
           <rss version="2.0">
             <channel>
@@ -2151,7 +2171,7 @@ describe('parse', () => {
         expect(parse(value)).toEqual(expected)
       })
 
-      it('RW-E12: should handle unescaped ampersand in title', () => {
+      it('should handle unescaped ampersand in title (RW-E12)', () => {
         const value = `
           <?xml version="1.0" encoding="UTF-8"?>
           <rss version="2.0">
@@ -2171,7 +2191,7 @@ describe('parse', () => {
         expect(parse(value)).toEqual(expected)
       })
 
-      it('RW-E12: should handle unescaped ampersand in item description', () => {
+      it('should handle unescaped ampersand in item description (RW-E12)', () => {
         const value = `
           <?xml version="1.0" encoding="UTF-8"?>
           <rss version="2.0">
@@ -2201,7 +2221,7 @@ describe('parse', () => {
         expect(parse(value)).toEqual(expected)
       })
 
-      it('RW-E06: should handle HTML entity &nbsp; in text', () => {
+      it('should handle HTML entity &nbsp; in text (RW-E06)', () => {
         const value = `
           <?xml version="1.0" encoding="UTF-8"?>
           <rss version="2.0">
@@ -2225,7 +2245,7 @@ describe('parse', () => {
         expect(parse(value)).toEqual(expected)
       })
 
-      it('RW-E07: should handle &copy; entity in text', () => {
+      it('should handle &copy; entity in text (RW-E07)', () => {
         const value = `
           <?xml version="1.0" encoding="UTF-8"?>
           <rss version="2.0">
@@ -2249,18 +2269,19 @@ describe('parse', () => {
         expect(parse(value)).toEqual(expected)
       })
 
-      it('RW-X01: should throw on truncated XML', () => {
+      it('should throw on truncated XML (RW-X01)', () => {
         const value = `
           <?xml version="1.0" encoding="UTF-8"?>
           <rss version="2.0">
             <channel>
               <title>Incomplete
         `
+        const throwing = () => parse(value)
 
-        expect(() => parse(value)).toThrow()
+        expect(throwing).toThrowError(MalformedError)
       })
 
-      it('RW-E17: should throw on unescaped less-than in title', () => {
+      it('should throw on unescaped less-than in title (RW-E17)', () => {
         const value = `
           <?xml version="1.0" encoding="UTF-8"?>
           <rss version="2.0">
@@ -2274,11 +2295,12 @@ describe('parse', () => {
             </channel>
           </rss>
         `
+        const throwing = () => parse(value)
 
-        expect(() => parse(value)).toThrow()
+        expect(throwing).toThrowError(MalformedError)
       })
 
-      it('RW-E11: should handle control character U+0008 in content', () => {
+      it('should handle control character U+0008 in content (RW-E11)', () => {
         const value = `
           <?xml version="1.0" encoding="UTF-8"?>
           <rss version="2.0">
@@ -2302,7 +2324,7 @@ describe('parse', () => {
         expect(parse(value)).toEqual(expected)
       })
 
-      it('RW-X04: should parse feed with DOCTYPE declaration', () => {
+      it('should parse feed with DOCTYPE declaration (RW-X04)', () => {
         const value = `
           <?xml version="1.0" encoding="UTF-8"?>
           <!DOCTYPE rss SYSTEM "https://example.com/rss.dtd">
@@ -2327,7 +2349,7 @@ describe('parse', () => {
         expect(parse(value)).toEqual(expected)
       })
 
-      it('RW-X08: should strip XML comments from element content', () => {
+      it('should strip XML comments from element content (RW-X08)', () => {
         const value = `
           <?xml version="1.0" encoding="UTF-8"?>
           <rss version="2.0">
@@ -2351,7 +2373,7 @@ describe('parse', () => {
         expect(parse(value)).toEqual(expected)
       })
 
-      it('RW-X10: should use first channel when multiple channel elements exist', () => {
+      it('should use first channel when multiple channel elements exist (RW-X10)', () => {
         const value = `
           <?xml version="1.0" encoding="UTF-8"?>
           <rss version="2.0">
@@ -2380,7 +2402,7 @@ describe('parse', () => {
         expect(parse(value)).toEqual(expected)
       })
 
-      it('RW-X11: should parse items placed outside channel element', () => {
+      it('should parse items placed outside channel element (RW-X11)', () => {
         const value = `
           <?xml version="1.0" encoding="UTF-8"?>
           <rss version="2.0">
@@ -2410,7 +2432,7 @@ describe('parse', () => {
         expect(parse(value)).toEqual(expected)
       })
 
-      it('RW-X12: should drop unquoted attribute values (fast-xml-parser limitation)', () => {
+      it('should drop unquoted attribute values (fast-xml-parser limitation) (RW-X12)', () => {
         const value = `
           <?xml version="1.0" encoding="UTF-8"?>
           <rss version="2.0">
@@ -2447,7 +2469,7 @@ describe('parse', () => {
     })
 
     describe('stop node edge cases', () => {
-      it('RW-D04: should preserve HTML tags in title as text', () => {
+      it('should preserve HTML tags in title as text (RW-D04)', () => {
         const value = `
           <?xml version="1.0" encoding="UTF-8"?>
           <rss version="2.0">
@@ -2471,7 +2493,7 @@ describe('parse', () => {
         expect(parse(value)).toEqual(expected)
       })
 
-      it('RW-C04: should handle CDATA with code containing angle brackets', () => {
+      it('should handle CDATA with code containing angle brackets (RW-C04)', () => {
         const value = `
           <?xml version="1.0" encoding="UTF-8"?>
           <rss version="2.0" xmlns:content="http://purl.org/rss/1.0/modules/content/">
@@ -2503,7 +2525,7 @@ describe('parse', () => {
         expect(parse(value)).toEqual(expected)
       })
 
-      it('RW-D04: should handle description with escaped HTML link', () => {
+      it('should handle description with escaped HTML link (RW-D04)', () => {
         const value = `
           <?xml version="1.0" encoding="UTF-8"?>
           <rss version="2.0">
@@ -2535,7 +2557,7 @@ describe('parse', () => {
     })
 
     describe('partial attributes', () => {
-      it('RW-A04: should handle enclosure with missing url attribute', () => {
+      it('should handle enclosure with missing url attribute (RW-A04)', () => {
         const value = `
           <?xml version="1.0" encoding="UTF-8"?>
           <rss version="2.0">
@@ -2565,7 +2587,7 @@ describe('parse', () => {
         expect(parse(value)).toEqual(expected)
       })
 
-      it('RW-A05: should drop enclosure with no attributes', () => {
+      it('should drop enclosure with no attributes (RW-A05)', () => {
         const value = `
           <?xml version="1.0" encoding="UTF-8"?>
           <rss version="2.0">
@@ -2590,7 +2612,7 @@ describe('parse', () => {
         expect(parse(value)).toEqual(expected)
       })
 
-      it('RW-N02: should parse item with only guid', () => {
+      it('should parse item with only guid (RW-N02)', () => {
         const value = `
           <?xml version="1.0" encoding="UTF-8"?>
           <rss version="2.0">
@@ -2618,7 +2640,7 @@ describe('parse', () => {
         expect(parse(value)).toEqual(expected)
       })
 
-      it('RW-T01: should handle invalid date strings as plain strings', () => {
+      it('should handle invalid date strings as plain strings (RW-T01)', () => {
         const value = `
           <?xml version="1.0" encoding="UTF-8"?>
           <rss version="2.0">
@@ -2648,7 +2670,7 @@ describe('parse', () => {
         expect(parse(value)).toEqual(expected)
       })
 
-      it('RW-A06: should handle large enclosure length values', () => {
+      it('should handle large enclosure length values (RW-A06)', () => {
         const value = `
           <?xml version="1.0" encoding="UTF-8"?>
           <rss version="2.0">
@@ -2680,7 +2702,7 @@ describe('parse', () => {
         expect(parse(value)).toEqual(expected)
       })
 
-      it('RW-NS07: should parse nested iTunes categories', () => {
+      it('should parse nested iTunes categories (RW-NS07)', () => {
         const value = `
           <?xml version="1.0" encoding="UTF-8"?>
           <rss version="2.0" xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd">
@@ -2714,7 +2736,7 @@ describe('parse', () => {
         expect(parse(value)).toEqual(expected)
       })
 
-      it('RW-C13: should unwrap CDATA-wrapped pubDate', () => {
+      it('should unwrap CDATA-wrapped pubDate (RW-C13)', () => {
         const value = `
           <?xml version="1.0" encoding="UTF-8"?>
           <rss version="2.0">
@@ -2744,7 +2766,7 @@ describe('parse', () => {
         expect(parse(value)).toEqual(expected)
       })
 
-      it('RW-C14: should omit empty content:encoded and keep description', () => {
+      it('should omit empty content:encoded and keep description (RW-C14)', () => {
         const value = `
           <?xml version="1.0" encoding="UTF-8"?>
           <rss version="2.0" xmlns:content="http://purl.org/rss/1.0/modules/content/">
@@ -2775,7 +2797,7 @@ describe('parse', () => {
         expect(parse(value)).toEqual(expected)
       })
 
-      it('RW-L14: should parse guid with isPermaLink true and no link element', () => {
+      it('should parse guid with isPermaLink true and no link element (RW-L14)', () => {
         const value = `
           <?xml version="1.0" encoding="UTF-8"?>
           <rss version="2.0">
@@ -2805,7 +2827,7 @@ describe('parse', () => {
         expect(parse(value)).toEqual(expected)
       })
 
-      it('RW-A13: should store non-MIME enclosure type as-is', () => {
+      it('should store non-MIME enclosure type as-is (RW-A13)', () => {
         const value = `
           <?xml version="1.0" encoding="UTF-8"?>
           <rss version="2.0">
@@ -2841,7 +2863,7 @@ describe('parse', () => {
         expect(parse(value)).toEqual(expected)
       })
 
-      it('RW-NS14: should parse dc:date in RSS 2.0', () => {
+      it('should parse dc:date in RSS 2.0 (RW-NS14)', () => {
         const value = `
           <?xml version="1.0" encoding="UTF-8"?>
           <rss version="2.0" xmlns:dc="http://purl.org/dc/elements/1.1/">
@@ -2873,7 +2895,7 @@ describe('parse', () => {
         expect(parse(value)).toEqual(expected)
       })
 
-      it('RW-NS15: should parse media:content with nested child elements', () => {
+      it('should parse media:content with nested child elements (RW-NS15)', () => {
         const value = `
           <?xml version="1.0" encoding="UTF-8"?>
           <rss version="2.0" xmlns:media="http://search.yahoo.com/mrss/">
@@ -2914,7 +2936,7 @@ describe('parse', () => {
         expect(parse(value)).toEqual(expected)
       })
 
-      it('RW-NS16: should parse both media:content and media:thumbnail', () => {
+      it('should parse both media:content and media:thumbnail (RW-NS16)', () => {
         const value = `
           <?xml version="1.0" encoding="UTF-8"?>
           <rss version="2.0" xmlns:media="http://search.yahoo.com/mrss/">
@@ -2959,7 +2981,7 @@ describe('parse', () => {
         expect(parse(value)).toEqual(expected)
       })
 
-      it('RW-NS17: should parse itunes:duration with MM:SS format', () => {
+      it('should parse itunes:duration with MM:SS format (RW-NS17)', () => {
         const value = `
           <?xml version="1.0" encoding="UTF-8"?>
           <rss version="2.0" xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd">
@@ -2974,12 +2996,24 @@ describe('parse', () => {
             </channel>
           </rss>
         `
-        const result = parse(value)
+        const expected = {
+          title: 'My Podcast',
+          link: 'https://example.com',
+          description: 'A podcast',
+          items: [
+            {
+              title: 'Episode 1',
+              itunes: {
+                duration: 199,
+              },
+            },
+          ],
+        }
 
-        expect(result.items?.[0]?.itunes?.duration).toBe(199)
+        expect(parse(value)).toEqual(expected)
       })
 
-      it('RW-NS18: should handle HTTPS variant of DC namespace URI', () => {
+      it('should handle HTTPS variant of DC namespace URI (RW-NS18)', () => {
         const value = `
           <?xml version="1.0" encoding="UTF-8"?>
           <rss version="2.0" xmlns:dc="https://purl.org/dc/elements/1.1/">
@@ -3011,7 +3045,7 @@ describe('parse', () => {
         expect(parse(value)).toEqual(expected)
       })
 
-      it('RW-NS19: should parse atom:link declared inline on channel element', () => {
+      it('should parse atom:link declared inline on channel element (RW-NS19)', () => {
         const value = `
           <?xml version="1.0" encoding="UTF-8"?>
           <rss version="2.0">
@@ -3041,7 +3075,7 @@ describe('parse', () => {
         expect(parse(value)).toEqual(expected)
       })
 
-      it('RW-X13: should decode numeric character reference &#39; in description', () => {
+      it('should decode numeric character reference &#39; in description (RW-X13)', () => {
         const value = `
           <?xml version="1.0" encoding="UTF-8"?>
           <rss version="2.0">
@@ -3071,7 +3105,7 @@ describe('parse', () => {
         expect(parse(value)).toEqual(expected)
       })
 
-      it('RW-X14: should omit self-closing empty link element', () => {
+      it('should omit self-closing empty link element (RW-X14)', () => {
         const value = `
           <?xml version="1.0" encoding="UTF-8"?>
           <rss version="2.0">
@@ -3096,7 +3130,7 @@ describe('parse', () => {
         expect(parse(value)).toEqual(expected)
       })
 
-      it('RW-X17: should handle leading whitespace before XML declaration', () => {
+      it('should handle leading whitespace before XML declaration (RW-X17)', () => {
         const value = `
           <?xml version="1.0" encoding="UTF-8"?>
           <rss version="2.0">
@@ -3120,8 +3154,9 @@ describe('parse', () => {
         expect(parse(value)).toEqual(expected)
       })
 
-      it('RW-X18: should ignore xml-stylesheet processing instruction', () => {
-        const value = `<?xml version="1.0" encoding="UTF-8"?><?xml-stylesheet type="text/xsl" href="style.xsl"?>
+      it('should ignore xml-stylesheet processing instruction (RW-X18)', () => {
+        const value = `
+          <?xml version="1.0" encoding="UTF-8"?><?xml-stylesheet type="text/xsl" href="style.xsl"?>
           <rss version="2.0">
             <channel>
               <title>Test</title>
@@ -3143,7 +3178,7 @@ describe('parse', () => {
         expect(parse(value)).toEqual(expected)
       })
 
-      it('RW-X19: should preserve raw XML inside stop node pubDate', () => {
+      it('should preserve raw XML inside stop node pubDate (RW-X19)', () => {
         const value = `
           <?xml version="1.0" encoding="UTF-8"?>
           <rss version="2.0">
@@ -3173,7 +3208,7 @@ describe('parse', () => {
         expect(parse(value)).toEqual(expected)
       })
 
-      it('RW-X20: should scope image child elements without polluting channel', () => {
+      it('should scope image child elements without polluting channel (RW-X20)', () => {
         const value = `
           <?xml version="1.0" encoding="UTF-8"?>
           <rss version="2.0">
@@ -3207,7 +3242,7 @@ describe('parse', () => {
         expect(parse(value)).toEqual(expected)
       })
 
-      it('RW-X21: should scope textInput child elements without polluting channel', () => {
+      it('should scope textInput child elements without polluting channel (RW-X21)', () => {
         const value = `
           <?xml version="1.0" encoding="UTF-8"?>
           <rss version="2.0">
@@ -3243,7 +3278,7 @@ describe('parse', () => {
         expect(parse(value)).toEqual(expected)
       })
 
-      it('RW-Q11: should preserve both author and dc:creator', () => {
+      it('should preserve both author and dc:creator (RW-Q11)', () => {
         const value = `
           <?xml version="1.0" encoding="UTF-8"?>
           <rss version="2.0" xmlns:dc="http://purl.org/dc/elements/1.1/">
@@ -3277,7 +3312,7 @@ describe('parse', () => {
         expect(parse(value)).toEqual(expected)
       })
 
-      it('RW-Q12: should collect multiple dc:creator elements', () => {
+      it('should collect multiple dc:creator elements (RW-Q12)', () => {
         const value = `
           <?xml version="1.0" encoding="UTF-8"?>
           <rss version="2.0" xmlns:dc="http://purl.org/dc/elements/1.1/">
@@ -3310,7 +3345,7 @@ describe('parse', () => {
         expect(parse(value)).toEqual(expected)
       })
 
-      it('RW-Q13: should treat itunes:explicit "1" as false', () => {
+      it('should treat itunes:explicit "1" as false (RW-Q13)', () => {
         const value = `
           <?xml version="1.0" encoding="UTF-8"?>
           <rss version="2.0" xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd">
@@ -3335,7 +3370,7 @@ describe('parse', () => {
         expect(parse(value)).toEqual(expected)
       })
 
-      it('RW-Q14: should parse itunes:duration with fractional seconds', () => {
+      it('should parse itunes:duration with fractional seconds (RW-Q14)', () => {
         const value = `
           <?xml version="1.0" encoding="UTF-8"?>
           <rss version="2.0" xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd">
@@ -3360,7 +3395,7 @@ describe('parse', () => {
         expect(parse(value)).toEqual(expected)
       })
 
-      it('RW-Q15: should parse itunes:image as text content without @href', () => {
+      it('should parse itunes:image as text content without @href (RW-Q15)', () => {
         const value = `
           <?xml version="1.0" encoding="UTF-8"?>
           <rss version="2.0" xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd">
@@ -3387,7 +3422,7 @@ describe('parse', () => {
     })
 
     describe('unicode and special characters', () => {
-      it('RW-E18: should preserve BiDi control characters in category text', () => {
+      it('should preserve BiDi control characters in category text (RW-E18)', () => {
         const value = `
           <?xml version="1.0" encoding="UTF-8"?>
           <rss version="2.0">
@@ -3414,7 +3449,7 @@ describe('parse', () => {
     })
 
     describe('description and content interaction', () => {
-      it('RW-D18: should parse both description and content:encoded regardless of order', () => {
+      it('should parse both description and content:encoded regardless of order (RW-D18)', () => {
         const value = `
           <?xml version="1.0" encoding="UTF-8"?>
           <rss version="2.0" xmlns:content="http://purl.org/rss/1.0/modules/content/">
@@ -3456,7 +3491,7 @@ describe('parse', () => {
         expect(parse(value)).toEqual(expected)
       })
 
-      it('RW-D23: should preserve bare HTML children inside description stop node', () => {
+      it('should preserve bare HTML children inside description stop node (RW-D23)', () => {
         const value = `
           <?xml version="1.0" encoding="UTF-8"?>
           <rss version="2.0">
@@ -3483,7 +3518,7 @@ describe('parse', () => {
     })
 
     describe('link edge cases', () => {
-      it('RW-L17: should parse text link separately from atom:link', () => {
+      it('should parse text link separately from atom:link (RW-L17)', () => {
         const value = `
           <?xml version="1.0" encoding="UTF-8"?>
           <rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
@@ -3509,7 +3544,7 @@ describe('parse', () => {
     })
 
     describe('dc namespace edge cases', () => {
-      it('RW-M09: should collect multiple dc:creator elements in order', () => {
+      it('should collect multiple dc:creator elements in order (RW-M09)', () => {
         const value = `
           <?xml version="1.0" encoding="UTF-8"?>
           <rss version="2.0" xmlns:dc="http://purl.org/dc/elements/1.1/">
@@ -3541,7 +3576,7 @@ describe('parse', () => {
         expect(parse(value)).toEqual(expected)
       })
 
-      it('RW-NS24: should ignore empty dc:title and keep core title', () => {
+      it('should ignore empty dc:title and keep core title (RW-NS24)', () => {
         const value = `
           <?xml version="1.0" encoding="UTF-8"?>
           <rss version="2.0" xmlns:dc="http://purl.org/dc/elements/1.1/">
@@ -3568,7 +3603,7 @@ describe('parse', () => {
     })
 
     describe('duplicate element handling', () => {
-      it('RW-M11: should use first guid when multiple guid elements exist', () => {
+      it('should use first guid when multiple guid elements exist (RW-M11)', () => {
         const value = `
           <?xml version="1.0" encoding="UTF-8"?>
           <rss version="2.0">
@@ -3596,7 +3631,7 @@ describe('parse', () => {
     })
 
     describe('image edge cases', () => {
-      it('RW-N22: should parse channel image with only url', () => {
+      it('should parse channel image with only url (RW-N22)', () => {
         const value = `
           <?xml version="1.0" encoding="UTF-8"?>
           <rss version="2.0">
@@ -3620,7 +3655,7 @@ describe('parse', () => {
         expect(parse(value)).toEqual(expected)
       })
 
-      it('RW-Q16: should not parse image element at item level', () => {
+      it('should not parse image element at item level (RW-Q16)', () => {
         const value = `
           <?xml version="1.0" encoding="UTF-8"?>
           <rss version="2.0">
@@ -3647,7 +3682,7 @@ describe('parse', () => {
     })
 
     describe('enclosure edge cases', () => {
-      it('RW-A14: should omit length for empty string enclosure length', () => {
+      it('should omit length for empty string enclosure length (RW-A14)', () => {
         const value = `
           <?xml version="1.0" encoding="UTF-8"?>
           <rss version="2.0">
@@ -3677,7 +3712,7 @@ describe('parse', () => {
         expect(parse(value)).toEqual(expected)
       })
 
-      it('RW-A14: should omit length for non-numeric enclosure length', () => {
+      it('should omit length for non-numeric enclosure length (RW-A14)', () => {
         const value = `
           <?xml version="1.0" encoding="UTF-8"?>
           <rss version="2.0">
@@ -3707,7 +3742,7 @@ describe('parse', () => {
         expect(parse(value)).toEqual(expected)
       })
 
-      it('RW-A15: should parse float enclosure length as number', () => {
+      it('should parse float enclosure length as number (RW-A15)', () => {
         const value = `
           <?xml version="1.0" encoding="UTF-8"?>
           <rss version="2.0">
@@ -3739,7 +3774,7 @@ describe('parse', () => {
         expect(parse(value)).toEqual(expected)
       })
 
-      it('RW-A19: should ignore enclosure text content without attributes', () => {
+      it('should ignore enclosure text content without attributes (RW-A19)', () => {
         const value = `
           <?xml version="1.0" encoding="UTF-8"?>
           <rss version="2.0">
@@ -3764,7 +3799,7 @@ describe('parse', () => {
         expect(parse(value)).toEqual(expected)
       })
 
-      it('RW-A20: should preserve MIME type with parameters in enclosure', () => {
+      it('should preserve MIME type with parameters in enclosure (RW-A20)', () => {
         const value = `
           <?xml version="1.0" encoding="UTF-8"?>
           <rss version="2.0">
@@ -3779,16 +3814,26 @@ describe('parse', () => {
             </channel>
           </rss>
         `
-        const result = parse(value)
+        const expected = {
+          title: 'Test',
+          link: 'https://example.com',
+          description: 'Test',
+          items: [
+            {
+              title: 'Post',
+              enclosures: [
+                { url: 'https://example.com/page', length: 5000, type: 'text/html; charset=utf-8' },
+              ],
+            },
+          ],
+        }
 
-        expect(result.items?.[0]?.enclosures).toEqual([
-          { url: 'https://example.com/page', length: 5000, type: 'text/html; charset=utf-8' },
-        ])
+        expect(parse(value)).toEqual(expected)
       })
     })
 
     describe('guid edge cases', () => {
-      it('RW-A16: should parse guid without isPermaLink attribute', () => {
+      it('should parse guid without isPermaLink attribute (RW-A16)', () => {
         const value = `
           <?xml version="1.0" encoding="UTF-8"?>
           <rss version="2.0">
@@ -3803,15 +3848,24 @@ describe('parse', () => {
             </channel>
           </rss>
         `
-        const result = parse(value)
+        const expected = {
+          title: 'Test',
+          link: 'https://example.com',
+          description: 'Test',
+          items: [
+            {
+              title: 'Post',
+              guid: { value: 'internal-id-12345' },
+            },
+          ],
+        }
 
-        expect(result.items?.[0]?.guid).toEqual({ value: 'internal-id-12345' })
-        expect(result.items?.[0]?.guid?.isPermaLink).toBeUndefined()
+        expect(parse(value)).toEqual(expected)
       })
     })
 
     describe('source element', () => {
-      it('RW-A17: should parse source with url attribute and text', () => {
+      it('should parse source with url attribute and text (RW-A17)', () => {
         const value = `
           <?xml version="1.0" encoding="UTF-8"?>
           <rss version="2.0">
@@ -3826,17 +3880,27 @@ describe('parse', () => {
             </channel>
           </rss>
         `
-        const result = parse(value)
+        const expected = {
+          title: 'Test',
+          link: 'https://example.com',
+          description: 'Test',
+          items: [
+            {
+              title: 'Post',
+              source: {
+                title: 'Source Name',
+                url: 'https://example.com/feed',
+              },
+            },
+          ],
+        }
 
-        expect(result.items?.[0]?.source).toEqual({
-          title: 'Source Name',
-          url: 'https://example.com/feed',
-        })
+        expect(parse(value)).toEqual(expected)
       })
     })
 
     describe('author edge cases', () => {
-      it('RW-A18: should parse plain author name string', () => {
+      it('should parse plain author name string (RW-A18)', () => {
         const value = `
           <?xml version="1.0" encoding="UTF-8"?>
           <rss version="2.0">
@@ -3851,9 +3915,19 @@ describe('parse', () => {
             </channel>
           </rss>
         `
-        const result = parse(value)
+        const expected = {
+          title: 'Test',
+          link: 'https://example.com',
+          description: 'Test',
+          items: [
+            {
+              title: 'Post',
+              authors: [{ name: 'John Doe' }],
+            },
+          ],
+        }
 
-        expect(result.items?.[0]?.authors).toEqual([{ name: 'John Doe' }])
+        expect(parse(value)).toEqual(expected)
       })
     })
 
@@ -3870,9 +3944,14 @@ describe('parse', () => {
             </channel>
           </rss>
         `
-        const result = parse(value)
+        const expected = {
+          title: 'Test',
+          link: 'https://example.com',
+          description: 'Test',
+          managingEditor: { email: 'editor@example.com', name: 'Editor Name' },
+        }
 
-        expect(result.managingEditor).toEqual({ email: 'editor@example.com', name: 'Editor Name' })
+        expect(parse(value)).toEqual(expected)
       })
 
       it('should parse webMaster in RFC 2822 format', () => {
@@ -3887,9 +3966,14 @@ describe('parse', () => {
             </channel>
           </rss>
         `
-        const result = parse(value)
+        const expected = {
+          title: 'Test',
+          link: 'https://example.com',
+          description: 'Test',
+          webMaster: { email: 'webmaster@example.com', name: 'Webmaster' },
+        }
 
-        expect(result.webMaster).toEqual({ email: 'webmaster@example.com', name: 'Webmaster' })
+        expect(parse(value)).toEqual(expected)
       })
 
       it('should parse managingEditor with email only', () => {
@@ -3904,14 +3988,19 @@ describe('parse', () => {
             </channel>
           </rss>
         `
-        const result = parse(value)
+        const expected = {
+          title: 'Test',
+          link: 'https://example.com',
+          description: 'Test',
+          managingEditor: { email: 'editor@example.com' },
+        }
 
-        expect(result.managingEditor).toEqual({ email: 'editor@example.com' })
+        expect(parse(value)).toEqual(expected)
       })
     })
 
     describe('foreign namespace on core elements', () => {
-      it('RW-NS25: should handle default namespace override on link element', () => {
+      it('should handle default namespace override on link element (RW-NS25)', () => {
         const value = `
           <?xml version="1.0" encoding="UTF-8"?>
           <rss version="2.0">
@@ -3922,14 +4011,18 @@ describe('parse', () => {
             </channel>
           </rss>
         `
-        const result = parse(value)
+        const expected = {
+          title: 'Test',
+          link: 'https://example.com',
+          description: 'Test',
+        }
 
-        expect(result.link).toBe('https://example.com')
+        expect(parse(value)).toEqual(expected)
       })
     })
 
     describe('atom namespace in RSS items', () => {
-      it('RW-NS26: should parse atom:author inside RSS item', () => {
+      it('should parse atom:author inside RSS item (RW-NS26)', () => {
         const value = `
           <?xml version="1.0" encoding="UTF-8"?>
           <rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
@@ -3946,14 +4039,26 @@ describe('parse', () => {
             </channel>
           </rss>
         `
-        const result = parse(value)
+        const expected = {
+          title: 'Test',
+          link: 'https://example.com',
+          description: 'Test',
+          items: [
+            {
+              title: 'Post',
+              atom: {
+                authors: [{ name: 'John Doe' }],
+              },
+            },
+          ],
+        }
 
-        expect(result.items?.[0]?.atom?.authors).toEqual([{ name: 'John Doe' }])
+        expect(parse(value)).toEqual(expected)
       })
     })
 
     describe('sy namespace edge cases', () => {
-      it('RW-NS27: should preserve bad date string in sy:updateBase', () => {
+      it('should preserve bad date string in sy:updateBase (RW-NS27)', () => {
         const value = `
           <?xml version="1.0" encoding="UTF-8"?>
           <rss version="2.0" xmlns:sy="http://purl.org/rss/1.0/modules/syndication/">
@@ -3965,14 +4070,21 @@ describe('parse', () => {
             </channel>
           </rss>
         `
-        const result = parse(value)
+        const expected = {
+          title: 'Test',
+          link: 'https://example.com',
+          description: 'Test',
+          sy: {
+            updateBase: 'not-a-date',
+          },
+        }
 
-        expect(result.sy?.updateBase).toBe('not-a-date')
+        expect(parse(value)).toEqual(expected)
       })
     })
 
     describe('namespace scoping', () => {
-      it('RW-NS28: should not leak dc:identifier nested inside media:content to item level', () => {
+      it('should not leak dc:identifier nested inside media:content to item level (RW-NS28)', () => {
         const value = `
           <?xml version="1.0" encoding="UTF-8"?>
           <rss version="2.0"
@@ -3991,15 +4103,26 @@ describe('parse', () => {
             </channel>
           </rss>
         `
-        const result = parse(value)
+        const expected = {
+          title: 'Test',
+          link: 'https://example.com',
+          description: 'Test',
+          items: [
+            {
+              title: 'Post',
+              media: {
+                contents: [{ url: 'https://example.com/video.mp4' }],
+              },
+            },
+          ],
+        }
 
-        expect(result.items?.[0]?.media?.contents?.[0]?.url).toBe('https://example.com/video.mp4')
-        expect(result.items?.[0]?.dc?.identifiers).toBeUndefined()
+        expect(parse(value)).toEqual(expected)
       })
     })
 
     describe('itunes and core field independence', () => {
-      it('RW-NS29: should parse itunes:summary and description independently', () => {
+      it('should parse itunes:summary and description independently (RW-NS29)', () => {
         const value = `
           <?xml version="1.0" encoding="UTF-8"?>
           <rss version="2.0" xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd">
@@ -4015,15 +4138,27 @@ describe('parse', () => {
             </channel>
           </rss>
         `
-        const result = parse(value)
+        const expected = {
+          title: 'My Podcast',
+          link: 'https://example.com',
+          description: 'A podcast',
+          items: [
+            {
+              title: 'Episode 1',
+              description: 'Real description',
+              itunes: {
+                summary: 'iTunes summary',
+              },
+            },
+          ],
+        }
 
-        expect(result.items?.[0]?.description).toBe('Real description')
-        expect(result.items?.[0]?.itunes?.summary).toBe('iTunes summary')
+        expect(parse(value)).toEqual(expected)
       })
     })
 
     describe('concatenated and malformed XML', () => {
-      it('RW-X22: should parse only first document from concatenated RSS documents', () => {
+      it('should parse only first document from concatenated RSS documents (RW-X22)', () => {
         const value = `
           <?xml version="1.0" encoding="UTF-8"?>
           <rss version="2.0">
@@ -4051,7 +4186,7 @@ describe('parse', () => {
         expect(parse(value)).toEqual(expected)
       })
 
-      it('RW-X23: should parse adjacent elements without whitespace', () => {
+      it('should parse adjacent elements without whitespace (RW-X23)', () => {
         const value = `
           <?xml version="1.0" encoding="UTF-8"?>
           <rss version="2.0"
@@ -4068,15 +4203,29 @@ describe('parse', () => {
             </channel>
           </rss>
         `
-        const result = parse(value)
+        const expected = {
+          title: 'Test',
+          link: 'https://example.com',
+          description: 'Test',
+          items: [
+            {
+              title: 'Post',
+              content: {
+                encoded: 'Article text',
+              },
+              media: {
+                contents: [{ url: 'https://example.com/img.jpg' }],
+              },
+            },
+          ],
+        }
 
-        expect(result.items?.[0]?.media?.contents?.[0]?.url).toBe('https://example.com/img.jpg')
-        expect(result.items?.[0]?.content?.encoded).toBe('Article text')
+        expect(parse(value)).toEqual(expected)
       })
     })
 
     describe('non-standard RSS version', () => {
-      it('RW-X24: should parse RSS with version 0.91', () => {
+      it('should parse RSS with version 0.91 (RW-X24)', () => {
         const value = `
           <?xml version="1.0" encoding="UTF-8"?>
           <rss version="0.91">
@@ -4102,7 +4251,7 @@ describe('parse', () => {
     })
 
     describe('itunes:explicit values', () => {
-      it('RW-Q17: should treat itunes:explicit "no" as false', () => {
+      it('should treat itunes:explicit "no" as false (RW-Q17)', () => {
         const value = `
           <?xml version="1.0" encoding="UTF-8"?>
           <rss version="2.0" xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd">
@@ -4117,14 +4266,26 @@ describe('parse', () => {
             </channel>
           </rss>
         `
-        const result = parse(value)
+        const expected = {
+          title: 'My Podcast',
+          link: 'https://example.com',
+          description: 'A podcast',
+          items: [
+            {
+              title: 'Episode 1',
+              itunes: {
+                explicit: false,
+              },
+            },
+          ],
+        }
 
-        expect(result.items?.[0]?.itunes?.explicit).toBe(false)
+        expect(parse(value)).toEqual(expected)
       })
     })
 
     describe('category edge cases', () => {
-      it('RW-Q18: should parse category with domain but empty text', () => {
+      it('should parse category with domain but empty text (RW-Q18)', () => {
         const value = `
           <?xml version="1.0" encoding="UTF-8"?>
           <rss version="2.0">
@@ -4139,9 +4300,19 @@ describe('parse', () => {
             </channel>
           </rss>
         `
-        const result = parse(value)
+        const expected = {
+          title: 'Test',
+          link: 'https://example.com',
+          description: 'Test',
+          items: [
+            {
+              title: 'Post',
+              categories: [{ domain: 'dmoz' }],
+            },
+          ],
+        }
 
-        expect(result.items?.[0]?.categories).toEqual([{ domain: 'dmoz' }])
+        expect(parse(value)).toEqual(expected)
       })
     })
   })
@@ -4256,9 +4427,7 @@ describe('parse', () => {
           },
         ],
       }
-      const result = parse(value, { parseDateFn: (raw) => new Date(raw) })
-
-      expect(result).toEqual(expected)
+      expect(parse(value, { parseDateFn: (raw) => new Date(raw) })).toEqual(expected)
     })
 
     it('should apply custom parseDateFn to namespace dates', () => {
@@ -4285,9 +4454,7 @@ describe('parse', () => {
           },
         ],
       }
-      const result = parse(value, { parseDateFn: (raw) => new Date(raw) })
-
-      expect(result).toEqual(expected)
+      expect(parse(value, { parseDateFn: (raw) => new Date(raw) })).toEqual(expected)
     })
 
     it('should propagate error when parseDateFn throws', () => {
@@ -4305,7 +4472,7 @@ describe('parse', () => {
       }
       const throwing = () => parse(value, { parseDateFn })
 
-      expect(throwing).toThrow('Parse failed')
+      expect(throwing).toThrowError('Parse failed')
     })
 
     it('should apply custom parseDateFn to podcast namespace dates', () => {
@@ -4344,9 +4511,7 @@ describe('parse', () => {
           },
         },
       }
-      const result = parse(value, { parseDateFn: (raw) => new Date(raw) })
-
-      expect(result).toEqual(expected)
+      expect(parse(value, { parseDateFn: (raw) => new Date(raw) })).toEqual(expected)
     })
 
     it('should apply custom parseDateFn to sy namespace dates', () => {
@@ -4365,9 +4530,7 @@ describe('parse', () => {
           updateBase: new Date('2023-03-15T12:00:00Z'),
         },
       }
-      const result = parse(value, { parseDateFn: (raw) => new Date(raw) })
-
-      expect(result).toEqual(expected)
+      expect(parse(value, { parseDateFn: (raw) => new Date(raw) })).toEqual(expected)
     })
 
     it('should apply custom parseDateFn to prism namespace dates', () => {
@@ -4396,9 +4559,7 @@ describe('parse', () => {
           },
         ],
       }
-      const result = parse(value, { parseDateFn: (raw) => new Date(raw) })
-
-      expect(result).toEqual(expected)
+      expect(parse(value, { parseDateFn: (raw) => new Date(raw) })).toEqual(expected)
     })
 
     it('should apply custom parseDateFn to rawvoice namespace dates', () => {
@@ -4421,9 +4582,7 @@ describe('parse', () => {
           },
         },
       }
-      const result = parse(value, { parseDateFn: (raw) => new Date(raw) })
-
-      expect(result).toEqual(expected)
+      expect(parse(value, { parseDateFn: (raw) => new Date(raw) })).toEqual(expected)
     })
   })
 })

--- a/src/feeds/rss/parse/utils.test.ts
+++ b/src/feeds/rss/parse/utils.test.ts
@@ -182,15 +182,15 @@ describe('parsePerson', () => {
     })
 
     it('should parse URL containing @ (Mastodon)', () => {
-      const value = 'https://mastodon.social/@user'
-      const expected = { link: 'https://mastodon.social/@user' }
+      const value = 'https://example.com/@user'
+      const expected = { link: 'https://example.com/@user' }
 
       expect(parsePerson(value)).toEqual(expected)
     })
 
     it('should parse URL containing @ (Medium)', () => {
-      const value = 'https://medium.com/@author'
-      const expected = { link: 'https://medium.com/@author' }
+      const value = 'https://example.com/@author'
+      const expected = { link: 'https://example.com/@author' }
 
       expect(parsePerson(value)).toEqual(expected)
     })
@@ -345,10 +345,10 @@ describe('parsePerson', () => {
       })
 
       it('should parse URL containing @ in brackets', () => {
-        const value = 'John Doe (https://mastodon.social/@johndoe)'
+        const value = 'John Doe (https://example.com/@johndoe)'
         const expected = {
           name: 'John Doe',
-          link: 'https://mastodon.social/@johndoe',
+          link: 'https://example.com/@johndoe',
         }
 
         expect(parsePerson(value)).toEqual(expected)
@@ -501,20 +501,20 @@ describe('parsePerson', () => {
 
     describe('multiple values (first wins)', () => {
       it('should use first email when multiple emails present', () => {
-        const value = 'John (john1@x.com) (john2@x.com)'
+        const value = 'John (john1@example.com) (john2@example.com)'
         const expected = {
-          name: 'John (john2@x.com)',
-          email: 'john1@x.com',
+          name: 'John (john2@example.com)',
+          email: 'john1@example.com',
         }
 
         expect(parsePerson(value)).toEqual(expected)
       })
 
       it('should use first URL when multiple URLs present', () => {
-        const value = 'John (https://x.com/1) (https://x.com/2)'
+        const value = 'John (https://example.com/1) (https://example.com/2)'
         const expected = {
-          name: 'John (https://x.com/2)',
-          link: 'https://x.com/1',
+          name: 'John (https://example.com/2)',
+          link: 'https://example.com/1',
         }
 
         expect(parsePerson(value)).toEqual(expected)
@@ -698,10 +698,10 @@ describe('parsePerson', () => {
     })
 
     it('should extract URL containing @ after name', () => {
-      const value = 'John Doe https://mastodon.social/@johndoe'
+      const value = 'John Doe https://example.com/@johndoe'
       const expected = {
         name: 'John Doe',
-        link: 'https://mastodon.social/@johndoe',
+        link: 'https://example.com/@johndoe',
       }
 
       expect(parsePerson(value)).toEqual(expected)
@@ -1396,7 +1396,7 @@ describe('parseItem', () => {
     expect(parseItem(value)).toEqual(expectedFull)
   })
 
-  it('should parse complete item object (without array of values)', () => {
+  it('should parse complete item object (with arrays of values)', () => {
     const value = {
       title: ['Item Title', 'Alternative Item Title'],
       link: ['https://example.com/item', 'https://example.com/item-alternate'],
@@ -2265,7 +2265,7 @@ describe('parseFeed', () => {
         '@rdf:resource': 'mailto:webmaster@example.com',
       },
       'admin:generatoragent': {
-        '@rdf:resource': 'http://www.movabletype.org/?v=3.2',
+        '@rdf:resource': 'https://example.com/generator?v=3.2',
       },
     }
     const value = { channel }
@@ -2274,7 +2274,7 @@ describe('parseFeed', () => {
       link: 'https://example.com',
       admin: {
         errorReportsTo: 'mailto:webmaster@example.com',
-        generatorAgent: 'http://www.movabletype.org/?v=3.2',
+        generatorAgent: 'https://example.com/generator?v=3.2',
       },
     }
 
@@ -2458,6 +2458,29 @@ describe('retrieveItems', () => {
     const expected = [{ title: 'Channel Item' }]
 
     expect(retrieveItems(value)).toEqual(expected)
+  })
+
+  it('should limit items to maxItems when option is set', () => {
+    const value = {
+      channel: {
+        item: [{ title: 'Item 1' }, { title: 'Item 2' }, { title: 'Item 3' }],
+      },
+    }
+    const options = { maxItems: 2 }
+    const expected = [{ title: 'Item 1' }, { title: 'Item 2' }]
+
+    expect(retrieveItems(value, options)).toEqual(expected)
+  })
+
+  it('should return undefined when maxItems is 0', () => {
+    const value = {
+      channel: {
+        item: [{ title: 'Item 1' }],
+      },
+    }
+    const options = { maxItems: 0 }
+
+    expect(retrieveItems(value, options)).toBeUndefined()
   })
 
   it('should return undefined when no items exist', () => {

--- a/src/namespaces/acast/parse/utils.test.ts
+++ b/src/namespaces/acast/parse/utils.test.ts
@@ -188,7 +188,7 @@ describe('retrieveFeed', () => {
           '#text': 'Example Network',
         },
       ],
-      'acast:importedfeed': ['https://example.com/original-feed', 'https://other.feed.com'],
+      'acast:importedfeed': ['https://example.com/original-feed', 'https://other.example.com/feed'],
     }
 
     expect(retrieveFeed(value)).toEqual(expectedFull)

--- a/src/namespaces/app/parse/utils.test.ts
+++ b/src/namespaces/app/parse/utils.test.ts
@@ -45,6 +45,7 @@ describe('parseControl', () => {
     expect(parseControl(null)).toBeUndefined()
     expect(parseControl(undefined)).toBeUndefined()
     expect(parseControl('string')).toBeUndefined()
+    expect(parseControl(123)).toBeUndefined()
   })
 })
 
@@ -174,5 +175,10 @@ describe('retrieveEntry', () => {
     expect(retrieveEntry(undefined)).toBeUndefined()
     expect(retrieveEntry('string')).toBeUndefined()
     expect(retrieveEntry(123)).toBeUndefined()
+  })
+
+  it.todo('should parse edited date with custom parseDateFn', () => {
+    // Pass options.parseDateFn that maps the edited string to a Date instance.
+    // Expected: edited equals the value returned by the custom parser instead of the raw string.
   })
 })

--- a/src/namespaces/arxiv/generate/utils.test.ts
+++ b/src/namespaces/arxiv/generate/utils.test.ts
@@ -68,12 +68,12 @@ describe('generatePrimaryCategory', () => {
   })
 
   it('should handle non-object inputs', () => {
-    // @ts-expect-error: Testing invalid input
+    // @ts-expect-error: This is for testing purposes.
     expect(generatePrimaryCategory('string')).toBeUndefined()
-    // @ts-expect-error: Testing invalid input
+    // @ts-expect-error: This is for testing purposes.
     expect(generatePrimaryCategory(123)).toBeUndefined()
     expect(generatePrimaryCategory(undefined)).toBeUndefined()
-    // @ts-expect-error: Testing invalid input
+    // @ts-expect-error: This is for testing purposes.
     expect(generatePrimaryCategory(null)).toBeUndefined()
   })
 })
@@ -124,12 +124,12 @@ describe('generateAuthor', () => {
   })
 
   it('should handle non-object inputs', () => {
-    // @ts-expect-error: Testing invalid input
+    // @ts-expect-error: This is for testing purposes.
     expect(generateAuthor('string')).toBeUndefined()
-    // @ts-expect-error: Testing invalid input
+    // @ts-expect-error: This is for testing purposes.
     expect(generateAuthor(123)).toBeUndefined()
     expect(generateAuthor(undefined)).toBeUndefined()
-    // @ts-expect-error: Testing invalid input
+    // @ts-expect-error: This is for testing purposes.
     expect(generateAuthor(null)).toBeUndefined()
   })
 })
@@ -217,12 +217,12 @@ describe('generateEntry', () => {
   })
 
   it('should handle non-object inputs', () => {
-    // @ts-expect-error: Testing invalid input
+    // @ts-expect-error: This is for testing purposes.
     expect(generateEntry('string')).toBeUndefined()
-    // @ts-expect-error: Testing invalid input
+    // @ts-expect-error: This is for testing purposes.
     expect(generateEntry(123)).toBeUndefined()
     expect(generateEntry(undefined)).toBeUndefined()
-    // @ts-expect-error: Testing invalid input
+    // @ts-expect-error: This is for testing purposes.
     expect(generateEntry(null)).toBeUndefined()
   })
 

--- a/src/namespaces/atom/generate/utils.test.ts
+++ b/src/namespaces/atom/generate/utils.test.ts
@@ -38,12 +38,43 @@ describe('generateEntry', () => {
     expect(generateEntry(value)).toEqual(expected)
   })
 
+  it('should handle empty strings', () => {
+    const value = {
+      id: '',
+      title: { value: 'Entry Title' },
+    }
+    const expected = {
+      'atom:title': { '#text': 'Entry Title' },
+    }
+
+    expect(generateEntry(value)).toEqual(expected)
+  })
+
+  it('should handle whitespace-only strings', () => {
+    const value = {
+      id: '   ',
+    }
+
+    expect(generateEntry(value)).toBeUndefined()
+  })
+
   it('should handle empty object', () => {
     expect(generateEntry({})).toBeUndefined()
   })
 
   it('should handle undefined input', () => {
     expect(generateEntry(undefined)).toBeUndefined()
+  })
+
+  it('should handle non-object inputs', () => {
+    // @ts-expect-error: This is for testing purposes.
+    expect(generateEntry('string')).toBeUndefined()
+    // @ts-expect-error: This is for testing purposes.
+    expect(generateEntry(123)).toBeUndefined()
+    // @ts-expect-error: This is for testing purposes.
+    expect(generateEntry(null)).toBeUndefined()
+    // @ts-expect-error: This is for testing purposes.
+    expect(generateEntry([])).toBeUndefined()
   })
 })
 
@@ -83,11 +114,42 @@ describe('generateFeed', () => {
     expect(generateFeed(value)).toEqual(expected)
   })
 
+  it('should handle empty strings', () => {
+    const value = {
+      id: '',
+      title: { value: 'Feed Title' },
+    }
+    const expected = {
+      'atom:title': { '#text': 'Feed Title' },
+    }
+
+    expect(generateFeed(value)).toEqual(expected)
+  })
+
+  it('should handle whitespace-only strings', () => {
+    const value = {
+      id: '   ',
+    }
+
+    expect(generateFeed(value)).toBeUndefined()
+  })
+
   it('should handle empty object', () => {
     expect(generateFeed({})).toBeUndefined()
   })
 
   it('should handle undefined input', () => {
     expect(generateFeed(undefined)).toBeUndefined()
+  })
+
+  it('should handle non-object inputs', () => {
+    // @ts-expect-error: This is for testing purposes.
+    expect(generateFeed('string')).toBeUndefined()
+    // @ts-expect-error: This is for testing purposes.
+    expect(generateFeed(123)).toBeUndefined()
+    // @ts-expect-error: This is for testing purposes.
+    expect(generateFeed(null)).toBeUndefined()
+    // @ts-expect-error: This is for testing purposes.
+    expect(generateFeed([])).toBeUndefined()
   })
 })

--- a/src/namespaces/atom/parse/utils.test.ts
+++ b/src/namespaces/atom/parse/utils.test.ts
@@ -53,6 +53,56 @@ describe('retrieveEntry', () => {
 
     expect(retrieveEntry(value)).toBeUndefined()
   })
+
+  it('should handle empty strings', () => {
+    const value = {
+      'atom:id': '',
+      'atom:title': 'Entry Title',
+    }
+    const expected = {
+      title: { value: 'Entry Title' },
+    }
+
+    expect(retrieveEntry(value)).toEqual(expected)
+  })
+
+  it('should handle whitespace-only strings', () => {
+    const value = {
+      'atom:id': '   ',
+      'atom:title': '\t\n',
+    }
+
+    expect(retrieveEntry(value)).toBeUndefined()
+  })
+
+  it('should handle null and undefined properties', () => {
+    const value = {
+      'atom:id': null,
+      'atom:title': undefined,
+    }
+
+    expect(retrieveEntry(value)).toBeUndefined()
+  })
+
+  it('should return undefined for empty object', () => {
+    const value = {}
+
+    expect(retrieveEntry(value)).toBeUndefined()
+  })
+
+  it('should return undefined for non-object input', () => {
+    expect(retrieveEntry('string')).toBeUndefined()
+    expect(retrieveEntry(123)).toBeUndefined()
+    expect(retrieveEntry(true)).toBeUndefined()
+    expect(retrieveEntry(null)).toBeUndefined()
+    expect(retrieveEntry(undefined)).toBeUndefined()
+    expect(retrieveEntry([])).toBeUndefined()
+  })
+
+  it.todo('should parse updated date with custom parseDateFn', () => {
+    // Pass options.parseDateFn that maps the updated string to a Date instance.
+    // Expected: updated equals the value returned by the custom parser instead of the raw string.
+  })
 })
 
 describe('retrieveFeed', () => {
@@ -130,5 +180,55 @@ describe('retrieveFeed', () => {
     }
 
     expect(retrieveFeed(value)).toBeUndefined()
+  })
+
+  it('should handle empty strings', () => {
+    const value = {
+      'atom:id': '',
+      'atom:title': 'Feed Title',
+    }
+    const expected = {
+      title: { value: 'Feed Title' },
+    }
+
+    expect(retrieveFeed(value)).toEqual(expected)
+  })
+
+  it('should handle whitespace-only strings', () => {
+    const value = {
+      'atom:id': '   ',
+      'atom:title': '\t\n',
+    }
+
+    expect(retrieveFeed(value)).toBeUndefined()
+  })
+
+  it('should handle null and undefined properties', () => {
+    const value = {
+      'atom:id': null,
+      'atom:title': undefined,
+    }
+
+    expect(retrieveFeed(value)).toBeUndefined()
+  })
+
+  it('should return undefined for empty object', () => {
+    const value = {}
+
+    expect(retrieveFeed(value)).toBeUndefined()
+  })
+
+  it('should return undefined for non-object input', () => {
+    expect(retrieveFeed('string')).toBeUndefined()
+    expect(retrieveFeed(123)).toBeUndefined()
+    expect(retrieveFeed(true)).toBeUndefined()
+    expect(retrieveFeed(null)).toBeUndefined()
+    expect(retrieveFeed(undefined)).toBeUndefined()
+    expect(retrieveFeed([])).toBeUndefined()
+  })
+
+  it.todo('should parse updated date with custom parseDateFn', () => {
+    // Pass options.parseDateFn that maps the updated string to a Date instance.
+    // Expected: updated equals the value returned by the custom parser instead of the raw string.
   })
 })

--- a/src/namespaces/blogchannel/generate/utils.test.ts
+++ b/src/namespaces/blogchannel/generate/utils.test.ts
@@ -5,12 +5,12 @@ describe('generateFeed', () => {
   it('should generate feed with all properties', () => {
     const value = {
       blogRoll: 'http://example.com/blogroll.opml',
-      blink: 'http://recommended-site.com/',
+      blink: 'http://recommended.example.com/',
       mySubscriptions: 'http://example.com/subscriptions.opml',
     }
     const expected = {
       'blogChannel:blogRoll': 'http://example.com/blogroll.opml',
-      'blogChannel:blink': 'http://recommended-site.com/',
+      'blogChannel:blink': 'http://recommended.example.com/',
       'blogChannel:mySubscriptions': 'http://example.com/subscriptions.opml',
     }
 
@@ -30,10 +30,10 @@ describe('generateFeed', () => {
 
   it('should generate feed with only blink', () => {
     const value = {
-      blink: 'http://recommended-site.com/',
+      blink: 'http://recommended.example.com/',
     }
     const expected = {
-      'blogChannel:blink': 'http://recommended-site.com/',
+      'blogChannel:blink': 'http://recommended.example.com/',
     }
 
     expect(generateFeed(value)).toEqual(expected)
@@ -53,10 +53,10 @@ describe('generateFeed', () => {
   it('should handle empty strings', () => {
     const value = {
       blogRoll: '',
-      blink: 'http://recommended-site.com/',
+      blink: 'http://recommended.example.com/',
     }
     const expected = {
-      'blogChannel:blink': 'http://recommended-site.com/',
+      'blogChannel:blink': 'http://recommended.example.com/',
     }
 
     expect(generateFeed(value)).toEqual(expected)
@@ -97,24 +97,27 @@ describe('generateFeed', () => {
     expect(generateFeed(null)).toBeUndefined()
   })
 
-  it('should handle various URL formats', () => {
-    const urls = [
+  const urlFormatCases: Array<[string, { 'blogChannel:blogRoll': string }]> = [
+    [
       'http://example.com/blogroll.opml',
+      { 'blogChannel:blogRoll': 'http://example.com/blogroll.opml' },
+    ],
+    [
       'https://example.com/blogroll.opml',
-      'http://example.com/blogroll.opml?foo=bar',
+      { 'blogChannel:blogRoll': 'https://example.com/blogroll.opml' },
+    ],
+    [
+      'http://example.com/blogroll.opml?format=opml',
+      { 'blogChannel:blogRoll': 'http://example.com/blogroll.opml?format=opml' },
+    ],
+    [
       'http://example.com/path/to/blogroll.opml',
-    ]
+      { 'blogChannel:blogRoll': 'http://example.com/path/to/blogroll.opml' },
+    ],
+  ]
 
-    for (const url of urls) {
-      const value = {
-        blogRoll: url,
-      }
-      const expected = {
-        'blogChannel:blogRoll': url,
-      }
-
-      expect(generateFeed(value)).toEqual(expected)
-    }
+  it.each(urlFormatCases)('should handle URL format: %s', (blogRoll, expected) => {
+    expect(generateFeed({ blogRoll })).toEqual(expected)
   })
 
   it('should handle partial feed data', () => {
@@ -133,11 +136,11 @@ describe('generateFeed', () => {
   it('should handle mixed empty and valid strings', () => {
     const value = {
       blogRoll: '',
-      blink: 'http://recommended-site.com/',
+      blink: 'http://recommended.example.com/',
       mySubscriptions: '   ',
     }
     const expected = {
-      'blogChannel:blink': 'http://recommended-site.com/',
+      'blogChannel:blink': 'http://recommended.example.com/',
     }
 
     expect(generateFeed(value)).toEqual(expected)

--- a/src/namespaces/blogchannel/parse/utils.test.ts
+++ b/src/namespaces/blogchannel/parse/utils.test.ts
@@ -4,14 +4,14 @@ import { retrieveFeed } from './utils.js'
 describe('retrieveFeed', () => {
   const expectedFull = {
     blogRoll: 'http://example.com/blogroll.opml',
-    blink: 'http://recommended-site.com/',
+    blink: 'http://recommended.example.com/',
     mySubscriptions: 'http://example.com/subscriptions.opml',
   }
 
   it('should parse all blogChannel feed properties when present (with #text)', () => {
     const value = {
       'blogchannel:blogroll': { '#text': 'http://example.com/blogroll.opml' },
-      'blogchannel:blink': { '#text': 'http://recommended-site.com/' },
+      'blogchannel:blink': { '#text': 'http://recommended.example.com/' },
       'blogchannel:mysubscriptions': { '#text': 'http://example.com/subscriptions.opml' },
     }
 
@@ -21,7 +21,7 @@ describe('retrieveFeed', () => {
   it('should parse all blogChannel feed properties when present (without #text)', () => {
     const value = {
       'blogchannel:blogroll': 'http://example.com/blogroll.opml',
-      'blogchannel:blink': 'http://recommended-site.com/',
+      'blogchannel:blink': 'http://recommended.example.com/',
       'blogchannel:mysubscriptions': 'http://example.com/subscriptions.opml',
     }
 
@@ -31,7 +31,7 @@ describe('retrieveFeed', () => {
   it('should parse feed properties from arrays (uses first)', () => {
     const value = {
       'blogchannel:blogroll': ['http://example.com/blogroll.opml', 'http://example.com/alt.opml'],
-      'blogchannel:blink': ['http://recommended-site.com/', 'http://other-site.com/'],
+      'blogchannel:blink': ['http://recommended.example.com/', 'http://other.example.com/'],
       'blogchannel:mysubscriptions': [
         'http://example.com/subscriptions.opml',
         'http://example.com/subs2.opml',
@@ -54,10 +54,10 @@ describe('retrieveFeed', () => {
 
   it('should parse feed with only blink', () => {
     const value = {
-      'blogchannel:blink': 'http://recommended-site.com/',
+      'blogchannel:blink': 'http://recommended.example.com/',
     }
     const expected = {
-      blink: 'http://recommended-site.com/',
+      blink: 'http://recommended.example.com/',
     }
 
     expect(retrieveFeed(value)).toEqual(expected)
@@ -90,11 +90,11 @@ describe('retrieveFeed', () => {
   it('should handle CDATA sections in text content', () => {
     const value = {
       'blogchannel:blogroll': { '#text': '<![CDATA[http://example.com/blogroll.opml]]>' },
-      'blogchannel:blink': { '#text': '<![CDATA[http://recommended-site.com/]]>' },
+      'blogchannel:blink': { '#text': '<![CDATA[http://recommended.example.com/]]>' },
     }
     const expected = {
       blogRoll: 'http://example.com/blogroll.opml',
-      blink: 'http://recommended-site.com/',
+      blink: 'http://recommended.example.com/',
     }
 
     expect(retrieveFeed(value)).toEqual(expected)
@@ -149,10 +149,10 @@ describe('retrieveFeed', () => {
   it('should handle empty string values', () => {
     const value = {
       'blogchannel:blogroll': { '#text': '' },
-      'blogchannel:blink': { '#text': 'http://recommended-site.com/' },
+      'blogchannel:blink': { '#text': 'http://recommended.example.com/' },
     }
     const expected = {
-      blink: 'http://recommended-site.com/',
+      blink: 'http://recommended.example.com/',
     }
 
     expect(retrieveFeed(value)).toEqual(expected)

--- a/src/namespaces/cc/parse/utils.test.ts
+++ b/src/namespaces/cc/parse/utils.test.ts
@@ -88,6 +88,74 @@ describe('retrieveItemOrFeed', () => {
     expect(retrieveItemOrFeed(value)).toEqual(expected)
   })
 
+  it('should parse properties from arrays (uses first)', () => {
+    const value = {
+      'cc:license': [
+        'https://creativecommons.org/licenses/by/4.0/',
+        'https://creativecommons.org/licenses/by-sa/4.0/',
+      ],
+      'cc:attributionname': ['John Doe', 'Jane Doe'],
+    }
+    const expected = {
+      license: 'https://creativecommons.org/licenses/by/4.0/',
+      attributionName: 'John Doe',
+    }
+
+    expect(retrieveItemOrFeed(value)).toEqual(expected)
+  })
+
+  it('should handle HTML entities in text content', () => {
+    const value = {
+      'cc:morepermissions': { '#text': 'https://example.com/license?type=by&amp;version=2.0' },
+    }
+    const expected = {
+      morePermissions: 'https://example.com/license?type=by&version=2.0',
+    }
+
+    expect(retrieveItemOrFeed(value)).toEqual(expected)
+  })
+
+  it('should handle CDATA sections in text content', () => {
+    const value = {
+      'cc:license': { '#text': '<![CDATA[https://creativecommons.org/licenses/by/4.0/]]>' },
+    }
+    const expected = {
+      license: 'https://creativecommons.org/licenses/by/4.0/',
+    }
+
+    expect(retrieveItemOrFeed(value)).toEqual(expected)
+  })
+
+  it('should handle missing #text properties', () => {
+    const value = {
+      'cc:license': {},
+      'cc:morepermissions': {},
+    }
+
+    expect(retrieveItemOrFeed(value)).toBeUndefined()
+  })
+
+  it('should handle empty string values', () => {
+    const value = {
+      'cc:license': { '#text': '' },
+      'cc:attributionname': 'John Doe',
+    }
+    const expected = {
+      attributionName: 'John Doe',
+    }
+
+    expect(retrieveItemOrFeed(value)).toEqual(expected)
+  })
+
+  it('should handle whitespace-only values', () => {
+    const value = {
+      'cc:license': { '#text': '   ' },
+      'cc:attributionname': { '#text': '\t\n' },
+    }
+
+    expect(retrieveItemOrFeed(value)).toBeUndefined()
+  })
+
   it('should return undefined for empty object', () => {
     expect(retrieveItemOrFeed({})).toBeUndefined()
   })

--- a/src/namespaces/content/generate/utils.test.ts
+++ b/src/namespaces/content/generate/utils.test.ts
@@ -35,6 +35,22 @@ describe('generateItem', () => {
     expect(generateItem(value)).toEqual(expected)
   })
 
+  it('should handle empty strings', () => {
+    const value = {
+      encoded: '',
+    }
+
+    expect(generateItem(value)).toBeUndefined()
+  })
+
+  it('should handle whitespace-only strings', () => {
+    const value = {
+      encoded: '   ',
+    }
+
+    expect(generateItem(value)).toBeUndefined()
+  })
+
   it('should handle empty object', () => {
     const value = {}
 
@@ -43,5 +59,16 @@ describe('generateItem', () => {
 
   it('should handle undefined input', () => {
     expect(generateItem(undefined)).toBeUndefined()
+  })
+
+  it('should handle non-object inputs', () => {
+    // @ts-expect-error: This is for testing purposes.
+    expect(generateItem('string')).toBeUndefined()
+    // @ts-expect-error: This is for testing purposes.
+    expect(generateItem(123)).toBeUndefined()
+    // @ts-expect-error: This is for testing purposes.
+    expect(generateItem(null)).toBeUndefined()
+    // @ts-expect-error: This is for testing purposes.
+    expect(generateItem([])).toBeUndefined()
   })
 })

--- a/src/namespaces/creativecommons/generate/utils.test.ts
+++ b/src/namespaces/creativecommons/generate/utils.test.ts
@@ -61,6 +61,14 @@ describe('generateItemOrFeed', () => {
     expect(generateItemOrFeed(value)).toBeUndefined()
   })
 
+  it('should handle empty licenses array', () => {
+    const value = {
+      licenses: [],
+    }
+
+    expect(generateItemOrFeed(value)).toBeUndefined()
+  })
+
   it('should handle empty object', () => {
     const value = {}
 

--- a/src/namespaces/creativecommons/parse/utils.test.ts
+++ b/src/namespaces/creativecommons/parse/utils.test.ts
@@ -41,28 +41,37 @@ describe('retrieveItemOrFeed', () => {
     expect(retrieveItemOrFeed(value)).toEqual(expected)
   })
 
-  it('should parse various Creative Commons license URLs', () => {
-    const licenses = [
+  const licenseCases: Array<[string, { licenses: Array<string> }]> = [
+    [
       'http://creativecommons.org/licenses/by/3.0/',
+      { licenses: ['http://creativecommons.org/licenses/by/3.0/'] },
+    ],
+    [
       'http://creativecommons.org/licenses/by-sa/4.0/',
+      { licenses: ['http://creativecommons.org/licenses/by-sa/4.0/'] },
+    ],
+    [
       'http://creativecommons.org/licenses/by-nc/2.0/',
+      { licenses: ['http://creativecommons.org/licenses/by-nc/2.0/'] },
+    ],
+    [
       'http://creativecommons.org/licenses/by-nc-sa/3.0/',
+      { licenses: ['http://creativecommons.org/licenses/by-nc-sa/3.0/'] },
+    ],
+    [
       'http://creativecommons.org/licenses/by-nc-nd/2.0/',
+      { licenses: ['http://creativecommons.org/licenses/by-nc-nd/2.0/'] },
+    ],
+    [
       'https://creativecommons.org/publicdomain/zero/1.0/',
-      'Attribution-NonCommercial',
-      'CreativeCommons license feed',
-    ]
+      { licenses: ['https://creativecommons.org/publicdomain/zero/1.0/'] },
+    ],
+    ['Attribution-NonCommercial', { licenses: ['Attribution-NonCommercial'] }],
+    ['CreativeCommons license feed', { licenses: ['CreativeCommons license feed'] }],
+  ]
 
-    for (const license of licenses) {
-      const value = {
-        'creativecommons:license': license,
-      }
-      const expected = {
-        licenses: [license],
-      }
-
-      expect(retrieveItemOrFeed(value)).toEqual(expected)
-    }
+  it.each(licenseCases)('should parse license: %s', (license, expected) => {
+    expect(retrieveItemOrFeed({ 'creativecommons:license': license })).toEqual(expected)
   })
 
   it('should handle HTML entities in license text', () => {

--- a/src/namespaces/dc/generate/utils.test.ts
+++ b/src/namespaces/dc/generate/utils.test.ts
@@ -132,8 +132,27 @@ describe('generateItemOrFeed', () => {
     expect(generateItemOrFeed(value)).toBeUndefined()
   })
 
-  it('should handle non-object inputs gracefully', () => {
+  it('should handle non-object inputs', () => {
+    // @ts-expect-error: This is for testing purposes.
+    expect(generateItemOrFeed('string')).toBeUndefined()
+    // @ts-expect-error: This is for testing purposes.
+    expect(generateItemOrFeed(123)).toBeUndefined()
     expect(generateItemOrFeed(undefined)).toBeUndefined()
+    // @ts-expect-error: This is for testing purposes.
+    expect(generateItemOrFeed(null)).toBeUndefined()
+    // @ts-expect-error: This is for testing purposes.
+    expect(generateItemOrFeed([])).toBeUndefined()
+  })
+
+  it('should wrap special characters in CDATA', () => {
+    const value = {
+      titles: ['Research & Development <Update>'],
+    }
+    const expected = {
+      'dc:title': [{ '#cdata': 'Research & Development <Update>' }],
+    }
+
+    expect(generateItemOrFeed(value)).toEqual(expected)
   })
 
   it('should handle coverage and rights arrays', () => {

--- a/src/namespaces/dc/parse/utils.test.ts
+++ b/src/namespaces/dc/parse/utils.test.ts
@@ -233,4 +233,9 @@ describe('retrieveItemOrFeed', () => {
 
     expect(retrieveItemOrFeed(value)).toBeUndefined()
   })
+
+  it.todo('should parse dates with custom parseDateFn', () => {
+    // Pass options.parseDateFn that maps each date string to a Date instance.
+    // Expected: dates contains the values returned by the custom parser instead of the raw strings.
+  })
 })

--- a/src/namespaces/dcterms/generate/utils.test.ts
+++ b/src/namespaces/dcterms/generate/utils.test.ts
@@ -230,7 +230,26 @@ describe('generateItemOrFeed', () => {
     expect(generateItemOrFeed(value)).toBeUndefined()
   })
 
-  it('should handle non-object inputs gracefully', () => {
+  it('should handle non-object inputs', () => {
+    // @ts-expect-error: This is for testing purposes.
+    expect(generateItemOrFeed('string')).toBeUndefined()
+    // @ts-expect-error: This is for testing purposes.
+    expect(generateItemOrFeed(123)).toBeUndefined()
     expect(generateItemOrFeed(undefined)).toBeUndefined()
+    // @ts-expect-error: This is for testing purposes.
+    expect(generateItemOrFeed(null)).toBeUndefined()
+    // @ts-expect-error: This is for testing purposes.
+    expect(generateItemOrFeed([])).toBeUndefined()
+  })
+
+  it('should wrap special characters in CDATA', () => {
+    const value = {
+      titles: ['Research & Development <Update>'],
+    }
+    const expected = {
+      'dcterms:title': [{ '#cdata': 'Research & Development <Update>' }],
+    }
+
+    expect(generateItemOrFeed(value)).toEqual(expected)
   })
 })

--- a/src/namespaces/dcterms/parse/utils.test.ts
+++ b/src/namespaces/dcterms/parse/utils.test.ts
@@ -419,4 +419,10 @@ describe('retrieveItemOrFeed', () => {
 
     expect(retrieveItemOrFeed(value)).toEqual(expected)
   })
+
+  it.todo('should parse date fields with custom parseDateFn', () => {
+    // Pass options.parseDateFn that maps each date string to a Date instance.
+    // Expected: dates, created and the other date fields contain the values returned by the
+    // custom parser instead of the raw strings.
+  })
 })

--- a/src/namespaces/feedpress/generate/utils.test.ts
+++ b/src/namespaces/feedpress/generate/utils.test.ts
@@ -125,53 +125,45 @@ describe('generateFeed', () => {
     expect(generateFeed(null)).toBeUndefined()
   })
 
-  it('should handle various locale codes correctly', () => {
-    const locales = ['en', 'fr', 'de', 'es', 'ja', 'zh', 'pt', 'ru']
+  const localeCases: Array<[string, { 'feedpress:locale': string }]> = [
+    ['en', { 'feedpress:locale': 'en' }],
+    ['fr', { 'feedpress:locale': 'fr' }],
+    ['de', { 'feedpress:locale': 'de' }],
+    ['es', { 'feedpress:locale': 'es' }],
+    ['ja', { 'feedpress:locale': 'ja' }],
+    ['zh', { 'feedpress:locale': 'zh' }],
+    ['pt', { 'feedpress:locale': 'pt' }],
+    ['ru', { 'feedpress:locale': 'ru' }],
+  ]
 
-    for (const locale of locales) {
-      const value = {
-        locale,
-      }
-      const expected = {
-        'feedpress:locale': locale,
-      }
-
-      expect(generateFeed(value)).toEqual(expected)
-    }
+  it.each(localeCases)('should handle locale code: %s', (locale, expected) => {
+    expect(generateFeed({ locale })).toEqual(expected)
   })
 
-  it('should handle numeric podcast IDs', () => {
-    const podcastIds = ['123456', '789012', '345678']
+  const podcastIdCases: Array<[string, { 'feedpress:podcastId': string }]> = [
+    ['123456', { 'feedpress:podcastId': '123456' }],
+    ['789012', { 'feedpress:podcastId': '789012' }],
+    ['345678', { 'feedpress:podcastId': '345678' }],
+  ]
 
-    for (const podcastId of podcastIds) {
-      const value = {
-        podcastId,
-      }
-      const expected = {
-        'feedpress:podcastId': podcastId,
-      }
-
-      expect(generateFeed(value)).toEqual(expected)
-    }
+  it.each(podcastIdCases)('should handle numeric podcast ID: %s', (podcastId, expected) => {
+    expect(generateFeed({ podcastId })).toEqual(expected)
   })
 
-  it('should handle various CSS file URLs', () => {
-    const cssFiles = [
-      'https://example.com/custom.css',
+  const cssFileCases: Array<[string, { 'feedpress:cssFile': string }]> = [
+    ['https://example.com/custom.css', { 'feedpress:cssFile': 'https://example.com/custom.css' }],
+    [
       'https://cdn.example.com/styles/podcast.css',
+      { 'feedpress:cssFile': 'https://cdn.example.com/styles/podcast.css' },
+    ],
+    [
       'https://example.com/theme.css?v=1.0',
-    ]
+      { 'feedpress:cssFile': 'https://example.com/theme.css?v=1.0' },
+    ],
+  ]
 
-    for (const cssFile of cssFiles) {
-      const value = {
-        cssFile,
-      }
-      const expected = {
-        'feedpress:cssFile': cssFile,
-      }
-
-      expect(generateFeed(value)).toEqual(expected)
-    }
+  it.each(cssFileCases)('should handle CSS file URL: %s', (cssFile, expected) => {
+    expect(generateFeed({ cssFile })).toEqual(expected)
   })
 
   it('should handle partial feed data', () => {

--- a/src/namespaces/geo/parse/utils.test.ts
+++ b/src/namespaces/geo/parse/utils.test.ts
@@ -80,6 +80,17 @@ describe('retrieveItemOrFeed', () => {
     expect(retrieveItemOrFeed(value)).toEqual(expected)
   })
 
+  it('should parse altitude only', () => {
+    const value = {
+      'geo:alt': '10.5',
+    }
+    const expected = {
+      alt: 10.5,
+    }
+
+    expect(retrieveItemOrFeed(value)).toEqual(expected)
+  })
+
   it('should handle empty strings', () => {
     const value = {
       'geo:lat': '',
@@ -164,5 +175,10 @@ describe('retrieveItemOrFeed', () => {
     }
 
     expect(retrieveItemOrFeed(value)).toEqual(expected)
+  })
+
+  it.todo('should handle out-of-range coordinate values', () => {
+    // Pass lat '91' and long '181' (outside the valid -90..90 and -180..180 ranges).
+    // Expected: pin whether the parser passes them through as numbers or drops them.
   })
 })

--- a/src/namespaces/georss/parse/utils.test.ts
+++ b/src/namespaces/georss/parse/utils.test.ts
@@ -319,9 +319,9 @@ describe('parseBox', () => {
   it('should handle partial box objects with missing corners', () => {
     // This simulates a case where parseLatLngPairs returns valid points
     // but one of them has undefined coordinates.
-    const valueWithInvalidPoints = '45.256 NaN 51.5 -0.12'
+    const value = '45.256 NaN 51.5 -0.12'
 
-    expect(parseBox(valueWithInvalidPoints)).toBeUndefined()
+    expect(parseBox(value)).toBeUndefined()
   })
 
   it('should return undefined if there are not exactly 2 points', () => {

--- a/src/namespaces/googleplay/generate/utils.test.ts
+++ b/src/namespaces/googleplay/generate/utils.test.ts
@@ -59,6 +59,27 @@ describe('generateItem', () => {
     expect(generateItem(value)).toEqual(expected)
   })
 
+  it('should handle whitespace-only strings', () => {
+    const value = {
+      author: '   ',
+      description: '\t\n',
+    }
+
+    expect(generateItem(value)).toBeUndefined()
+  })
+
+  it('should handle object with all undefined properties', () => {
+    const value = {
+      author: undefined,
+      description: undefined,
+      explicit: undefined,
+      block: undefined,
+      image: undefined,
+    }
+
+    expect(generateItem(value)).toBeUndefined()
+  })
+
   it('should return undefined for empty object', () => {
     expect(generateItem({})).toBeUndefined()
   })
@@ -133,6 +154,30 @@ describe('generateFeed', () => {
     }
 
     expect(generateFeed(value)).toEqual(expected)
+  })
+
+  it('should handle whitespace-only strings', () => {
+    const value = {
+      author: '   ',
+      description: '\t\n',
+    }
+
+    expect(generateFeed(value)).toBeUndefined()
+  })
+
+  it('should handle object with all undefined properties', () => {
+    const value = {
+      author: undefined,
+      description: undefined,
+      explicit: undefined,
+      block: undefined,
+      image: undefined,
+      newFeedUrl: undefined,
+      email: undefined,
+      categories: undefined,
+    }
+
+    expect(generateFeed(value)).toBeUndefined()
   })
 
   it('should return undefined for empty object', () => {

--- a/src/namespaces/googleplay/parse/utils.test.ts
+++ b/src/namespaces/googleplay/parse/utils.test.ts
@@ -1,6 +1,169 @@
 import { describe, expect, it } from 'bun:test'
 import type { GooglePlayNs } from '../common/types.js'
-import { retrieveFeed, retrieveItem } from './utils.js'
+import { parseCategory, parseExplicit, parseImage, retrieveFeed, retrieveItem } from './utils.js'
+
+describe('parseImage', () => {
+  it('should parse image with href attribute', () => {
+    const value = {
+      '@href': 'https://example.com/image.jpg',
+    }
+    const expected: GooglePlayNs.Image = {
+      href: 'https://example.com/image.jpg',
+    }
+
+    expect(parseImage(value)).toEqual(expected)
+  })
+
+  it('should parse image from string value', () => {
+    const value = 'https://example.com/image.jpg'
+    const expected: GooglePlayNs.Image = {
+      href: 'https://example.com/image.jpg',
+    }
+
+    expect(parseImage(value)).toEqual(expected)
+  })
+
+  it('should parse image from #text property', () => {
+    const value = {
+      '#text': 'https://example.com/image.jpg',
+    }
+    const expected: GooglePlayNs.Image = {
+      href: 'https://example.com/image.jpg',
+    }
+
+    expect(parseImage(value)).toEqual(expected)
+  })
+
+  it('should handle coercible number values', () => {
+    const value = 123
+    const expected: GooglePlayNs.Image = {
+      href: '123',
+    }
+
+    expect(parseImage(value)).toEqual(expected)
+  })
+
+  it('should return undefined for empty strings', () => {
+    expect(parseImage('')).toBeUndefined()
+    expect(parseImage({ '@href': '' })).toBeUndefined()
+  })
+
+  it('should return undefined for whitespace-only strings', () => {
+    expect(parseImage('   ')).toBeUndefined()
+  })
+
+  it('should return undefined for empty object', () => {
+    expect(parseImage({})).toBeUndefined()
+  })
+
+  it('should return undefined for non-object inputs', () => {
+    expect(parseImage(null)).toBeUndefined()
+    expect(parseImage(undefined)).toBeUndefined()
+    expect(parseImage([])).toBeUndefined()
+    expect(parseImage(true)).toBeUndefined()
+  })
+})
+
+describe('parseCategory', () => {
+  it('should parse category with text attribute', () => {
+    const value = {
+      '@text': 'Technology',
+    }
+
+    expect(parseCategory(value)).toBe('Technology')
+  })
+
+  it('should parse category from string value', () => {
+    const value = 'Technology'
+
+    expect(parseCategory(value)).toBe('Technology')
+  })
+
+  it('should parse category from #text property', () => {
+    const value = {
+      '#text': 'Technology',
+    }
+
+    expect(parseCategory(value)).toBe('Technology')
+  })
+
+  it('should handle coercible number values', () => {
+    expect(parseCategory(123)).toBe('123')
+  })
+
+  it('should return undefined for empty strings', () => {
+    expect(parseCategory('')).toBeUndefined()
+    expect(parseCategory({ '@text': '' })).toBeUndefined()
+  })
+
+  it('should return undefined for whitespace-only strings', () => {
+    expect(parseCategory('   ')).toBeUndefined()
+  })
+
+  it('should return undefined for empty object', () => {
+    expect(parseCategory({})).toBeUndefined()
+  })
+
+  it('should return undefined for non-object inputs', () => {
+    expect(parseCategory(null)).toBeUndefined()
+    expect(parseCategory(undefined)).toBeUndefined()
+    expect(parseCategory([])).toBeUndefined()
+  })
+})
+
+describe('parseExplicit', () => {
+  it('should parse yes as true case-insensitively', () => {
+    expect(parseExplicit('yes')).toBe(true)
+    expect(parseExplicit('Yes')).toBe(true)
+    expect(parseExplicit('YES')).toBe(true)
+  })
+
+  it('should parse no as false case-insensitively', () => {
+    expect(parseExplicit('no')).toBe(false)
+    expect(parseExplicit('NO')).toBe(false)
+  })
+
+  it('should parse clean value case-insensitively', () => {
+    expect(parseExplicit('clean')).toBe('clean')
+    expect(parseExplicit('CLEAN')).toBe('clean')
+    expect(parseExplicit('  Clean  ')).toBe('clean')
+  })
+
+  it('should parse clean from #text property', () => {
+    const value = {
+      '#text': 'clean',
+    }
+
+    expect(parseExplicit(value)).toBe('clean')
+  })
+
+  it('should parse non-yes values as false', () => {
+    expect(parseExplicit('maybe')).toBe(false)
+  })
+
+  it('should return undefined for empty and whitespace-only strings', () => {
+    expect(parseExplicit('')).toBeUndefined()
+    expect(parseExplicit('   ')).toBeUndefined()
+  })
+
+  it('should return undefined for null and undefined inputs', () => {
+    expect(parseExplicit(null)).toBeUndefined()
+    expect(parseExplicit(undefined)).toBeUndefined()
+  })
+
+  it.todo('should parse yes from #text property', () => {
+    // parseExplicit({ '#text': 'yes' }) currently returns undefined because the yes/no branch
+    // passes the raw object to parseYesNoBoolean instead of the retrieved text, while the clean
+    // branch reads the retrieved text.
+    // Expected: true.
+  })
+
+  it.todo('should handle non-string inputs without throwing', () => {
+    // parseExplicit currently throws a TypeError for {}, [], 123 and true because retrieveText
+    // returns the raw value and .trim() is called on a non-string.
+    // Expected: undefined instead of a throw.
+  })
+})
 
 describe('retrieveItem', () => {
   it('should parse complete item object with all properties', () => {

--- a/src/namespaces/itunes/generate/utils.test.ts
+++ b/src/namespaces/itunes/generate/utils.test.ts
@@ -99,7 +99,7 @@ describe('generateCategory', () => {
   })
 
   it('should handle non-object inputs', () => {
-    // @ts-expect-error: Testing with invalid input type.
+    // @ts-expect-error: This is for testing purposes.
     expect(generateCategory(123)).toBeUndefined()
     expect(generateCategory(undefined)).toBeUndefined()
   })
@@ -221,16 +221,14 @@ describe('generateItem', () => {
     expect(generateItem(value)).toEqual(expected)
   })
 
-  it('should handle different episodeType values', () => {
-    const values = [{ episodeType: 'full' }, { episodeType: 'trailer' }, { episodeType: 'bonus' }]
+  const episodeTypeCases: Array<[string, { 'itunes:episodeType': string }]> = [
+    ['full', { 'itunes:episodeType': 'full' }],
+    ['trailer', { 'itunes:episodeType': 'trailer' }],
+    ['bonus', { 'itunes:episodeType': 'bonus' }],
+  ]
 
-    for (const value of values) {
-      const expected = {
-        'itunes:episodeType': value.episodeType,
-      }
-
-      expect(generateItem(value)).toEqual(expected)
-    }
+  it.each(episodeTypeCases)('should handle episodeType value: %s', (episodeType, expected) => {
+    expect(generateItem({ episodeType })).toEqual(expected)
   })
 
   it('should handle empty keywords array', () => {
@@ -417,16 +415,13 @@ describe('generateFeed', () => {
     expect(generateFeed(value)).toEqual(expected)
   })
 
-  it('should handle type values', () => {
-    const values = [{ type: 'episodic' }, { type: 'serial' }]
+  const typeCases: Array<[string, { 'itunes:type': string }]> = [
+    ['episodic', { 'itunes:type': 'episodic' }],
+    ['serial', { 'itunes:type': 'serial' }],
+  ]
 
-    for (const value of values) {
-      const expected = {
-        'itunes:type': value.type,
-      }
-
-      expect(generateFeed(value)).toEqual(expected)
-    }
+  it.each(typeCases)('should handle type value: %s', (type, expected) => {
+    expect(generateFeed({ type })).toEqual(expected)
   })
 
   it('should handle empty categories array', () => {

--- a/src/namespaces/itunes/parse/utils.test.ts
+++ b/src/namespaces/itunes/parse/utils.test.ts
@@ -242,6 +242,7 @@ describe('parseOwner', () => {
 
     expect(parseOwner(value)).toEqual(expected)
   })
+
   it('should handle non-string values for name and email', () => {
     const value = {
       'itunes:name': { '#text': 123 },
@@ -417,29 +418,29 @@ describe('parseExplicit', () => {
 
 describe('parseDuration', () => {
   it('should handle numbers directly', () => {
-    expect(parseDuration(42)).toEqual(42)
-    expect(parseDuration(0)).toEqual(0)
-    expect(parseDuration(3600)).toEqual(3600)
+    expect(parseDuration(42)).toBe(42)
+    expect(parseDuration(0)).toBe(0)
+    expect(parseDuration(3600)).toBe(3600)
   })
 
   it('should handle numeric strings', () => {
-    expect(parseDuration('120')).toEqual(120)
-    expect(parseDuration('0')).toEqual(0)
-    expect(parseDuration('3600')).toEqual(3600)
+    expect(parseDuration('120')).toBe(120)
+    expect(parseDuration('0')).toBe(0)
+    expect(parseDuration('3600')).toBe(3600)
   })
 
   it('should parse HH:MM:SS format', () => {
-    expect(parseDuration('01:30:45')).toEqual(5445)
-    expect(parseDuration('00:00:30')).toEqual(30)
-    expect(parseDuration('02:00:00')).toEqual(7200)
-    expect(parseDuration('100:00:00')).toEqual(360000)
+    expect(parseDuration('01:30:45')).toBe(5445)
+    expect(parseDuration('00:00:30')).toBe(30)
+    expect(parseDuration('02:00:00')).toBe(7200)
+    expect(parseDuration('100:00:00')).toBe(360000)
   })
 
   it('should parse MM:SS format', () => {
-    expect(parseDuration('05:30')).toEqual(330)
-    expect(parseDuration('00:45')).toEqual(45)
-    expect(parseDuration('90:00')).toEqual(5400)
-    expect(parseDuration('1:30')).toEqual(90)
+    expect(parseDuration('05:30')).toBe(330)
+    expect(parseDuration('00:45')).toBe(45)
+    expect(parseDuration('90:00')).toBe(5400)
+    expect(parseDuration('1:30')).toBe(90)
   })
 
   it('should handle invalid time formats', () => {
@@ -494,6 +495,11 @@ describe('parseDuration', () => {
   it('should handle undefined', () => {
     expect(parseDuration(undefined)).toBeUndefined()
   })
+
+  it.todo('should handle negative and very large durations', () => {
+    // Pass -42, Number.MAX_SAFE_INTEGER and '-01:30:00'.
+    // Expected: pin whether negative durations pass through as numbers or are rejected.
+  })
 })
 
 describe('parseImage', () => {
@@ -501,14 +507,14 @@ describe('parseImage', () => {
     const value = { '@href': 'https://example.com/image.jpg' }
     const expected = 'https://example.com/image.jpg'
 
-    expect(parseImage(value)).toEqual(expected)
+    expect(parseImage(value)).toBe(expected)
   })
 
   it('should parse image in a non-standard format', () => {
     const value = 'https://example.com/image.jpg'
     const expected = 'https://example.com/image.jpg'
 
-    expect(parseImage(value)).toEqual(expected)
+    expect(parseImage(value)).toBe(expected)
   })
 
   it('should return undefined when @href is missing', () => {
@@ -527,21 +533,21 @@ describe('parseImage', () => {
     const value = { '@href': 'https://example.com/image&amp;.jpg' }
     const expected = 'https://example.com/image&.jpg'
 
-    expect(parseImage(value)).toEqual(expected)
+    expect(parseImage(value)).toBe(expected)
   })
 
   it('should handle CDATA in @href', () => {
     const value = { '@href': '<![CDATA[https://example.com/image.jpg]]>' }
     const expected = 'https://example.com/image.jpg'
 
-    expect(parseImage(value)).toEqual(expected)
+    expect(parseImage(value)).toBe(expected)
   })
 
   it('should coerce non-string @href values to string', () => {
     const value = { '@href': 123 }
     const expected = '123'
 
-    expect(parseImage(value)).toEqual(expected)
+    expect(parseImage(value)).toBe(expected)
   })
 
   it('should return undefined for null or undefined @href', () => {
@@ -656,49 +662,38 @@ describe('retrieveItem', () => {
     expect(retrieveItem(value)).toEqual(expected)
   })
 
-  it('should parse duration in various formats', () => {
-    const testWithDuration = (durationValue: string, expectedDuration: number) => {
-      const value = { 'itunes:duration': { '#text': durationValue } }
-      const expected = retrieveItem(value)
+  const durationCases: Array<[string, { duration: number }]> = [
+    ['3600', { duration: 3600 }],
+    ['01:30:00', { duration: 5400 }],
+    ['45:30', { duration: 2730 }],
+  ]
 
-      expect(expected).toHaveProperty('duration', expectedDuration)
-    }
-
-    testWithDuration('3600', 3600)
-    testWithDuration('01:30:00', 5400)
-    testWithDuration('45:30', 2730)
+  it.each(durationCases)('should parse duration format: %s', (duration, expected) => {
+    expect(retrieveItem({ 'itunes:duration': { '#text': duration } })).toEqual(expected)
   })
 
-  it('should parse explicit value correctly', () => {
-    const testWithExplicit = (explicitValue: string, expectedExplicit: boolean) => {
-      const value = {
-        'itunes:explicit': { '#text': explicitValue },
-      }
-      const result = retrieveItem(value)
-      expect(result).toHaveProperty('explicit', expectedExplicit)
-    }
+  const explicitCases: Array<[string, { explicit: boolean }]> = [
+    ['true', { explicit: true }],
+    ['false', { explicit: false }],
+    ['yes', { explicit: true }],
+    ['no', { explicit: false }],
+    ['explicit', { explicit: true }],
+    ['clean', { explicit: false }],
+  ]
 
-    testWithExplicit('true', true)
-    testWithExplicit('false', false)
-    testWithExplicit('yes', true)
-    testWithExplicit('no', false)
-    testWithExplicit('explicit', true)
-    testWithExplicit('clean', false)
+  it.each(explicitCases)('should parse explicit value: %s', (explicit, expected) => {
+    expect(retrieveItem({ 'itunes:explicit': { '#text': explicit } })).toEqual(expected)
   })
 
-  it('should parse block value correctly', () => {
-    const testWithBlock = (blockValue: string, expectedBlock: boolean) => {
-      const value = {
-        'itunes:block': { '#text': blockValue },
-      }
-      const result = retrieveItem(value)
-      expect(result).toHaveProperty('block', expectedBlock)
-    }
+  const blockCases: Array<[string, { block: boolean }]> = [
+    ['yes', { block: true }],
+    ['no', { block: false }],
+    ['true', { block: true }],
+    ['false', { block: false }],
+  ]
 
-    testWithBlock('yes', true)
-    testWithBlock('no', false)
-    testWithBlock('true', true)
-    testWithBlock('false', false)
+  it.each(blockCases)('should parse block value: %s', (block, expected) => {
+    expect(retrieveItem({ 'itunes:block': { '#text': block } })).toEqual(expected)
   })
 
   it('should handle HTML entities in text content', () => {
@@ -1003,26 +998,22 @@ describe('retrieveFeed', () => {
     expect(retrieveFeed(value)).toEqual(expected)
   })
 
-  it('should parse explicit value correctly', () => {
-    const testWithExplicit = (explicitValue: string, expectedExplicit: boolean) => {
-      const value = {
-        'itunes:image': { '@href': 'https://example.com/image.jpg' },
-        'itunes:explicit': { '#text': explicitValue },
-      }
-      const expected = {
-        image: 'https://example.com/image.jpg',
-        explicit: expectedExplicit,
-      }
+  const explicitCases: Array<[string, { image: string; explicit: boolean }]> = [
+    ['true', { image: 'https://example.com/image.jpg', explicit: true }],
+    ['false', { image: 'https://example.com/image.jpg', explicit: false }],
+    ['yes', { image: 'https://example.com/image.jpg', explicit: true }],
+    ['no', { image: 'https://example.com/image.jpg', explicit: false }],
+    ['explicit', { image: 'https://example.com/image.jpg', explicit: true }],
+    ['clean', { image: 'https://example.com/image.jpg', explicit: false }],
+  ]
 
-      expect(retrieveFeed(value)).toEqual(expected)
+  it.each(explicitCases)('should parse explicit value: %s', (explicit, expected) => {
+    const value = {
+      'itunes:image': { '@href': 'https://example.com/image.jpg' },
+      'itunes:explicit': { '#text': explicit },
     }
 
-    testWithExplicit('true', true)
-    testWithExplicit('false', false)
-    testWithExplicit('yes', true)
-    testWithExplicit('no', false)
-    testWithExplicit('explicit', true)
-    testWithExplicit('clean', false)
+    expect(retrieveFeed(value)).toEqual(expected)
   })
 
   it('should parse block and complete values correctly', () => {

--- a/src/namespaces/media/generate/utils.test.ts
+++ b/src/namespaces/media/generate/utils.test.ts
@@ -4,6 +4,7 @@ import {
   generateCategory,
   generateComments,
   generateCommonElements,
+  generateCommunity,
   generateContent,
   generateCopyright,
   generateCredit,
@@ -58,6 +59,12 @@ describe('generateRating', () => {
     expect(generateRating(value)).toEqual(expected)
   })
 
+  it('should handle empty object', () => {
+    const value = {}
+
+    expect(generateRating(value)).toBeUndefined()
+  })
+
   it('should handle non-object inputs', () => {
     expect(generateRating(undefined)).toBeUndefined()
     // @ts-expect-error: This is for testing purposes.
@@ -88,6 +95,12 @@ describe('generateTitleOrDescription', () => {
     }
 
     expect(generateTitleOrDescription(value)).toEqual(expected)
+  })
+
+  it('should handle empty object', () => {
+    const value = {}
+
+    expect(generateTitleOrDescription(value)).toBeUndefined()
   })
 
   it('should handle non-object inputs', () => {
@@ -124,6 +137,12 @@ describe('generateThumbnail', () => {
     expect(generateThumbnail(value)).toEqual(expected)
   })
 
+  it('should handle empty object', () => {
+    const value = {}
+
+    expect(generateThumbnail(value)).toBeUndefined()
+  })
+
   it('should handle non-object inputs', () => {
     expect(generateThumbnail(undefined)).toBeUndefined()
   })
@@ -133,12 +152,12 @@ describe('generateCategory', () => {
   it('should generate category with all properties', () => {
     const value = {
       name: 'music/artist/album/song',
-      scheme: 'http://blah.com/scheme',
+      scheme: 'http://example.org/scheme',
       label: 'Music',
     }
     const expected = {
       '#text': 'music/artist/album/song',
-      '@scheme': 'http://blah.com/scheme',
+      '@scheme': 'http://example.org/scheme',
       '@label': 'Music',
     }
 
@@ -154,6 +173,12 @@ describe('generateCategory', () => {
     }
 
     expect(generateCategory(value)).toEqual(expected)
+  })
+
+  it('should handle empty object', () => {
+    const value = {}
+
+    expect(generateCategory(value)).toBeUndefined()
   })
 
   it('should handle non-object inputs', () => {
@@ -186,6 +211,12 @@ describe('generateHash', () => {
     expect(generateHash(value)).toEqual(expected)
   })
 
+  it('should handle empty object', () => {
+    const value = {}
+
+    expect(generateHash(value)).toBeUndefined()
+  })
+
   it('should handle non-object inputs', () => {
     expect(generateHash(undefined)).toBeUndefined()
   })
@@ -194,12 +225,12 @@ describe('generateHash', () => {
 describe('generatePlayer', () => {
   it('should generate player with all properties', () => {
     const value = {
-      url: 'http://www.foo.com/player?id=1111',
+      url: 'http://www.example.com/player?id=1111',
       height: 200,
       width: 400,
     }
     const expected = {
-      '@url': 'http://www.foo.com/player?id=1111',
+      '@url': 'http://www.example.com/player?id=1111',
       '@height': 200,
       '@width': 400,
     }
@@ -209,13 +240,19 @@ describe('generatePlayer', () => {
 
   it('should generate player with minimal properties', () => {
     const value = {
-      url: 'http://www.foo.com/player',
+      url: 'http://www.example.com/player',
     }
     const expected = {
-      '@url': 'http://www.foo.com/player',
+      '@url': 'http://www.example.com/player',
     }
 
     expect(generatePlayer(value)).toEqual(expected)
+  })
+
+  it('should handle empty object', () => {
+    const value = {}
+
+    expect(generatePlayer(value)).toBeUndefined()
   })
 
   it('should handle non-object inputs', () => {
@@ -250,6 +287,12 @@ describe('generateCredit', () => {
     expect(generateCredit(value)).toEqual(expected)
   })
 
+  it('should handle empty object', () => {
+    const value = {}
+
+    expect(generateCredit(value)).toBeUndefined()
+  })
+
   it('should handle non-object inputs', () => {
     expect(generateCredit(undefined)).toBeUndefined()
   })
@@ -258,12 +301,12 @@ describe('generateCredit', () => {
 describe('generateCopyright', () => {
   it('should generate copyright with all properties', () => {
     const value = {
-      value: '2005 FooBar Media',
-      url: 'http://blah.com/additional-info.html',
+      value: '2005 Example Media',
+      url: 'http://example.org/additional-info.html',
     }
     const expected = {
-      '#text': '2005 FooBar Media',
-      '@url': 'http://blah.com/additional-info.html',
+      '#text': '2005 Example Media',
+      '@url': 'http://example.org/additional-info.html',
     }
 
     expect(generateCopyright(value)).toEqual(expected)
@@ -278,6 +321,12 @@ describe('generateCopyright', () => {
     }
 
     expect(generateCopyright(value)).toEqual(expected)
+  })
+
+  it('should handle empty object', () => {
+    const value = {}
+
+    expect(generateCopyright(value)).toBeUndefined()
   })
 
   it('should handle non-object inputs', () => {
@@ -316,6 +365,12 @@ describe('generateText', () => {
     expect(generateText(value)).toEqual(expected)
   })
 
+  it('should handle empty object', () => {
+    const value = {}
+
+    expect(generateText(value)).toBeUndefined()
+  })
+
   it('should handle non-object inputs', () => {
     expect(generateText(undefined)).toBeUndefined()
   })
@@ -348,6 +403,12 @@ describe('generateRestriction', () => {
     }
 
     expect(generateRestriction(value)).toEqual(expected)
+  })
+
+  it('should handle empty object', () => {
+    const value = {}
+
+    expect(generateRestriction(value)).toBeUndefined()
   })
 
   it('should handle non-object inputs', () => {
@@ -384,6 +445,12 @@ describe('generateStarRating', () => {
     expect(generateStarRating(value)).toEqual(expected)
   })
 
+  it('should handle empty object', () => {
+    const value = {}
+
+    expect(generateStarRating(value)).toBeUndefined()
+  })
+
   it('should handle non-object inputs', () => {
     expect(generateStarRating(undefined)).toBeUndefined()
   })
@@ -414,6 +481,12 @@ describe('generateStatistics', () => {
     expect(generateStatistics(value)).toEqual(expected)
   })
 
+  it('should handle empty object', () => {
+    const value = {}
+
+    expect(generateStatistics(value)).toBeUndefined()
+  })
+
   it('should handle non-object inputs', () => {
     expect(generateStatistics(undefined)).toBeUndefined()
   })
@@ -427,7 +500,7 @@ describe('generateTag', () => {
     }
     const expected = 'music:5'
 
-    expect(generateTag(value)).toEqual(expected)
+    expect(generateTag(value)).toBe(expected)
   })
 
   it('should generate tag with default weight when not provided', () => {
@@ -436,7 +509,7 @@ describe('generateTag', () => {
     }
     const expected = 'video:1'
 
-    expect(generateTag(value)).toEqual(expected)
+    expect(generateTag(value)).toBe(expected)
   })
 
   it('should return undefined when name is empty', () => {
@@ -457,8 +530,75 @@ describe('generateTag', () => {
     expect(generateTag(value)).toBeUndefined()
   })
 
+  it('should handle empty object', () => {
+    const value = {}
+
+    expect(generateTag(value)).toBeUndefined()
+  })
+
   it('should handle non-object inputs', () => {
     expect(generateTag(undefined)).toBeUndefined()
+  })
+})
+
+describe('generateCommunity', () => {
+  it('should generate community with all properties', () => {
+    const value = {
+      starRating: {
+        average: 4.5,
+        count: 2500,
+        min: 1,
+        max: 5,
+      },
+      statistics: {
+        views: 12345,
+        favorites: 100,
+      },
+      tags: [
+        { name: 'music', weight: 5 },
+        { name: 'video', weight: 1 },
+      ],
+    }
+    const expected = {
+      'media:starRating': {
+        '@average': 4.5,
+        '@count': 2500,
+        '@min': 1,
+        '@max': 5,
+      },
+      'media:statistics': {
+        '@views': 12345,
+        '@favorites': 100,
+      },
+      'media:tags': 'music:5,video:1',
+    }
+
+    expect(generateCommunity(value)).toEqual(expected)
+  })
+
+  it('should generate community with minimal properties', () => {
+    const value = {
+      statistics: {
+        views: 500,
+      },
+    }
+    const expected = {
+      'media:statistics': {
+        '@views': 500,
+      },
+    }
+
+    expect(generateCommunity(value)).toEqual(expected)
+  })
+
+  it('should handle empty object', () => {
+    const value = {}
+
+    expect(generateCommunity(value)).toBeUndefined()
+  })
+
+  it('should handle non-object inputs', () => {
+    expect(generateCommunity(undefined)).toBeUndefined()
   })
 })
 
@@ -576,6 +716,23 @@ describe('generateParam', () => {
     expect(generateParam(value)).toEqual(expected)
   })
 
+  it('should generate param with minimal properties', () => {
+    const value = {
+      value: 'application/x-shockwave-flash',
+    }
+    const expected = {
+      '#text': 'application/x-shockwave-flash',
+    }
+
+    expect(generateParam(value)).toEqual(expected)
+  })
+
+  it('should handle empty object', () => {
+    const value = {}
+
+    expect(generateParam(value)).toBeUndefined()
+  })
+
   it('should handle non-object inputs', () => {
     expect(generateParam(undefined)).toBeUndefined()
   })
@@ -584,7 +741,7 @@ describe('generateParam', () => {
 describe('generateEmbed', () => {
   it('should generate embed with all properties', () => {
     const value = {
-      url: 'http://www.foo.com/player.swf',
+      url: 'http://www.example.com/player.swf',
       width: 512,
       height: 323,
       params: [
@@ -599,7 +756,7 @@ describe('generateEmbed', () => {
       ],
     }
     const expected = {
-      '@url': 'http://www.foo.com/player.swf',
+      '@url': 'http://www.example.com/player.swf',
       '@width': 512,
       '@height': 323,
       'media:param': [
@@ -619,13 +776,19 @@ describe('generateEmbed', () => {
 
   it('should generate embed with minimal properties', () => {
     const value = {
-      url: 'http://www.foo.com/player.swf',
+      url: 'http://www.example.com/player.swf',
     }
     const expected = {
-      '@url': 'http://www.foo.com/player.swf',
+      '@url': 'http://www.example.com/player.swf',
     }
 
     expect(generateEmbed(value)).toEqual(expected)
+  })
+
+  it('should handle empty object', () => {
+    const value = {}
+
+    expect(generateEmbed(value)).toBeUndefined()
   })
 
   it('should handle non-object inputs', () => {
@@ -658,6 +821,12 @@ describe('generateStatus', () => {
     expect(generateStatus(value)).toEqual(expected)
   })
 
+  it('should handle empty object', () => {
+    const value = {}
+
+    expect(generateStatus(value)).toBeUndefined()
+  })
+
   it('should handle non-object inputs', () => {
     expect(generateStatus(undefined)).toBeUndefined()
   })
@@ -667,13 +836,13 @@ describe('generatePrice', () => {
   it('should generate price with all properties', () => {
     const value = {
       type: 'rent',
-      info: 'http://www.dummy.jp/payment_info',
+      info: 'http://www.example.net/payment_info',
       price: 19.99,
       currency: 'EUR',
     }
     const expected = {
       '@type': 'rent',
-      '@info': 'http://www.dummy.jp/payment_info',
+      '@info': 'http://www.example.net/payment_info',
       '@price': 19.99,
       '@currency': 'EUR',
     }
@@ -690,6 +859,12 @@ describe('generatePrice', () => {
     }
 
     expect(generatePrice(value)).toEqual(expected)
+  })
+
+  it('should handle empty object', () => {
+    const value = {}
+
+    expect(generatePrice(value)).toBeUndefined()
   })
 
   it('should handle non-object inputs', () => {
@@ -735,6 +910,12 @@ describe('generateLicense', () => {
     expect(generateLicense(value)).toEqual(expected)
   })
 
+  it('should handle empty object', () => {
+    const value = {}
+
+    expect(generateLicense(value)).toBeUndefined()
+  })
+
   it('should handle non-object inputs', () => {
     expect(generateLicense(undefined)).toBeUndefined()
   })
@@ -745,12 +926,12 @@ describe('generateSubTitle', () => {
     const value = {
       type: 'application/smil',
       lang: 'en',
-      href: 'http://www.foo.com/subtitle.smil',
+      href: 'http://www.example.com/subtitle.smil',
     }
     const expected = {
       '@type': 'application/smil',
       '@lang': 'en',
-      '@href': 'http://www.foo.com/subtitle.smil',
+      '@href': 'http://www.example.com/subtitle.smil',
     }
 
     expect(generateSubTitle(value)).toEqual(expected)
@@ -758,13 +939,19 @@ describe('generateSubTitle', () => {
 
   it('should generate subtitle with minimal properties', () => {
     const value = {
-      href: 'http://www.foo.com/subtitle.txt',
+      href: 'http://www.example.com/subtitle.txt',
     }
     const expected = {
-      '@href': 'http://www.foo.com/subtitle.txt',
+      '@href': 'http://www.example.com/subtitle.txt',
     }
 
     expect(generateSubTitle(value)).toEqual(expected)
+  })
+
+  it('should handle empty object', () => {
+    const value = {}
+
+    expect(generateSubTitle(value)).toBeUndefined()
   })
 
   it('should handle non-object inputs', () => {
@@ -776,11 +963,11 @@ describe('generatePeerLink', () => {
   it('should generate peer link with all properties', () => {
     const value = {
       type: 'application/x-bittorrent',
-      href: 'http://www.foo.com/sampleFile.torrent',
+      href: 'http://www.example.com/sampleFile.torrent',
     }
     const expected = {
       '@type': 'application/x-bittorrent',
-      '@href': 'http://www.foo.com/sampleFile.torrent',
+      '@href': 'http://www.example.com/sampleFile.torrent',
     }
 
     expect(generatePeerLink(value)).toEqual(expected)
@@ -788,13 +975,19 @@ describe('generatePeerLink', () => {
 
   it('should generate peer link with minimal properties', () => {
     const value = {
-      href: 'http://www.foo.com/file.torrent',
+      href: 'http://www.example.com/file.torrent',
     }
     const expected = {
-      '@href': 'http://www.foo.com/file.torrent',
+      '@href': 'http://www.example.com/file.torrent',
     }
 
     expect(generatePeerLink(value)).toEqual(expected)
+  })
+
+  it('should handle empty object', () => {
+    const value = {}
+
+    expect(generatePeerLink(value)).toBeUndefined()
   })
 
   it('should handle non-object inputs', () => {
@@ -812,6 +1005,12 @@ describe('generateRights', () => {
     }
 
     expect(generateRights(value)).toEqual(expected)
+  })
+
+  it('should handle empty object', () => {
+    const value = {}
+
+    expect(generateRights(value)).toBeUndefined()
   })
 
   it('should handle non-object inputs', () => {
@@ -846,6 +1045,12 @@ describe('generateScene', () => {
     }
 
     expect(generateScene(value)).toEqual(expected)
+  })
+
+  it('should handle empty object', () => {
+    const value = {}
+
+    expect(generateScene(value)).toBeUndefined()
   })
 
   it('should handle non-object inputs', () => {
@@ -884,6 +1089,12 @@ describe('generateLocation', () => {
     expect(generateLocation(value)).toEqual(expected)
   })
 
+  it('should handle empty object', () => {
+    const value = {}
+
+    expect(generateLocation(value)).toBeUndefined()
+  })
+
   it('should handle non-object inputs', () => {
     expect(generateLocation(undefined)).toBeUndefined()
   })
@@ -892,7 +1103,7 @@ describe('generateLocation', () => {
 describe('generateContent', () => {
   it('should generate content with all properties including CommonElements', () => {
     const value = {
-      url: 'http://www.foo.com/movie.mov',
+      url: 'http://www.example.com/movie.mov',
       fileSize: 2000,
       type: 'video/quicktime',
       medium: 'video',
@@ -924,7 +1135,7 @@ describe('generateContent', () => {
       keywords: ['video', 'movie', 'entertainment'],
       thumbnails: [
         {
-          url: 'http://www.foo.com/keyframe.jpg',
+          url: 'http://www.example.com/keyframe.jpg',
           width: 75,
           height: 50,
           time: '12:05:01.123',
@@ -944,7 +1155,7 @@ describe('generateContent', () => {
         },
       ],
       player: {
-        url: 'http://www.foo.com/player',
+        url: 'http://www.example.com/player',
         height: 200,
         width: 400,
       },
@@ -956,8 +1167,8 @@ describe('generateContent', () => {
         },
       ],
       copyright: {
-        value: '2005 FooBar Media',
-        url: 'http://blah.com/info.html',
+        value: '2005 Example Media',
+        url: 'http://example.org/info.html',
       },
       texts: [
         {
@@ -995,7 +1206,7 @@ describe('generateContent', () => {
       },
       comments: ['Great video!', 'Thanks for sharing'],
       embed: {
-        url: 'http://www.foo.com/player.swf',
+        url: 'http://www.example.com/player.swf',
         width: 512,
         height: 323,
         params: [
@@ -1014,7 +1225,7 @@ describe('generateContent', () => {
       prices: [
         {
           type: 'rent',
-          info: 'http://www.dummy.jp/payment_info',
+          info: 'http://www.example.net/payment_info',
           price: 19.99,
           currency: 'EUR',
         },
@@ -1030,13 +1241,13 @@ describe('generateContent', () => {
         {
           type: 'application/smil',
           lang: 'en',
-          href: 'http://www.foo.com/subtitle.smil',
+          href: 'http://www.example.com/subtitle.smil',
         },
       ],
       peerLinks: [
         {
           type: 'application/x-bittorrent',
-          href: 'http://www.foo.com/file.torrent',
+          href: 'http://www.example.com/file.torrent',
         },
       ],
       locations: [
@@ -1061,7 +1272,7 @@ describe('generateContent', () => {
       ],
     }
     const expected = {
-      '@url': 'http://www.foo.com/movie.mov',
+      '@url': 'http://www.example.com/movie.mov',
       '@fileSize': 2000,
       '@type': 'video/quicktime',
       '@medium': 'video',
@@ -1092,7 +1303,7 @@ describe('generateContent', () => {
       'media:keywords': 'video,movie,entertainment',
       'media:thumbnail': [
         {
-          '@url': 'http://www.foo.com/keyframe.jpg',
+          '@url': 'http://www.example.com/keyframe.jpg',
           '@width': 75,
           '@height': 50,
           '@time': '12:05:01.123',
@@ -1112,7 +1323,7 @@ describe('generateContent', () => {
         },
       ],
       'media:player': {
-        '@url': 'http://www.foo.com/player',
+        '@url': 'http://www.example.com/player',
         '@height': 200,
         '@width': 400,
       },
@@ -1124,8 +1335,8 @@ describe('generateContent', () => {
         },
       ],
       'media:copyright': {
-        '#text': '2005 FooBar Media',
-        '@url': 'http://blah.com/info.html',
+        '#text': '2005 Example Media',
+        '@url': 'http://example.org/info.html',
       },
       'media:text': [
         {
@@ -1160,7 +1371,7 @@ describe('generateContent', () => {
         'media:comment': ['Great video!', 'Thanks for sharing'],
       },
       'media:embed': {
-        '@url': 'http://www.foo.com/player.swf',
+        '@url': 'http://www.example.com/player.swf',
         '@width': 512,
         '@height': 323,
         'media:param': [
@@ -1183,7 +1394,7 @@ describe('generateContent', () => {
       'media:price': [
         {
           '@type': 'rent',
-          '@info': 'http://www.dummy.jp/payment_info',
+          '@info': 'http://www.example.net/payment_info',
           '@price': 19.99,
           '@currency': 'EUR',
         },
@@ -1199,13 +1410,13 @@ describe('generateContent', () => {
         {
           '@type': 'application/smil',
           '@lang': 'en',
-          '@href': 'http://www.foo.com/subtitle.smil',
+          '@href': 'http://www.example.com/subtitle.smil',
         },
       ],
       'media:peerLink': [
         {
           '@type': 'application/x-bittorrent',
-          '@href': 'http://www.foo.com/file.torrent',
+          '@href': 'http://www.example.com/file.torrent',
         },
       ],
       'media:location': [
@@ -1237,13 +1448,19 @@ describe('generateContent', () => {
 
   it('should generate content with minimal properties', () => {
     const value = {
-      url: 'http://www.foo.com/audio.mp3',
+      url: 'http://www.example.com/audio.mp3',
     }
     const expected = {
-      '@url': 'http://www.foo.com/audio.mp3',
+      '@url': 'http://www.example.com/audio.mp3',
     }
 
     expect(generateContent(value)).toEqual(expected)
+  })
+
+  it('should handle empty object', () => {
+    const value = {}
+
+    expect(generateContent(value)).toBeUndefined()
   })
 
   it('should handle non-object inputs', () => {
@@ -1256,12 +1473,12 @@ describe('generateGroup', () => {
     const value = {
       contents: [
         {
-          url: 'http://www.foo.com/song_lo.mp3',
+          url: 'http://www.example.com/song_lo.mp3',
           fileSize: 1000,
           bitrate: 128,
         },
         {
-          url: 'http://www.foo.com/song_hi.mp3',
+          url: 'http://www.example.com/song_hi.mp3',
           fileSize: 2000,
           bitrate: 192,
         },
@@ -1284,7 +1501,7 @@ describe('generateGroup', () => {
       keywords: ['music', 'audio', 'song'],
       thumbnails: [
         {
-          url: 'http://www.foo.com/album_art.jpg',
+          url: 'http://www.example.com/album_art.jpg',
           width: 300,
           height: 300,
         },
@@ -1303,7 +1520,7 @@ describe('generateGroup', () => {
         },
       ],
       player: {
-        url: 'http://www.foo.com/music_player',
+        url: 'http://www.example.com/music_player',
         height: 50,
         width: 400,
       },
@@ -1316,7 +1533,7 @@ describe('generateGroup', () => {
       ],
       copyright: {
         value: '2023 Record Label',
-        url: 'http://label.com/info.html',
+        url: 'http://records.example.com/info.html',
       },
       texts: [
         {
@@ -1356,7 +1573,7 @@ describe('generateGroup', () => {
       },
       comments: ['Love this song!', 'Amazing track'],
       embed: {
-        url: 'http://www.foo.com/audio_player.swf',
+        url: 'http://www.example.com/audio_player.swf',
         width: 400,
         height: 50,
       },
@@ -1380,14 +1597,14 @@ describe('generateGroup', () => {
       ],
       subTitles: [
         {
-          href: 'http://www.foo.com/lyrics.txt',
+          href: 'http://www.example.com/lyrics.txt',
           type: 'text/plain',
           lang: 'en',
         },
       ],
       peerLinks: [
         {
-          href: 'http://www.foo.com/music.torrent',
+          href: 'http://www.example.com/music.torrent',
         },
       ],
       locations: [
@@ -1409,12 +1626,12 @@ describe('generateGroup', () => {
     const expected = {
       'media:content': [
         {
-          '@url': 'http://www.foo.com/song_lo.mp3',
+          '@url': 'http://www.example.com/song_lo.mp3',
           '@fileSize': 1000,
           '@bitrate': 128,
         },
         {
-          '@url': 'http://www.foo.com/song_hi.mp3',
+          '@url': 'http://www.example.com/song_hi.mp3',
           '@fileSize': 2000,
           '@bitrate': 192,
         },
@@ -1436,7 +1653,7 @@ describe('generateGroup', () => {
       'media:keywords': 'music,audio,song',
       'media:thumbnail': [
         {
-          '@url': 'http://www.foo.com/album_art.jpg',
+          '@url': 'http://www.example.com/album_art.jpg',
           '@width': 300,
           '@height': 300,
         },
@@ -1455,7 +1672,7 @@ describe('generateGroup', () => {
         },
       ],
       'media:player': {
-        '@url': 'http://www.foo.com/music_player',
+        '@url': 'http://www.example.com/music_player',
         '@height': 50,
         '@width': 400,
       },
@@ -1468,7 +1685,7 @@ describe('generateGroup', () => {
       ],
       'media:copyright': {
         '#text': '2023 Record Label',
-        '@url': 'http://label.com/info.html',
+        '@url': 'http://records.example.com/info.html',
       },
       'media:text': [
         {
@@ -1501,7 +1718,7 @@ describe('generateGroup', () => {
         'media:comment': ['Love this song!', 'Amazing track'],
       },
       'media:embed': {
-        '@url': 'http://www.foo.com/audio_player.swf',
+        '@url': 'http://www.example.com/audio_player.swf',
         '@width': 400,
         '@height': 50,
       },
@@ -1529,14 +1746,14 @@ describe('generateGroup', () => {
       ],
       'media:subTitle': [
         {
-          '@href': 'http://www.foo.com/lyrics.txt',
+          '@href': 'http://www.example.com/lyrics.txt',
           '@type': 'text/plain',
           '@lang': 'en',
         },
       ],
       'media:peerLink': [
         {
-          '@href': 'http://www.foo.com/music.torrent',
+          '@href': 'http://www.example.com/music.torrent',
         },
       ],
       'media:location': [
@@ -1576,6 +1793,12 @@ describe('generateGroup', () => {
     expect(generateGroup(value)).toEqual(expected)
   })
 
+  it('should handle empty object', () => {
+    const value = {}
+
+    expect(generateGroup(value)).toBeUndefined()
+  })
+
   it('should handle non-object inputs', () => {
     expect(generateGroup(undefined)).toBeUndefined()
   })
@@ -1588,7 +1811,7 @@ describe('generateItemOrFeed', () => {
         {
           contents: [
             {
-              url: 'http://www.foo.com/video.mp4',
+              url: 'http://www.example.com/video.mp4',
               type: 'video/mp4',
             },
           ],
@@ -1599,7 +1822,7 @@ describe('generateItemOrFeed', () => {
       ],
       contents: [
         {
-          url: 'http://www.foo.com/audio.mp3',
+          url: 'http://www.example.com/audio.mp3',
           type: 'audio/mpeg',
         },
       ],
@@ -1621,7 +1844,7 @@ describe('generateItemOrFeed', () => {
       keywords: ['media', 'content', 'test'],
       thumbnails: [
         {
-          url: 'http://www.foo.com/thumb.jpg',
+          url: 'http://www.example.com/thumb.jpg',
           width: 160,
           height: 120,
         },
@@ -1640,7 +1863,7 @@ describe('generateItemOrFeed', () => {
         },
       ],
       player: {
-        url: 'http://www.foo.com/player',
+        url: 'http://www.example.com/player',
         height: 400,
         width: 600,
       },
@@ -1682,7 +1905,7 @@ describe('generateItemOrFeed', () => {
       },
       comments: ['Great content!'],
       embed: {
-        url: 'http://www.foo.com/embed.swf',
+        url: 'http://www.example.com/embed.swf',
       },
       responses: ['http://example.com/response'],
       backLinks: ['http://example.com/backlink'],
@@ -1701,12 +1924,12 @@ describe('generateItemOrFeed', () => {
       ],
       subTitles: [
         {
-          href: 'http://www.foo.com/subs.srt',
+          href: 'http://www.example.com/subs.srt',
         },
       ],
       peerLinks: [
         {
-          href: 'http://www.foo.com/peer.torrent',
+          href: 'http://www.example.com/peer.torrent',
         },
       ],
       locations: [
@@ -1728,7 +1951,7 @@ describe('generateItemOrFeed', () => {
         {
           'media:content': [
             {
-              '@url': 'http://www.foo.com/video.mp4',
+              '@url': 'http://www.example.com/video.mp4',
               '@type': 'video/mp4',
             },
           ],
@@ -1739,7 +1962,7 @@ describe('generateItemOrFeed', () => {
       ],
       'media:content': [
         {
-          '@url': 'http://www.foo.com/audio.mp3',
+          '@url': 'http://www.example.com/audio.mp3',
           '@type': 'audio/mpeg',
         },
       ],
@@ -1760,7 +1983,7 @@ describe('generateItemOrFeed', () => {
       'media:keywords': 'media,content,test',
       'media:thumbnail': [
         {
-          '@url': 'http://www.foo.com/thumb.jpg',
+          '@url': 'http://www.example.com/thumb.jpg',
           '@width': 160,
           '@height': 120,
         },
@@ -1779,7 +2002,7 @@ describe('generateItemOrFeed', () => {
         },
       ],
       'media:player': {
-        '@url': 'http://www.foo.com/player',
+        '@url': 'http://www.example.com/player',
         '@height': 400,
         '@width': 600,
       },
@@ -1818,7 +2041,7 @@ describe('generateItemOrFeed', () => {
         'media:comment': ['Great content!'],
       },
       'media:embed': {
-        '@url': 'http://www.foo.com/embed.swf',
+        '@url': 'http://www.example.com/embed.swf',
       },
       'media:responses': {
         'media:response': ['http://example.com/response'],
@@ -1841,12 +2064,12 @@ describe('generateItemOrFeed', () => {
       ],
       'media:subTitle': [
         {
-          '@href': 'http://www.foo.com/subs.srt',
+          '@href': 'http://www.example.com/subs.srt',
         },
       ],
       'media:peerLink': [
         {
-          '@href': 'http://www.foo.com/peer.torrent',
+          '@href': 'http://www.example.com/peer.torrent',
         },
       ],
       'media:location': [

--- a/src/namespaces/opensearch/generate/utils.test.ts
+++ b/src/namespaces/opensearch/generate/utils.test.ts
@@ -142,7 +142,7 @@ describe('generateFeed', () => {
     expect(generateFeed(value)).toEqual(expected)
   })
 
-  it('should generate feed with 0-based indexing (arXiv style)', () => {
+  it('should generate feed with 0-based indexing', () => {
     const value = {
       totalResults: 1000,
       startIndex: 0,

--- a/src/namespaces/opensearch/parse/utils.test.ts
+++ b/src/namespaces/opensearch/parse/utils.test.ts
@@ -53,6 +53,36 @@ describe('parseQuery', () => {
     expect(parseQuery(value)).toEqual(expected)
   })
 
+  it('should handle coercible numeric values', () => {
+    const value = {
+      '@role': 'request',
+      '@count': 10,
+      '@startindex': 21,
+    }
+    const expected = {
+      role: 'request',
+      count: 10,
+      startIndex: 21,
+    }
+
+    expect(parseQuery(value)).toEqual(expected)
+  })
+
+  it('should handle mixed valid and invalid attributes', () => {
+    const value = {
+      '@role': 'request',
+      '@count': 'not a number',
+      '@searchterms': '',
+      '@language': 'en',
+    }
+    const expected = {
+      role: 'request',
+      language: 'en',
+    }
+
+    expect(parseQuery(value)).toEqual(expected)
+  })
+
   it('should return undefined for empty object', () => {
     const value = {}
 
@@ -160,7 +190,7 @@ describe('retrieveFeed', () => {
     expect(retrieveFeed(value)).toEqual(expected)
   })
 
-  it('should handle 0-based indexing (arXiv style)', () => {
+  it('should handle 0-based indexing', () => {
     const value = {
       'opensearch:totalresults': '1000',
       'opensearch:startindex': '0',

--- a/src/namespaces/podcast/generate/utils.test.ts
+++ b/src/namespaces/podcast/generate/utils.test.ts
@@ -65,6 +65,12 @@ describe('generateTranscript', () => {
     expect(generateTranscript(value)).toEqual(expected)
   })
 
+  it('should handle empty object', () => {
+    const value = {}
+
+    expect(generateTranscript(value)).toBeUndefined()
+  })
+
   it('should handle non-object inputs', () => {
     expect(generateTranscript(undefined)).toBeUndefined()
     // @ts-expect-error: This is for testing purposes.
@@ -97,6 +103,12 @@ describe('generateLocked', () => {
     expect(generateLocked(value)).toEqual(expected)
   })
 
+  it('should handle empty object', () => {
+    const value = {}
+
+    expect(generateLocked(value)).toBeUndefined()
+  })
+
   it('should handle non-object inputs', () => {
     expect(generateLocked(undefined)).toBeUndefined()
   })
@@ -127,6 +139,12 @@ describe('generateFunding', () => {
     expect(generateFunding(value)).toEqual(expected)
   })
 
+  it('should handle empty object', () => {
+    const value = {}
+
+    expect(generateFunding(value)).toBeUndefined()
+  })
+
   it('should handle non-object inputs', () => {
     expect(generateFunding(undefined)).toBeUndefined()
   })
@@ -144,6 +162,12 @@ describe('generateChapters', () => {
     }
 
     expect(generateChapters(value)).toEqual(expected)
+  })
+
+  it('should handle empty object', () => {
+    const value = {}
+
+    expect(generateChapters(value)).toBeUndefined()
   })
 
   it('should handle non-object inputs', () => {
@@ -178,6 +202,12 @@ describe('generateSoundbite', () => {
     }
 
     expect(generateSoundbite(value)).toEqual(expected)
+  })
+
+  it('should handle empty object', () => {
+    const value = {}
+
+    expect(generateSoundbite(value)).toBeUndefined()
   })
 
   it('should handle non-object inputs', () => {
@@ -216,6 +246,12 @@ describe('generatePerson', () => {
     expect(generatePerson(value)).toEqual(expected)
   })
 
+  it('should handle empty object', () => {
+    const value = {}
+
+    expect(generatePerson(value)).toBeUndefined()
+  })
+
   it('should handle non-object inputs', () => {
     expect(generatePerson(undefined)).toBeUndefined()
   })
@@ -252,6 +288,12 @@ describe('generateLocation', () => {
     expect(generateLocation(value)).toEqual(expected)
   })
 
+  it('should handle empty object', () => {
+    const value = {}
+
+    expect(generateLocation(value)).toBeUndefined()
+  })
+
   it('should handle non-object inputs', () => {
     expect(generateLocation(undefined)).toBeUndefined()
   })
@@ -282,6 +324,12 @@ describe('generateSeason', () => {
     expect(generateSeason(value)).toEqual(expected)
   })
 
+  it('should handle empty object', () => {
+    const value = {}
+
+    expect(generateSeason(value)).toBeUndefined()
+  })
+
   it('should handle non-object inputs', () => {
     expect(generateSeason(undefined)).toBeUndefined()
   })
@@ -310,6 +358,12 @@ describe('generateEpisode', () => {
     }
 
     expect(generateEpisode(value)).toEqual(expected)
+  })
+
+  it('should handle empty object', () => {
+    const value = {}
+
+    expect(generateEpisode(value)).toBeUndefined()
   })
 
   it('should handle non-object inputs', () => {
@@ -354,6 +408,12 @@ describe('generateTrailer', () => {
     expect(generateTrailer(value)).toEqual(expected)
   })
 
+  it('should handle empty object', () => {
+    const value = {}
+
+    expect(generateTrailer(value)).toBeUndefined()
+  })
+
   it('should handle non-object inputs', () => {
     expect(generateTrailer(undefined)).toBeUndefined()
   })
@@ -382,6 +442,12 @@ describe('generateLicense', () => {
     }
 
     expect(generateLicense(value)).toEqual(expected)
+  })
+
+  it('should handle empty object', () => {
+    const value = {}
+
+    expect(generateLicense(value)).toBeUndefined()
   })
 
   it('should handle non-object inputs', () => {
@@ -414,6 +480,12 @@ describe('generateSource', () => {
     expect(generateSource(value)).toEqual(expected)
   })
 
+  it('should handle empty object', () => {
+    const value = {}
+
+    expect(generateSource(value)).toBeUndefined()
+  })
+
   it('should handle non-object inputs', () => {
     expect(generateSource(undefined)).toBeUndefined()
   })
@@ -431,6 +503,12 @@ describe('generateIntegrity', () => {
     }
 
     expect(generateIntegrity(value)).toEqual(expected)
+  })
+
+  it('should handle empty object', () => {
+    const value = {}
+
+    expect(generateIntegrity(value)).toBeUndefined()
   })
 
   it('should handle non-object inputs', () => {
@@ -497,6 +575,12 @@ describe('generateAlternateEnclosure', () => {
     expect(generateAlternateEnclosure(value)).toEqual(expected)
   })
 
+  it('should handle empty object', () => {
+    const value = {}
+
+    expect(generateAlternateEnclosure(value)).toBeUndefined()
+  })
+
   it('should handle non-object inputs', () => {
     expect(generateAlternateEnclosure(undefined)).toBeUndefined()
   })
@@ -539,6 +623,12 @@ describe('generateValueRecipient', () => {
     }
 
     expect(generateValueRecipient(value)).toEqual(expected)
+  })
+
+  it('should handle empty object', () => {
+    const value = {}
+
+    expect(generateValueRecipient(value)).toBeUndefined()
   })
 
   it('should handle non-object inputs', () => {
@@ -603,6 +693,12 @@ describe('generateValueTimeSplit', () => {
     expect(generateValueTimeSplit(value)).toEqual(expected)
   })
 
+  it('should handle empty object', () => {
+    const value = {}
+
+    expect(generateValueTimeSplit(value)).toBeUndefined()
+  })
+
   it('should handle non-object inputs', () => {
     expect(generateValueTimeSplit(undefined)).toBeUndefined()
   })
@@ -663,6 +759,12 @@ describe('generateValue', () => {
     expect(generateValue(value)).toEqual(expected)
   })
 
+  it('should handle empty object', () => {
+    const value = {}
+
+    expect(generateValue(value)).toBeUndefined()
+  })
+
   it('should handle non-object inputs', () => {
     expect(generateValue(undefined)).toBeUndefined()
   })
@@ -703,6 +805,12 @@ describe('generateImage', () => {
     expect(generateImage(value)).toEqual(expected)
   })
 
+  it('should handle empty object', () => {
+    const value = {}
+
+    expect(generateImage(value)).toBeUndefined()
+  })
+
   it('should handle non-object inputs', () => {
     expect(generateImage(undefined)).toBeUndefined()
   })
@@ -731,6 +839,12 @@ describe('generateContentLink', () => {
     }
 
     expect(generateContentLink(value)).toEqual(expected)
+  })
+
+  it('should handle empty object', () => {
+    const value = {}
+
+    expect(generateContentLink(value)).toBeUndefined()
   })
 
   it('should handle non-object inputs', () => {
@@ -769,6 +883,12 @@ describe('generateSocialInteract', () => {
     expect(generateSocialInteract(value)).toEqual(expected)
   })
 
+  it('should handle empty object', () => {
+    const value = {}
+
+    expect(generateSocialInteract(value)).toBeUndefined()
+  })
+
   it('should handle non-object inputs', () => {
     expect(generateSocialInteract(undefined)).toBeUndefined()
   })
@@ -805,6 +925,12 @@ describe('generateChat', () => {
     expect(generateChat(value)).toEqual(expected)
   })
 
+  it('should handle empty object', () => {
+    const value = {}
+
+    expect(generateChat(value)).toBeUndefined()
+  })
+
   it('should handle non-object inputs', () => {
     expect(generateChat(undefined)).toBeUndefined()
   })
@@ -835,6 +961,12 @@ describe('generateBlock', () => {
     expect(generateBlock(value)).toEqual(expected)
   })
 
+  it('should handle empty object', () => {
+    const value = {}
+
+    expect(generateBlock(value)).toBeUndefined()
+  })
+
   it('should handle non-object inputs', () => {
     expect(generateBlock(undefined)).toBeUndefined()
   })
@@ -863,6 +995,12 @@ describe('generateTxt', () => {
     }
 
     expect(generateTxt(value)).toEqual(expected)
+  })
+
+  it('should handle empty object', () => {
+    const value = {}
+
+    expect(generateTxt(value)).toBeUndefined()
   })
 
   it('should handle non-object inputs', () => {
@@ -899,6 +1037,12 @@ describe('generateRemoteItem', () => {
     }
 
     expect(generateRemoteItem(value)).toEqual(expected)
+  })
+
+  it('should handle empty object', () => {
+    const value = {}
+
+    expect(generateRemoteItem(value)).toBeUndefined()
   })
 
   it('should handle non-object inputs', () => {
@@ -944,6 +1088,12 @@ describe('generatePodroll', () => {
     expect(generatePodroll(value)).toBeUndefined()
   })
 
+  it('should handle empty object', () => {
+    const value = {}
+
+    expect(generatePodroll(value)).toBeUndefined()
+  })
+
   it('should handle non-object inputs', () => {
     expect(generatePodroll(undefined)).toBeUndefined()
   })
@@ -978,6 +1128,12 @@ describe('generateUpdateFrequency', () => {
     expect(generateUpdateFrequency(value)).toEqual(expected)
   })
 
+  it('should handle empty object', () => {
+    const value = {}
+
+    expect(generateUpdateFrequency(value)).toBeUndefined()
+  })
+
   it('should handle non-object inputs', () => {
     expect(generateUpdateFrequency(undefined)).toBeUndefined()
   })
@@ -1004,6 +1160,12 @@ describe('generatePodping', () => {
     }
 
     expect(generatePodping(value)).toEqual(expected)
+  })
+
+  it('should handle empty object', () => {
+    const value = {}
+
+    expect(generatePodping(value)).toBeUndefined()
   })
 
   it('should handle non-object inputs', () => {
@@ -1044,6 +1206,12 @@ describe('generatePublisher', () => {
     }
 
     expect(generatePublisher(value)).toEqual(expected)
+  })
+
+  it('should handle empty object', () => {
+    const value = {}
+
+    expect(generatePublisher(value)).toBeUndefined()
   })
 
   it('should handle non-object inputs', () => {
@@ -1268,6 +1436,12 @@ describe('generateLiveItem', () => {
     }
 
     expect(generateLiveItem(value)).toEqual(expected)
+  })
+
+  it('should handle empty object', () => {
+    const value = {}
+
+    expect(generateLiveItem(value)).toBeUndefined()
   })
 
   it('should handle non-object inputs', () => {

--- a/src/namespaces/podcast/parse/utils.test.ts
+++ b/src/namespaces/podcast/parse/utils.test.ts
@@ -945,7 +945,7 @@ describe('parseSeason', () => {
     expect(parseSeason(value)).toBeUndefined()
   })
 
-  it('should return undefined for not supoprted input', () => {
+  it('should return undefined for not supported input', () => {
     expect(parseSeason(undefined)).toBeUndefined()
     expect(parseSeason(null)).toBeUndefined()
     expect(parseSeason([])).toBeUndefined()
@@ -1211,6 +1211,11 @@ describe('parseTrailer', () => {
     expect(parseTrailer(undefined)).toBeUndefined()
     expect(parseTrailer(null)).toBeUndefined()
     expect(parseTrailer([])).toBeUndefined()
+  })
+
+  it.todo('should parse pubDate with custom parseDateFn', () => {
+    // Pass options.parseDateFn that converts the RFC 822 string into a Date instance.
+    // Expected: pubDate equals the value returned by parseDateFn instead of the raw string.
   })
 })
 
@@ -2453,6 +2458,11 @@ describe('parseLiveItem', () => {
     expect(parseLiveItem(null)).toBeUndefined()
     expect(parseLiveItem([])).toBeUndefined()
   })
+
+  it.todo('should parse start and end with custom parseDateFn', () => {
+    // Pass options.parseDateFn that converts the RFC 3339 strings into Date instances.
+    // Expected: start and end equal the values returned by parseDateFn instead of raw strings.
+  })
 })
 
 describe('parseContentLink', () => {
@@ -3211,6 +3221,11 @@ describe('parseUpdateFrequency', () => {
     expect(parseUpdateFrequency(undefined)).toBeUndefined()
     expect(parseUpdateFrequency(null)).toBeUndefined()
     expect(parseUpdateFrequency([])).toBeUndefined()
+  })
+
+  it.todo('should parse dtstart with custom parseDateFn', () => {
+    // Pass options.parseDateFn that converts the RFC 3339 string into a Date instance.
+    // Expected: dtstart equals the value returned by parseDateFn instead of the raw string.
   })
 })
 

--- a/src/namespaces/prism/generate/utils.test.ts
+++ b/src/namespaces/prism/generate/utils.test.ts
@@ -4,28 +4,28 @@ import { generateFeed, generateItem } from './utils.js'
 describe('generateFeed', () => {
   it('should generate feed with core properties', () => {
     const value = {
-      publicationName: 'Nature',
-      issn: '0028-0836',
-      eIssn: '1476-4687',
+      publicationName: 'Journal of Examples',
+      issn: '1234-5678',
+      eIssn: '8765-4321',
       volume: '615',
       number: '7952',
       publicationDates: [new Date('2023-03-15T00:00:00Z')],
       aggregationType: 'journal',
       publishingFrequency: 'weekly',
-      urls: ['https://www.nature.com'],
+      urls: ['https://journal.example.com'],
       teasers: ['A short promotional description'],
       keywords: ['science', 'research'],
     }
     const expected = {
-      'prism:publicationName': 'Nature',
-      'prism:issn': '0028-0836',
-      'prism:eIssn': '1476-4687',
+      'prism:publicationName': 'Journal of Examples',
+      'prism:issn': '1234-5678',
+      'prism:eIssn': '8765-4321',
       'prism:volume': '615',
       'prism:number': '7952',
       'prism:publicationDate': ['2023-03-15T00:00:00.000Z'],
       'prism:aggregationType': 'journal',
       'prism:publishingFrequency': 'weekly',
-      'prism:url': ['https://www.nature.com'],
+      'prism:url': ['https://journal.example.com'],
       'prism:teaser': ['A short promotional description'],
       'prism:keyword': ['science', 'research'],
     }
@@ -218,13 +218,13 @@ describe('generateFeed', () => {
     const value = {
       edition: 'International',
       contentType: 'article',
-      alternateTitles: ['Nature Journal', 'Nature Magazine'],
+      alternateTitles: ['Example Journal', 'Example Magazine'],
       subtitles: ['The International Weekly Journal of Science'],
     }
     const expected = {
       'prism:edition': 'International',
       'prism:contentType': 'article',
-      'prism:alternateTitle': ['Nature Journal', 'Nature Magazine'],
+      'prism:alternateTitle': ['Example Journal', 'Example Magazine'],
       'prism:subtitle': ['The International Weekly Journal of Science'],
     }
 
@@ -235,12 +235,12 @@ describe('generateFeed', () => {
     const value = {
       bookEditions: ['First Edition', 'Second Edition'],
       nationalCatalogNumber: 'NC12345',
-      productCodes: ['NAT-2023-615', 'NAT-2023-616'],
+      productCodes: ['EXJ-2023-615', 'EXJ-2023-616'],
     }
     const expected = {
       'prism:bookEdition': ['First Edition', 'Second Edition'],
       'prism:nationalCatalogNumber': 'NC12345',
-      'prism:productCode': ['NAT-2023-615', 'NAT-2023-616'],
+      'prism:productCode': ['EXJ-2023-615', 'EXJ-2023-616'],
     }
 
     expect(generateFeed(value)).toEqual(expected)
@@ -265,15 +265,15 @@ describe('generateFeed', () => {
 
   it('should generate feed with organization and entity fields', () => {
     const value = {
-      corporateEntities: ['Springer Nature', 'Nature Research'],
-      distributor: 'Nature Publishing Group',
-      organizations: ['Nature Research'],
+      corporateEntities: ['Example Publishing', 'Example Research'],
+      distributor: 'Example Distribution Group',
+      organizations: ['Example Research'],
       persons: ['Dr. Jane Smith', 'Dr. John Doe'],
     }
     const expected = {
-      'prism:corporateEntity': ['Springer Nature', 'Nature Research'],
-      'prism:distributor': 'Nature Publishing Group',
-      'prism:organization': ['Nature Research'],
+      'prism:corporateEntity': ['Example Publishing', 'Example Research'],
+      'prism:distributor': 'Example Distribution Group',
+      'prism:organization': ['Example Research'],
       'prism:person': ['Dr. Jane Smith', 'Dr. John Doe'],
     }
 
@@ -282,15 +282,15 @@ describe('generateFeed', () => {
 
   it('should generate feed with blog and link fields', () => {
     const value = {
-      blogTitle: 'Nature News Blog',
-      blogURL: 'https://www.nature.com/news/blog',
-      links: ['https://www.nature.com/nature'],
+      blogTitle: 'Example News Blog',
+      blogURL: 'https://journal.example.com/news/blog',
+      links: ['https://journal.example.com/journal'],
       ratings: ['A+', 'Excellent'],
     }
     const expected = {
-      'prism:blogTitle': 'Nature News Blog',
-      'prism:blogURL': 'https://www.nature.com/news/blog',
-      'prism:link': ['https://www.nature.com/nature'],
+      'prism:blogTitle': 'Example News Blog',
+      'prism:blogURL': 'https://journal.example.com/news/blog',
+      'prism:link': ['https://journal.example.com/journal'],
       'prism:rating': ['A+', 'Excellent'],
     }
 
@@ -299,12 +299,37 @@ describe('generateFeed', () => {
 
   it('should handle empty strings by omitting them', () => {
     const value = {
-      publicationName: 'Nature',
+      publicationName: 'Journal of Examples',
       issn: '',
       volume: '   ',
     }
     const expected = {
-      'prism:publicationName': 'Nature',
+      'prism:publicationName': 'Journal of Examples',
+    }
+
+    expect(generateFeed(value)).toEqual(expected)
+  })
+
+  it('should filter out empty values from array fields', () => {
+    const value = {
+      keywords: ['science', '', '   '],
+      isbns: ['', '   '],
+    }
+    const expected = {
+      'prism:keyword': ['science'],
+    }
+
+    expect(generateFeed(value)).toEqual(expected)
+  })
+
+  it('should filter out undefined values', () => {
+    const value = {
+      publicationName: 'Journal of Examples',
+      issn: undefined,
+      aggregateIssueNumber: undefined,
+    }
+    const expected = {
+      'prism:publicationName': 'Journal of Examples',
     }
 
     expect(generateFeed(value)).toEqual(expected)
@@ -328,8 +353,8 @@ describe('generateFeed', () => {
 describe('generateItem', () => {
   it('should generate item with core properties', () => {
     const value = {
-      doi: '10.1038/s41586-023-05842-x',
-      urls: ['https://www.nature.com/articles/s41586-023-05842-x'],
+      doi: '10.1234/example-2023-0001',
+      urls: ['https://journal.example.com/articles/example-2023-0001'],
       volume: '615',
       number: '7952',
       startingPage: '425',
@@ -339,8 +364,8 @@ describe('generateItem', () => {
       genres: ['research-article'],
     }
     const expected = {
-      'prism:doi': '10.1038/s41586-023-05842-x',
-      'prism:url': ['https://www.nature.com/articles/s41586-023-05842-x'],
+      'prism:doi': '10.1234/example-2023-0001',
+      'prism:url': ['https://journal.example.com/articles/example-2023-0001'],
       'prism:volume': '615',
       'prism:number': '7952',
       'prism:startingPage': '425',
@@ -571,6 +596,31 @@ describe('generateItem', () => {
       'prism:modificationDate': '2023-03-10T00:00:00.000Z',
       'prism:dateReceived': '2023-01-15T00:00:00.000Z',
       'prism:killDate': '2024-03-15T00:00:00.000Z',
+    }
+
+    expect(generateItem(value)).toEqual(expected)
+  })
+
+  it('should filter out empty values from array fields', () => {
+    const value = {
+      keywords: ['quantum', '', '   '],
+      genres: ['', '   '],
+    }
+    const expected = {
+      'prism:keyword': ['quantum'],
+    }
+
+    expect(generateItem(value)).toEqual(expected)
+  })
+
+  it('should filter out undefined values', () => {
+    const value = {
+      doi: '10.1234/example-2023-0001',
+      volume: undefined,
+      wordCount: undefined,
+    }
+    const expected = {
+      'prism:doi': '10.1234/example-2023-0001',
     }
 
     expect(generateItem(value)).toEqual(expected)

--- a/src/namespaces/prism/parse/utils.test.ts
+++ b/src/namespaces/prism/parse/utils.test.ts
@@ -4,28 +4,28 @@ import { retrieveFeed, retrieveItem } from './utils.js'
 describe('retrieveFeed', () => {
   it('should parse complete feed object with core properties', () => {
     const value = {
-      'prism:publicationname': 'Nature',
-      'prism:issn': '0028-0836',
-      'prism:eissn': '1476-4687',
+      'prism:publicationname': 'Journal of Examples',
+      'prism:issn': '1234-5678',
+      'prism:eissn': '8765-4321',
       'prism:volume': '615',
       'prism:number': '7952',
       'prism:publicationdate': '2023-03-15',
       'prism:aggregationtype': 'journal',
       'prism:publishingfrequency': 'weekly',
-      'prism:url': 'https://www.nature.com',
+      'prism:url': 'https://journal.example.com',
       'prism:teaser': 'A short promotional description',
       'prism:keyword': ['science', 'research'],
     }
     const expected = {
-      publicationName: 'Nature',
-      issn: '0028-0836',
-      eIssn: '1476-4687',
+      publicationName: 'Journal of Examples',
+      issn: '1234-5678',
+      eIssn: '8765-4321',
       volume: '615',
       number: '7952',
       publicationDates: ['2023-03-15'],
       aggregationType: 'journal',
       publishingFrequency: 'weekly',
-      urls: ['https://www.nature.com'],
+      urls: ['https://journal.example.com'],
       teasers: ['A short promotional description'],
       keywords: ['science', 'research'],
     }
@@ -233,13 +233,13 @@ describe('retrieveFeed', () => {
     const value = {
       'prism:edition': 'International',
       'prism:contenttype': 'article',
-      'prism:alternatetitle': ['Nature Journal', 'Nature Magazine'],
+      'prism:alternatetitle': ['Example Journal', 'Example Magazine'],
       'prism:subtitle': ['The International Weekly Journal of Science'],
     }
     const expected = {
       edition: 'International',
       contentType: 'article',
-      alternateTitles: ['Nature Journal', 'Nature Magazine'],
+      alternateTitles: ['Example Journal', 'Example Magazine'],
       subtitles: ['The International Weekly Journal of Science'],
     }
 
@@ -250,12 +250,12 @@ describe('retrieveFeed', () => {
     const value = {
       'prism:bookedition': ['First Edition', 'Second Edition'],
       'prism:nationalcatalognumber': 'NC12345',
-      'prism:productcode': ['NAT-2023-615', 'NAT-2023-616'],
+      'prism:productcode': ['EXJ-2023-615', 'EXJ-2023-616'],
     }
     const expected = {
       bookEditions: ['First Edition', 'Second Edition'],
       nationalCatalogNumber: 'NC12345',
-      productCodes: ['NAT-2023-615', 'NAT-2023-616'],
+      productCodes: ['EXJ-2023-615', 'EXJ-2023-616'],
     }
 
     expect(retrieveFeed(value)).toEqual(expected)
@@ -280,15 +280,15 @@ describe('retrieveFeed', () => {
 
   it('should parse feed with organization and entity fields', () => {
     const value = {
-      'prism:corporateentity': ['Springer Nature', 'Nature Research'],
-      'prism:distributor': 'Nature Publishing Group',
-      'prism:organization': ['Nature Research'],
+      'prism:corporateentity': ['Example Publishing', 'Example Research'],
+      'prism:distributor': 'Example Distribution Group',
+      'prism:organization': ['Example Research'],
       'prism:person': ['Dr. Jane Smith', 'Dr. John Doe'],
     }
     const expected = {
-      corporateEntities: ['Springer Nature', 'Nature Research'],
-      distributor: 'Nature Publishing Group',
-      organizations: ['Nature Research'],
+      corporateEntities: ['Example Publishing', 'Example Research'],
+      distributor: 'Example Distribution Group',
+      organizations: ['Example Research'],
       persons: ['Dr. Jane Smith', 'Dr. John Doe'],
     }
 
@@ -297,15 +297,15 @@ describe('retrieveFeed', () => {
 
   it('should parse feed with blog and link fields', () => {
     const value = {
-      'prism:blogtitle': 'Nature News Blog',
-      'prism:blogurl': 'https://www.nature.com/news/blog',
-      'prism:link': ['https://www.nature.com/nature'],
+      'prism:blogtitle': 'Example News Blog',
+      'prism:blogurl': 'https://journal.example.com/news/blog',
+      'prism:link': ['https://journal.example.com/journal'],
       'prism:rating': ['A+', 'Excellent'],
     }
     const expected = {
-      blogTitle: 'Nature News Blog',
-      blogURL: 'https://www.nature.com/news/blog',
-      links: ['https://www.nature.com/nature'],
+      blogTitle: 'Example News Blog',
+      blogURL: 'https://journal.example.com/news/blog',
+      links: ['https://journal.example.com/journal'],
       ratings: ['A+', 'Excellent'],
     }
 
@@ -314,12 +314,54 @@ describe('retrieveFeed', () => {
 
   it('should handle empty strings by omitting them', () => {
     const value = {
-      'prism:publicationname': 'Nature',
+      'prism:publicationname': 'Journal of Examples',
       'prism:issn': '',
       'prism:volume': '   ',
     }
     const expected = {
-      publicationName: 'Nature',
+      publicationName: 'Journal of Examples',
+    }
+
+    expect(retrieveFeed(value)).toEqual(expected)
+  })
+
+  it('should use first element when singular field is an array', () => {
+    const value = {
+      'prism:publicationname': ['Journal of Examples', 'Second Journal'],
+      'prism:volume': ['615', '616'],
+    }
+    const expected = {
+      publicationName: 'Journal of Examples',
+      volume: '615',
+    }
+
+    expect(retrieveFeed(value)).toEqual(expected)
+  })
+
+  it('should handle coercible values', () => {
+    const value = {
+      'prism:volume': 615,
+      'prism:aggregateissuenumber': '500',
+      'prism:bytecount': 1048576,
+    }
+    const expected = {
+      volume: '615',
+      aggregateIssueNumber: 500,
+      byteCount: 1048576,
+    }
+
+    expect(retrieveFeed(value)).toEqual(expected)
+  })
+
+  it('should handle mixed valid and invalid properties', () => {
+    const value = {
+      'prism:publicationname': 'Journal of Examples',
+      'prism:bytecount': 'not a number',
+      'prism:issn': '',
+      'other:property': 'value',
+    }
+    const expected = {
+      publicationName: 'Journal of Examples',
     }
 
     expect(retrieveFeed(value)).toEqual(expected)
@@ -337,13 +379,19 @@ describe('retrieveFeed', () => {
     expect(retrieveFeed(null)).toBeUndefined()
     expect(retrieveFeed([])).toBeUndefined()
   })
+
+  it.todo('should parse date fields with custom parseDateFn', () => {
+    // Pass options.parseDateFn that converts date strings into Date instances.
+    // Expected: coverDate, publicationDates, creationDate and the other date fields equal
+    // the values returned by parseDateFn instead of the raw strings.
+  })
 })
 
 describe('retrieveItem', () => {
   it('should parse complete item object with core properties', () => {
     const value = {
-      'prism:doi': '10.1038/s41586-023-05842-x',
-      'prism:url': 'https://www.nature.com/articles/s41586-023-05842-x',
+      'prism:doi': '10.1234/example-2023-0001',
+      'prism:url': 'https://journal.example.com/articles/example-2023-0001',
       'prism:volume': '615',
       'prism:number': '7952',
       'prism:startingpage': '425',
@@ -353,8 +401,8 @@ describe('retrieveItem', () => {
       'prism:genre': ['research-article'],
     }
     const expected = {
-      doi: '10.1038/s41586-023-05842-x',
-      urls: ['https://www.nature.com/articles/s41586-023-05842-x'],
+      doi: '10.1234/example-2023-0001',
+      urls: ['https://journal.example.com/articles/example-2023-0001'],
       volume: '615',
       number: '7952',
       startingPage: '425',
@@ -620,6 +668,48 @@ describe('retrieveItem', () => {
     expect(retrieveItem(value)).toEqual(expected)
   })
 
+  it('should use first element when singular field is an array', () => {
+    const value = {
+      'prism:doi': ['10.1234/example-2023-0001', '10.1234/example-2023-0002'],
+      'prism:volume': ['615', '616'],
+    }
+    const expected = {
+      doi: '10.1234/example-2023-0001',
+      volume: '615',
+    }
+
+    expect(retrieveItem(value)).toEqual(expected)
+  })
+
+  it('should handle coercible values', () => {
+    const value = {
+      'prism:volume': 615,
+      'prism:pagecount': '15',
+      'prism:wordcount': 5000,
+    }
+    const expected = {
+      volume: '615',
+      pageCount: 15,
+      wordCount: 5000,
+    }
+
+    expect(retrieveItem(value)).toEqual(expected)
+  })
+
+  it('should handle mixed valid and invalid properties', () => {
+    const value = {
+      'prism:doi': '10.1234/example-2023-0001',
+      'prism:wordcount': 'not a number',
+      'prism:volume': '',
+      'other:property': 'value',
+    }
+    const expected = {
+      doi: '10.1234/example-2023-0001',
+    }
+
+    expect(retrieveItem(value)).toEqual(expected)
+  })
+
   it('should return undefined for empty object', () => {
     const value = {}
 
@@ -631,5 +721,11 @@ describe('retrieveItem', () => {
     expect(retrieveItem(undefined)).toBeUndefined()
     expect(retrieveItem(null)).toBeUndefined()
     expect(retrieveItem([])).toBeUndefined()
+  })
+
+  it.todo('should parse date fields with custom parseDateFn', () => {
+    // Pass options.parseDateFn that converts date strings into Date instances.
+    // Expected: publicationDates, creationDate, modificationDate and the other date fields
+    // equal the values returned by parseDateFn instead of the raw strings.
   })
 })

--- a/src/namespaces/psc/parse/utils.test.ts
+++ b/src/namespaces/psc/parse/utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'bun:test'
-import { parseChapter, retrieveItem } from './utils.js'
+import { parseChapter, parseChapters, retrieveItem } from './utils.js'
 
 describe('parseChapter', () => {
   it('should parse complete chapter with all attributes', () => {
@@ -86,6 +86,72 @@ describe('parseChapter', () => {
     }
 
     expect(parseChapter(value)).toEqual(expected)
+  })
+})
+
+describe('parseChapters', () => {
+  it('should parse multiple chapters', () => {
+    const value = {
+      'psc:chapter': [
+        {
+          '@start': '00:00:00.000',
+          '@title': 'Introduction',
+        },
+        {
+          '@start': '00:05:30.000',
+          '@title': 'Chapter 1',
+        },
+      ],
+    }
+    const expected = [
+      {
+        start: '00:00:00.000',
+        title: 'Introduction',
+      },
+      {
+        start: '00:05:30.000',
+        title: 'Chapter 1',
+      },
+    ]
+
+    expect(parseChapters(value)).toEqual(expected)
+  })
+
+  it('should parse single chapter into an array', () => {
+    const value = {
+      'psc:chapter': {
+        '@start': '00:00:00.000',
+        '@title': 'Single Chapter',
+      },
+    }
+    const expected = [
+      {
+        start: '00:00:00.000',
+        title: 'Single Chapter',
+      },
+    ]
+
+    expect(parseChapters(value)).toEqual(expected)
+  })
+
+  it('should return undefined when psc:chapter is missing', () => {
+    const value = {
+      'other:element': 'value',
+    }
+
+    expect(parseChapters(value)).toBeUndefined()
+  })
+
+  it('should return undefined for empty object', () => {
+    const value = {}
+
+    expect(parseChapters(value)).toBeUndefined()
+  })
+
+  it('should return undefined for non-object input', () => {
+    expect(parseChapters('not an object')).toBeUndefined()
+    expect(parseChapters(null)).toBeUndefined()
+    expect(parseChapters(undefined)).toBeUndefined()
   })
 })
 

--- a/src/namespaces/rawvoice/generate/utils.test.ts
+++ b/src/namespaces/rawvoice/generate/utils.test.ts
@@ -1,5 +1,15 @@
 import { describe, expect, it } from 'bun:test'
-import { generateFeed, generateItem, generateMetamark } from './utils.js'
+import {
+  generateAlternateEnclosure,
+  generateDonate,
+  generateFeed,
+  generateItem,
+  generateLiveStream,
+  generateMetamark,
+  generatePoster,
+  generateRating,
+  generateSubscribe,
+} from './utils.js'
 
 describe('generateItem', () => {
   it('should generate valid item object with all properties', () => {
@@ -210,12 +220,300 @@ describe('generateItem', () => {
 })
 
 describe('generateMetamark', () => {
+  it('should generate metamark with all properties', () => {
+    const value = {
+      type: 'ad',
+      link: 'https://example.com/ad',
+      position: 120,
+      duration: 30,
+      value: 'ad-123456',
+    }
+    const expected = {
+      '#text': 'ad-123456',
+      '@type': 'ad',
+      '@link': 'https://example.com/ad',
+      '@position': 120,
+      '@duration': 30,
+    }
+
+    expect(generateMetamark(value)).toEqual(expected)
+  })
+
+  it('should generate metamark with minimal properties', () => {
+    const value = {
+      type: 'comment',
+      position: 60,
+    }
+    const expected = {
+      '@type': 'comment',
+      '@position': 60,
+    }
+
+    expect(generateMetamark(value)).toEqual(expected)
+  })
+
+  it('should generate metamark with special characters in value', () => {
+    const value = {
+      type: 'comment',
+      value: 'Q&A segment',
+    }
+    const expected = {
+      '#cdata': 'Q&A segment',
+      '@type': 'comment',
+    }
+
+    expect(generateMetamark(value)).toEqual(expected)
+  })
+
+  it('should return undefined for empty object', () => {
+    const value = {}
+
+    expect(generateMetamark(value)).toBeUndefined()
+  })
+
   it('should return undefined for non-object input', () => {
     expect(generateMetamark(undefined)).toBeUndefined()
     // @ts-expect-error: This is for testing purposes.
     expect(generateMetamark('string')).toBeUndefined()
     // @ts-expect-error: This is for testing purposes.
     expect(generateMetamark(null)).toBeUndefined()
+  })
+})
+
+describe('generateRating', () => {
+  it('should generate rating with all properties', () => {
+    const value = {
+      value: 'TV-14',
+      tv: 'TV-14',
+      movie: 'PG-13',
+    }
+    const expected = {
+      '#text': 'TV-14',
+      '@tv': 'TV-14',
+      '@movie': 'PG-13',
+    }
+
+    expect(generateRating(value)).toEqual(expected)
+  })
+
+  it('should generate rating with minimal properties', () => {
+    const value = {
+      value: 'TV-G',
+    }
+    const expected = {
+      '#text': 'TV-G',
+    }
+
+    expect(generateRating(value)).toEqual(expected)
+  })
+
+  it('should return undefined for empty object', () => {
+    const value = {}
+
+    expect(generateRating(value)).toBeUndefined()
+  })
+
+  it('should return undefined for non-object input', () => {
+    expect(generateRating(undefined)).toBeUndefined()
+    // @ts-expect-error: This is for testing purposes.
+    expect(generateRating('string')).toBeUndefined()
+    // @ts-expect-error: This is for testing purposes.
+    expect(generateRating(null)).toBeUndefined()
+  })
+})
+
+describe('generateLiveStream', () => {
+  it('should generate live stream with all properties', () => {
+    const value = {
+      url: 'https://live.example.com/stream.m3u8',
+      schedule: new Date('Mon, 15 Jan 2024 10:00:00 GMT'),
+      duration: '3600',
+      type: 'audio',
+    }
+    const expected = {
+      '#text': 'https://live.example.com/stream.m3u8',
+      '@schedule': 'Mon, 15 Jan 2024 10:00:00 GMT',
+      '@duration': '3600',
+      '@type': 'audio',
+    }
+
+    expect(generateLiveStream(value)).toEqual(expected)
+  })
+
+  it('should generate live stream with minimal properties', () => {
+    const value = {
+      url: 'https://live.example.com/stream.m3u8',
+    }
+    const expected = {
+      '#text': 'https://live.example.com/stream.m3u8',
+    }
+
+    expect(generateLiveStream(value)).toEqual(expected)
+  })
+
+  it('should return undefined for empty object', () => {
+    const value = {}
+
+    expect(generateLiveStream(value)).toBeUndefined()
+  })
+
+  it('should return undefined for non-object input', () => {
+    expect(generateLiveStream(undefined)).toBeUndefined()
+    // @ts-expect-error: This is for testing purposes.
+    expect(generateLiveStream('string')).toBeUndefined()
+    // @ts-expect-error: This is for testing purposes.
+    expect(generateLiveStream(null)).toBeUndefined()
+  })
+})
+
+describe('generatePoster', () => {
+  it('should generate poster with url', () => {
+    const value = {
+      url: 'https://example.com/poster.jpg',
+    }
+    const expected = {
+      '@url': 'https://example.com/poster.jpg',
+    }
+
+    expect(generatePoster(value)).toEqual(expected)
+  })
+
+  it('should return undefined for empty object', () => {
+    const value = {}
+
+    expect(generatePoster(value)).toBeUndefined()
+  })
+
+  it('should return undefined for non-object input', () => {
+    expect(generatePoster(undefined)).toBeUndefined()
+    // @ts-expect-error: This is for testing purposes.
+    expect(generatePoster('string')).toBeUndefined()
+    // @ts-expect-error: This is for testing purposes.
+    expect(generatePoster(null)).toBeUndefined()
+  })
+})
+
+describe('generateAlternateEnclosure', () => {
+  it('should generate alternate enclosure with all properties', () => {
+    const value = {
+      src: 'https://example.com/video.webm',
+      type: 'video/webm',
+      length: 1024,
+    }
+    const expected = {
+      '@src': 'https://example.com/video.webm',
+      '@type': 'video/webm',
+      '@length': 1024,
+    }
+
+    expect(generateAlternateEnclosure(value)).toEqual(expected)
+  })
+
+  it('should generate alternate enclosure with minimal properties', () => {
+    const value = {
+      src: 'https://example.com/video.mp4',
+    }
+    const expected = {
+      '@src': 'https://example.com/video.mp4',
+    }
+
+    expect(generateAlternateEnclosure(value)).toEqual(expected)
+  })
+
+  it('should return undefined for empty object', () => {
+    const value = {}
+
+    expect(generateAlternateEnclosure(value)).toBeUndefined()
+  })
+
+  it('should return undefined for non-object input', () => {
+    expect(generateAlternateEnclosure(undefined)).toBeUndefined()
+    expect(generateAlternateEnclosure('string')).toBeUndefined()
+    // @ts-expect-error: This is for testing purposes.
+    expect(generateAlternateEnclosure(null)).toBeUndefined()
+  })
+})
+
+describe('generateSubscribe', () => {
+  it('should generate subscribe with multiple attributes', () => {
+    const value = {
+      feed: 'https://example.com/feed/podcast/',
+      itunes: 'https://itunes.apple.com/us/podcast/example/id123',
+      spotify: 'https://open.spotify.com/show/example123',
+    }
+    const expected = {
+      '@feed': 'https://example.com/feed/podcast/',
+      '@itunes': 'https://itunes.apple.com/us/podcast/example/id123',
+      '@spotify': 'https://open.spotify.com/show/example123',
+    }
+
+    expect(generateSubscribe(value)).toEqual(expected)
+  })
+
+  it('should filter out empty attribute values', () => {
+    const value = {
+      feed: 'https://example.com/feed/',
+      itunes: '',
+    }
+    const expected = {
+      '@feed': 'https://example.com/feed/',
+    }
+
+    expect(generateSubscribe(value)).toEqual(expected)
+  })
+
+  it('should return undefined for empty object', () => {
+    const value = {}
+
+    expect(generateSubscribe(value)).toBeUndefined()
+  })
+
+  it('should return undefined for non-object input', () => {
+    expect(generateSubscribe(undefined)).toBeUndefined()
+    // @ts-expect-error: This is for testing purposes.
+    expect(generateSubscribe('string')).toBeUndefined()
+    // @ts-expect-error: This is for testing purposes.
+    expect(generateSubscribe(null)).toBeUndefined()
+  })
+})
+
+describe('generateDonate', () => {
+  it('should generate donate with all properties', () => {
+    const value = {
+      href: 'https://example.com/donate',
+      value: 'Support the show',
+    }
+    const expected = {
+      '#text': 'Support the show',
+      '@href': 'https://example.com/donate',
+    }
+
+    expect(generateDonate(value)).toEqual(expected)
+  })
+
+  it('should generate donate with minimal properties', () => {
+    const value = {
+      href: 'https://example.com/donate',
+    }
+    const expected = {
+      '@href': 'https://example.com/donate',
+    }
+
+    expect(generateDonate(value)).toEqual(expected)
+  })
+
+  it('should return undefined for empty object', () => {
+    const value = {}
+
+    expect(generateDonate(value)).toBeUndefined()
+  })
+
+  it('should return undefined for non-object input', () => {
+    expect(generateDonate(undefined)).toBeUndefined()
+    // @ts-expect-error: This is for testing purposes.
+    expect(generateDonate('string')).toBeUndefined()
+    // @ts-expect-error: This is for testing purposes.
+    expect(generateDonate(null)).toBeUndefined()
   })
 })
 

--- a/src/namespaces/rawvoice/parse/utils.test.ts
+++ b/src/namespaces/rawvoice/parse/utils.test.ts
@@ -1,5 +1,15 @@
 import { describe, expect, it } from 'bun:test'
-import { parseMetamark, retrieveFeed, retrieveItem } from './utils.js'
+import {
+  parseAlternateEnclosure,
+  parseDonate,
+  parseLiveStream,
+  parseMetamark,
+  parsePoster,
+  parseRating,
+  parseSubscribe,
+  retrieveFeed,
+  retrieveItem,
+} from './utils.js'
 
 describe('retrieveItem', () => {
   const expectedFull = {
@@ -111,7 +121,7 @@ describe('retrieveItem', () => {
 
   it('should handle empty strings', () => {
     const value = {
-      'rawvoice:isHd': '',
+      'rawvoice:ishd': '',
       'rawvoice:embed': { '#text': 'content' },
     }
     const expected = {
@@ -123,7 +133,7 @@ describe('retrieveItem', () => {
 
   it('should handle whitespace-only strings', () => {
     const value = {
-      'rawvoice:isHd': '   ',
+      'rawvoice:ishd': '   ',
     }
 
     expect(retrieveItem(value)).toBeUndefined()
@@ -626,9 +636,316 @@ describe('retrieveFeed', () => {
 })
 
 describe('parseMetamark', () => {
+  it('should parse metamark with all properties', () => {
+    const value = {
+      '#text': 'ad-123456',
+      '@type': 'ad',
+      '@link': 'https://example.com/ad',
+      '@position': 120,
+      '@duration': 30,
+    }
+    const expected = {
+      type: 'ad',
+      link: 'https://example.com/ad',
+      position: 120,
+      duration: 30,
+      value: 'ad-123456',
+    }
+
+    expect(parseMetamark(value)).toEqual(expected)
+  })
+
+  it('should parse metamark with minimal properties', () => {
+    const value = {
+      '@type': 'comment',
+      '@position': 60,
+    }
+    const expected = {
+      type: 'comment',
+      position: 60,
+    }
+
+    expect(parseMetamark(value)).toEqual(expected)
+  })
+
+  it('should handle coercible numeric string attributes', () => {
+    const value = {
+      '@type': 'video',
+      '@position': '180',
+      '@duration': '45',
+    }
+    const expected = {
+      type: 'video',
+      position: 180,
+      duration: 45,
+    }
+
+    expect(parseMetamark(value)).toEqual(expected)
+  })
+
+  it('should return undefined for empty object', () => {
+    const value = {}
+
+    expect(parseMetamark(value)).toBeUndefined()
+  })
+
   it('should return undefined for non-object input', () => {
     expect(parseMetamark(undefined)).toBeUndefined()
     expect(parseMetamark('string')).toBeUndefined()
     expect(parseMetamark(null)).toBeUndefined()
+  })
+})
+
+describe('parseRating', () => {
+  it('should parse rating with all properties', () => {
+    const value = {
+      '#text': 'TV-14',
+      '@tv': 'TV-14',
+      '@movie': 'PG-13',
+    }
+    const expected = {
+      value: 'TV-14',
+      tv: 'TV-14',
+      movie: 'PG-13',
+    }
+
+    expect(parseRating(value)).toEqual(expected)
+  })
+
+  it('should parse rating from plain string', () => {
+    const value = 'TV-G'
+    const expected = {
+      value: 'TV-G',
+    }
+
+    expect(parseRating(value)).toEqual(expected)
+  })
+
+  it('should return undefined for empty object', () => {
+    const value = {}
+
+    expect(parseRating(value)).toBeUndefined()
+  })
+
+  it('should return undefined for null and undefined inputs', () => {
+    expect(parseRating(undefined)).toBeUndefined()
+    expect(parseRating(null)).toBeUndefined()
+  })
+})
+
+describe('parseLiveStream', () => {
+  it('should parse live stream with all properties', () => {
+    const value = {
+      '#text': 'https://live.example.com/stream.m3u8',
+      '@schedule': 'Mon, 15 Jan 2024 10:00:00 GMT',
+      '@duration': '3600',
+      '@type': 'audio',
+    }
+    const expected = {
+      url: 'https://live.example.com/stream.m3u8',
+      schedule: 'Mon, 15 Jan 2024 10:00:00 GMT',
+      duration: '3600',
+      type: 'audio',
+    }
+
+    expect(parseLiveStream(value)).toEqual(expected)
+  })
+
+  it('should parse live stream from plain string', () => {
+    const value = 'https://live.example.com/stream.m3u8'
+    const expected = {
+      url: 'https://live.example.com/stream.m3u8',
+    }
+
+    expect(parseLiveStream(value)).toEqual(expected)
+  })
+
+  it('should return undefined for empty object', () => {
+    const value = {}
+
+    expect(parseLiveStream(value)).toBeUndefined()
+  })
+
+  it('should return undefined for null and undefined inputs', () => {
+    expect(parseLiveStream(undefined)).toBeUndefined()
+    expect(parseLiveStream(null)).toBeUndefined()
+  })
+
+  it.todo('should parse schedule with custom parseDateFn', () => {
+    // Pass options.parseDateFn that converts the RFC 822 string into a Date instance.
+    // Expected: schedule equals the value returned by parseDateFn instead of the raw string.
+  })
+})
+
+describe('parsePoster', () => {
+  it('should parse poster with url', () => {
+    const value = {
+      '@url': 'https://example.com/poster.jpg',
+    }
+    const expected = {
+      url: 'https://example.com/poster.jpg',
+    }
+
+    expect(parsePoster(value)).toEqual(expected)
+  })
+
+  it('should return undefined for empty object', () => {
+    const value = {}
+
+    expect(parsePoster(value)).toBeUndefined()
+  })
+
+  it('should return undefined for non-object inputs', () => {
+    expect(parsePoster('not an object')).toBeUndefined()
+    expect(parsePoster(undefined)).toBeUndefined()
+    expect(parsePoster(null)).toBeUndefined()
+    expect(parsePoster([])).toBeUndefined()
+  })
+})
+
+describe('parseAlternateEnclosure', () => {
+  it('should parse alternate enclosure with all properties', () => {
+    const value = {
+      '@src': 'https://example.com/video.webm',
+      '@type': 'video/webm',
+      '@length': 1024,
+    }
+    const expected = {
+      src: 'https://example.com/video.webm',
+      type: 'video/webm',
+      length: 1024,
+    }
+
+    expect(parseAlternateEnclosure(value)).toEqual(expected)
+  })
+
+  it('should parse alternate enclosure with minimal properties', () => {
+    const value = {
+      '@src': 'https://example.com/video.mp4',
+    }
+    const expected = {
+      src: 'https://example.com/video.mp4',
+    }
+
+    expect(parseAlternateEnclosure(value)).toEqual(expected)
+  })
+
+  it('should handle coercible numeric string length', () => {
+    const value = {
+      '@src': 'https://example.com/video.mp4',
+      '@length': '2048',
+    }
+    const expected = {
+      src: 'https://example.com/video.mp4',
+      length: 2048,
+    }
+
+    expect(parseAlternateEnclosure(value)).toEqual(expected)
+  })
+
+  it('should return undefined for empty object', () => {
+    const value = {}
+
+    expect(parseAlternateEnclosure(value)).toBeUndefined()
+  })
+
+  it('should return undefined for non-object inputs', () => {
+    expect(parseAlternateEnclosure('not an object')).toBeUndefined()
+    expect(parseAlternateEnclosure(undefined)).toBeUndefined()
+    expect(parseAlternateEnclosure(null)).toBeUndefined()
+    expect(parseAlternateEnclosure([])).toBeUndefined()
+  })
+})
+
+describe('parseSubscribe', () => {
+  it('should parse subscribe with multiple attributes', () => {
+    const value = {
+      '@feed': 'https://example.com/feed/podcast/',
+      '@itunes': 'https://itunes.apple.com/us/podcast/example/id123',
+      '@spotify': 'https://open.spotify.com/show/example123',
+    }
+    const expected = {
+      feed: 'https://example.com/feed/podcast/',
+      itunes: 'https://itunes.apple.com/us/podcast/example/id123',
+      spotify: 'https://open.spotify.com/show/example123',
+    }
+
+    expect(parseSubscribe(value)).toEqual(expected)
+  })
+
+  it('should ignore non-attribute keys', () => {
+    const value = {
+      '#text': 'Subscribe here',
+      '@feed': 'https://example.com/feed/',
+    }
+    const expected = {
+      feed: 'https://example.com/feed/',
+    }
+
+    expect(parseSubscribe(value)).toEqual(expected)
+  })
+
+  it('should filter out empty attribute values', () => {
+    const value = {
+      '@feed': 'https://example.com/feed/',
+      '@itunes': '',
+    }
+    const expected = {
+      feed: 'https://example.com/feed/',
+    }
+
+    expect(parseSubscribe(value)).toEqual(expected)
+  })
+
+  it('should return undefined for empty object', () => {
+    const value = {}
+
+    expect(parseSubscribe(value)).toBeUndefined()
+  })
+
+  it('should return undefined for non-object inputs', () => {
+    expect(parseSubscribe('not an object')).toBeUndefined()
+    expect(parseSubscribe(undefined)).toBeUndefined()
+    expect(parseSubscribe(null)).toBeUndefined()
+    expect(parseSubscribe([])).toBeUndefined()
+  })
+})
+
+describe('parseDonate', () => {
+  it('should parse donate with all properties', () => {
+    const value = {
+      '#text': 'Support the show',
+      '@href': 'https://example.com/donate',
+    }
+    const expected = {
+      href: 'https://example.com/donate',
+      value: 'Support the show',
+    }
+
+    expect(parseDonate(value)).toEqual(expected)
+  })
+
+  it('should parse donate with minimal properties', () => {
+    const value = {
+      '@href': 'https://example.com/donate',
+    }
+    const expected = {
+      href: 'https://example.com/donate',
+    }
+
+    expect(parseDonate(value)).toEqual(expected)
+  })
+
+  it('should return undefined for empty object', () => {
+    const value = {}
+
+    expect(parseDonate(value)).toBeUndefined()
+  })
+
+  it('should return undefined for non-object inputs', () => {
+    expect(parseDonate('not an object')).toBeUndefined()
+    expect(parseDonate(undefined)).toBeUndefined()
+    expect(parseDonate(null)).toBeUndefined()
+    expect(parseDonate([])).toBeUndefined()
   })
 })

--- a/src/namespaces/rdf/parse/utils.test.ts
+++ b/src/namespaces/rdf/parse/utils.test.ts
@@ -49,6 +49,17 @@ describe('retrieveAbout', () => {
     expect(retrieveAbout(value)).toEqual(expected)
   })
 
+  it('should handle coercible number values', () => {
+    const value = {
+      '@about': 12345,
+    }
+    const expected = {
+      about: '12345',
+    }
+
+    expect(retrieveAbout(value)).toEqual(expected)
+  })
+
   it('should handle empty strings', () => {
     const value = {
       '@about': '',

--- a/src/namespaces/source/generate/utils.test.ts
+++ b/src/namespaces/source/generate/utils.test.ts
@@ -35,7 +35,6 @@ describe('generateAccount', () => {
     const value = {
       service: 'twitter',
     }
-
     const expected = {
       '@service': 'twitter',
     }
@@ -53,17 +52,6 @@ describe('generateAccount', () => {
 })
 
 describe('generateLikes', () => {
-  it('should generate likes with only server', () => {
-    const value = {
-      server: 'http://likes.example.com/',
-    }
-    const expected = {
-      '@server': 'http://likes.example.com/',
-    }
-
-    expect(generateLikes(value)).toEqual(expected)
-  })
-
   it('should generate likes with only server', () => {
     const value = {
       server: 'http://likes.example.com/',

--- a/src/namespaces/source/parse/utils.test.ts
+++ b/src/namespaces/source/parse/utils.test.ts
@@ -81,6 +81,13 @@ describe('parseLikes', () => {
 
     expect(parseLikes(value)).toBeUndefined()
   })
+
+  it('should return undefined for non-object inputs', () => {
+    expect(parseLikes('not an object')).toBeUndefined()
+    expect(parseLikes(undefined)).toBeUndefined()
+    expect(parseLikes(null)).toBeUndefined()
+    expect(parseLikes([])).toBeUndefined()
+  })
 })
 
 describe('parseArchive', () => {
@@ -138,6 +145,19 @@ describe('parseArchive', () => {
     }
 
     expect(parseArchive(value)).toEqual(expected)
+  })
+
+  it('should return undefined for empty object', () => {
+    const value = {}
+
+    expect(parseArchive(value)).toBeUndefined()
+  })
+
+  it('should return undefined for non-object inputs', () => {
+    expect(parseArchive('not an object')).toBeUndefined()
+    expect(parseArchive(undefined)).toBeUndefined()
+    expect(parseArchive(null)).toBeUndefined()
+    expect(parseArchive([])).toBeUndefined()
   })
 })
 

--- a/src/namespaces/spotify/generate/utils.test.ts
+++ b/src/namespaces/spotify/generate/utils.test.ts
@@ -97,6 +97,12 @@ describe('generateSandbox', () => {
     expect(generateSandbox(value)).toEqual(expected)
   })
 
+  it.todo('should return undefined for empty object', () => {
+    // generateSandbox({}) currently returns { '@enabled': undefined } because the generator
+    // skips trimObject, unlike every sibling generator in this file. Expected: undefined for
+    // an empty object. Pin this once the generator trims its value.
+  })
+
   it('should return undefined for non-object input', () => {
     // @ts-expect-error: This is for testing purposes.
     expect(generateSandbox(null)).toBeUndefined()
@@ -342,38 +348,30 @@ describe('generateFeed', () => {
     expect(generateFeed(null)).toBeUndefined()
   })
 
-  it('should handle country codes correctly', () => {
-    const countryCodes = ['US', 'GB', 'CA', 'AU', 'DE', 'FR', 'JP']
+  const countryCases: Array<[string, { 'spotify:countryOfOrigin': string }]> = [
+    ['US', { 'spotify:countryOfOrigin': 'US' }],
+    ['GB', { 'spotify:countryOfOrigin': 'GB' }],
+    ['CA', { 'spotify:countryOfOrigin': 'CA' }],
+    ['AU', { 'spotify:countryOfOrigin': 'AU' }],
+    ['DE', { 'spotify:countryOfOrigin': 'DE' }],
+    ['FR', { 'spotify:countryOfOrigin': 'FR' }],
+    ['JP', { 'spotify:countryOfOrigin': 'JP' }],
+  ]
 
-    for (const code of countryCodes) {
-      const value = {
-        countryOfOrigin: code,
-      }
-      const expected = {
-        'spotify:countryOfOrigin': code,
-      }
-
-      expect(generateFeed(value)).toEqual(expected)
-    }
+  it.each(countryCases)('should handle country code %s', (countryOfOrigin, expected) => {
+    expect(generateFeed({ countryOfOrigin })).toEqual(expected)
   })
 
-  it('should handle various recentCount limit values', () => {
-    const limits = [1, 5, 10, 50, 100]
+  const limitCases: Array<[number, { 'spotify:limit': { '@recentCount': number } }]> = [
+    [1, { 'spotify:limit': { '@recentCount': 1 } }],
+    [5, { 'spotify:limit': { '@recentCount': 5 } }],
+    [10, { 'spotify:limit': { '@recentCount': 10 } }],
+    [50, { 'spotify:limit': { '@recentCount': 50 } }],
+    [100, { 'spotify:limit': { '@recentCount': 100 } }],
+  ]
 
-    for (const count of limits) {
-      const value = {
-        limit: {
-          recentCount: count,
-        },
-      }
-      const expected = {
-        'spotify:limit': {
-          '@recentCount': count,
-        },
-      }
-
-      expect(generateFeed(value)).toEqual(expected)
-    }
+  it.each(limitCases)('should handle recentCount limit value %s', (recentCount, expected) => {
+    expect(generateFeed({ limit: { recentCount } })).toEqual(expected)
   })
 
   it('should handle limit with undefined recentCount', () => {

--- a/src/namespaces/sy/parse/utils.test.ts
+++ b/src/namespaces/sy/parse/utils.test.ts
@@ -134,4 +134,9 @@ describe('retrieveFeed', () => {
 
     expect(retrieveFeed(value)).toEqual(expected)
   })
+
+  it.todo('should parse updateBase with custom parseDateFn', () => {
+    // Pass options.parseDateFn that converts the date string into a Date instance.
+    // Expected: updateBase equals the value returned by parseDateFn instead of the raw string.
+  })
 })

--- a/src/namespaces/thr/generate/utils.test.ts
+++ b/src/namespaces/thr/generate/utils.test.ts
@@ -30,6 +30,25 @@ describe('generateInReplyTo', () => {
     expect(generateInReplyTo(value)).toEqual(expected)
   })
 
+  it('should generate in-reply-to with partial properties', () => {
+    const value = {
+      href: 'http://example.com/original-post#comment-1',
+      type: 'text/html',
+    }
+    const expected = {
+      '@href': 'http://example.com/original-post#comment-1',
+      '@type': 'text/html',
+    }
+
+    expect(generateInReplyTo(value)).toEqual(expected)
+  })
+
+  it('should handle empty object', () => {
+    const value = {}
+
+    expect(generateInReplyTo(value)).toBeUndefined()
+  })
+
   it('should handle undefined input', () => {
     expect(generateInReplyTo(undefined)).toBeUndefined()
   })
@@ -47,6 +66,34 @@ describe('generateLink', () => {
     }
 
     expect(generateLink(value)).toEqual(expected)
+  })
+
+  it('should generate link attributes with only count', () => {
+    const value = {
+      count: 25,
+    }
+    const expected = {
+      '@thr:count': 25,
+    }
+
+    expect(generateLink(value)).toEqual(expected)
+  })
+
+  it('should generate link attributes with only updated', () => {
+    const value = {
+      updated: new Date('2023-12-15T14:30:00Z'),
+    }
+    const expected = {
+      '@thr:updated': '2023-12-15T14:30:00.000Z',
+    }
+
+    expect(generateLink(value)).toEqual(expected)
+  })
+
+  it('should handle empty object', () => {
+    const value = {}
+
+    expect(generateLink(value)).toBeUndefined()
   })
 
   it('should handle undefined input', () => {
@@ -105,6 +152,12 @@ describe('generateItem', () => {
     }
 
     expect(generateItem(value)).toEqual(expected)
+  })
+
+  it('should handle empty object', () => {
+    const value = {}
+
+    expect(generateItem(value)).toBeUndefined()
   })
 
   it('should handle undefined input', () => {

--- a/src/namespaces/thr/parse/utils.test.ts
+++ b/src/namespaces/thr/parse/utils.test.ts
@@ -177,6 +177,11 @@ describe('retrieveLink', () => {
     expect(retrieveLink(null)).toBeUndefined()
     expect(retrieveLink([])).toBeUndefined()
   })
+
+  it.todo('should parse updated with custom parseDateFn', () => {
+    // Pass options.parseDateFn that converts the RFC 3339 string into a Date instance.
+    // Expected: updated equals the value returned by parseDateFn instead of the raw string.
+  })
 })
 
 describe('retrieveItem', () => {

--- a/src/namespaces/trackback/generate/utils.test.ts
+++ b/src/namespaces/trackback/generate/utils.test.ts
@@ -5,11 +5,17 @@ describe('generateItem', () => {
   it('should generate item with all properties', () => {
     const value = {
       ping: 'https://example.com/trackback/123',
-      abouts: ['https://blog1.com/trackback/456', 'https://blog2.com/trackback/789'],
+      abouts: [
+        'https://blog1.example.com/trackback/456',
+        'https://blog2.example.com/trackback/789',
+      ],
     }
     const expected = {
       'trackback:ping': 'https://example.com/trackback/123',
-      'trackback:about': ['https://blog1.com/trackback/456', 'https://blog2.com/trackback/789'],
+      'trackback:about': [
+        'https://blog1.example.com/trackback/456',
+        'https://blog2.example.com/trackback/789',
+      ],
     }
 
     expect(generateItem(value)).toEqual(expected)
@@ -28,21 +34,10 @@ describe('generateItem', () => {
 
   it('should generate item with only about property', () => {
     const value = {
-      abouts: ['https://blog1.com/trackback/456'],
+      abouts: ['https://blog1.example.com/trackback/456'],
     }
     const expected = {
-      'trackback:about': ['https://blog1.com/trackback/456'],
-    }
-
-    expect(generateItem(value)).toEqual(expected)
-  })
-
-  it('should generate item with single about value', () => {
-    const value = {
-      abouts: ['https://blog1.com/trackback/456'],
-    }
-    const expected = {
-      'trackback:about': ['https://blog1.com/trackback/456'],
+      'trackback:about': ['https://blog1.example.com/trackback/456'],
     }
 
     expect(generateItem(value)).toEqual(expected)
@@ -51,16 +46,16 @@ describe('generateItem', () => {
   it('should generate item with multiple about values', () => {
     const value = {
       abouts: [
-        'https://blog1.com/trackback/456',
-        'https://blog2.com/trackback/789',
-        'https://blog3.com/trackback/abc',
+        'https://blog1.example.com/trackback/456',
+        'https://blog2.example.com/trackback/789',
+        'https://blog3.example.com/trackback/abc',
       ],
     }
     const expected = {
       'trackback:about': [
-        'https://blog1.com/trackback/456',
-        'https://blog2.com/trackback/789',
-        'https://blog3.com/trackback/abc',
+        'https://blog1.example.com/trackback/456',
+        'https://blog2.example.com/trackback/789',
+        'https://blog3.example.com/trackback/abc',
       ],
     }
 
@@ -80,12 +75,15 @@ describe('generateItem', () => {
 
   it('should handle special characters in about array', () => {
     const value = {
-      abouts: ['https://blog1.com/track?id=1&key=abc', 'https://blog2.com/track?id=2&key=def'],
+      abouts: [
+        'https://blog1.example.com/track?id=1&key=abc',
+        'https://blog2.example.com/track?id=2&key=def',
+      ],
     }
     const expected = {
       'trackback:about': [
-        { '#cdata': 'https://blog1.com/track?id=1&key=abc' },
-        { '#cdata': 'https://blog2.com/track?id=2&key=def' },
+        { '#cdata': 'https://blog1.example.com/track?id=1&key=abc' },
+        { '#cdata': 'https://blog2.example.com/track?id=2&key=def' },
       ],
     }
 
@@ -95,10 +93,10 @@ describe('generateItem', () => {
   it('should handle empty strings', () => {
     const value = {
       ping: '',
-      abouts: ['https://blog1.com/trackback/456'],
+      abouts: ['https://blog1.example.com/trackback/456'],
     }
     const expected = {
-      'trackback:about': ['https://blog1.com/trackback/456'],
+      'trackback:about': ['https://blog1.example.com/trackback/456'],
     }
 
     expect(generateItem(value)).toEqual(expected)
@@ -106,10 +104,10 @@ describe('generateItem', () => {
 
   it('should handle empty strings in about array', () => {
     const value = {
-      abouts: ['', 'https://blog1.com/trackback/456', ''],
+      abouts: ['', 'https://blog1.example.com/trackback/456', ''],
     }
     const expected = {
-      'trackback:about': ['https://blog1.com/trackback/456'],
+      'trackback:about': ['https://blog1.example.com/trackback/456'],
     }
 
     expect(generateItem(value)).toEqual(expected)
@@ -149,10 +147,18 @@ describe('generateItem', () => {
 
   it('should handle mixed valid and invalid values in about array', () => {
     const value = {
-      abouts: ['https://blog1.com/trackback/456', '', '   ', 'https://blog2.com/trackback/789'],
+      abouts: [
+        'https://blog1.example.com/trackback/456',
+        '',
+        '   ',
+        'https://blog2.example.com/trackback/789',
+      ],
     }
     const expected = {
-      'trackback:about': ['https://blog1.com/trackback/456', 'https://blog2.com/trackback/789'],
+      'trackback:about': [
+        'https://blog1.example.com/trackback/456',
+        'https://blog2.example.com/trackback/789',
+      ],
     }
 
     expect(generateItem(value)).toEqual(expected)

--- a/src/namespaces/trackback/parse/utils.test.ts
+++ b/src/namespaces/trackback/parse/utils.test.ts
@@ -5,11 +5,17 @@ describe('retrieveItem', () => {
   it('should parse complete item with all properties', () => {
     const value = {
       'trackback:ping': 'https://example.com/trackback/123',
-      'trackback:about': ['https://blog1.com/trackback/456', 'https://blog2.com/trackback/789'],
+      'trackback:about': [
+        'https://blog1.example.com/trackback/456',
+        'https://blog2.example.com/trackback/789',
+      ],
     }
     const expected = {
       ping: 'https://example.com/trackback/123',
-      abouts: ['https://blog1.com/trackback/456', 'https://blog2.com/trackback/789'],
+      abouts: [
+        'https://blog1.example.com/trackback/456',
+        'https://blog2.example.com/trackback/789',
+      ],
     }
 
     expect(retrieveItem(value)).toEqual(expected)
@@ -28,10 +34,10 @@ describe('retrieveItem', () => {
 
   it('should parse item with only about property', () => {
     const value = {
-      'trackback:about': ['https://blog1.com/trackback/456'],
+      'trackback:about': ['https://blog1.example.com/trackback/456'],
     }
     const expected = {
-      abouts: ['https://blog1.com/trackback/456'],
+      abouts: ['https://blog1.example.com/trackback/456'],
     }
 
     expect(retrieveItem(value)).toEqual(expected)
@@ -39,10 +45,10 @@ describe('retrieveItem', () => {
 
   it('should parse item with single about value', () => {
     const value = {
-      'trackback:about': 'https://blog1.com/trackback/456',
+      'trackback:about': 'https://blog1.example.com/trackback/456',
     }
     const expected = {
-      abouts: ['https://blog1.com/trackback/456'],
+      abouts: ['https://blog1.example.com/trackback/456'],
     }
 
     expect(retrieveItem(value)).toEqual(expected)
@@ -51,16 +57,16 @@ describe('retrieveItem', () => {
   it('should parse item with multiple about values', () => {
     const value = {
       'trackback:about': [
-        'https://blog1.com/trackback/456',
-        'https://blog2.com/trackback/789',
-        'https://blog3.com/trackback/abc',
+        'https://blog1.example.com/trackback/456',
+        'https://blog2.example.com/trackback/789',
+        'https://blog3.example.com/trackback/abc',
       ],
     }
     const expected = {
       abouts: [
-        'https://blog1.com/trackback/456',
-        'https://blog2.com/trackback/789',
-        'https://blog3.com/trackback/abc',
+        'https://blog1.example.com/trackback/456',
+        'https://blog2.example.com/trackback/789',
+        'https://blog3.example.com/trackback/abc',
       ],
     }
 
@@ -81,12 +87,15 @@ describe('retrieveItem', () => {
   it('should handle HTML entities in about array', () => {
     const value = {
       'trackback:about': [
-        { '#text': 'https://blog1.com/track?id=1&amp;key=abc' },
-        { '#text': 'https://blog2.com/track?id=2&amp;key=def' },
+        { '#text': 'https://blog1.example.com/track?id=1&amp;key=abc' },
+        { '#text': 'https://blog2.example.com/track?id=2&amp;key=def' },
       ],
     }
     const expected = {
-      abouts: ['https://blog1.com/track?id=1&key=abc', 'https://blog2.com/track?id=2&key=def'],
+      abouts: [
+        'https://blog1.example.com/track?id=1&key=abc',
+        'https://blog2.example.com/track?id=2&key=def',
+      ],
     }
 
     expect(retrieveItem(value)).toEqual(expected)
@@ -106,12 +115,15 @@ describe('retrieveItem', () => {
   it('should handle CDATA sections in about array', () => {
     const value = {
       'trackback:about': [
-        { '#text': '<![CDATA[https://blog1.com/trackback/456]]>' },
-        { '#text': '<![CDATA[https://blog2.com/trackback/789]]>' },
+        { '#text': '<![CDATA[https://blog1.example.com/trackback/456]]>' },
+        { '#text': '<![CDATA[https://blog2.example.com/trackback/789]]>' },
       ],
     }
     const expected = {
-      abouts: ['https://blog1.com/trackback/456', 'https://blog2.com/trackback/789'],
+      abouts: [
+        'https://blog1.example.com/trackback/456',
+        'https://blog2.example.com/trackback/789',
+      ],
     }
 
     expect(retrieveItem(value)).toEqual(expected)
@@ -120,10 +132,10 @@ describe('retrieveItem', () => {
   it('should handle empty strings', () => {
     const value = {
       'trackback:ping': '',
-      'trackback:about': ['https://blog1.com/trackback/456'],
+      'trackback:about': ['https://blog1.example.com/trackback/456'],
     }
     const expected = {
-      abouts: ['https://blog1.com/trackback/456'],
+      abouts: ['https://blog1.example.com/trackback/456'],
     }
 
     expect(retrieveItem(value)).toEqual(expected)
@@ -131,10 +143,10 @@ describe('retrieveItem', () => {
 
   it('should handle empty strings in about array', () => {
     const value = {
-      'trackback:about': ['', 'https://blog1.com/trackback/456', ''],
+      'trackback:about': ['', 'https://blog1.example.com/trackback/456', ''],
     }
     const expected = {
-      abouts: ['https://blog1.com/trackback/456'],
+      abouts: ['https://blog1.example.com/trackback/456'],
     }
 
     expect(retrieveItem(value)).toEqual(expected)
@@ -172,14 +184,17 @@ describe('retrieveItem', () => {
   it('should handle mixed valid and invalid values in about array', () => {
     const value = {
       'trackback:about': [
-        'https://blog1.com/trackback/456',
+        'https://blog1.example.com/trackback/456',
         '',
         '   ',
-        'https://blog2.com/trackback/789',
+        'https://blog2.example.com/trackback/789',
       ],
     }
     const expected = {
-      abouts: ['https://blog1.com/trackback/456', 'https://blog2.com/trackback/789'],
+      abouts: [
+        'https://blog1.example.com/trackback/456',
+        'https://blog2.example.com/trackback/789',
+      ],
     }
 
     expect(retrieveItem(value)).toEqual(expected)
@@ -188,12 +203,15 @@ describe('retrieveItem', () => {
   it('should handle about array with objects containing #text', () => {
     const value = {
       'trackback:about': [
-        { '#text': 'https://blog1.com/trackback/456' },
-        { '#text': 'https://blog2.com/trackback/789' },
+        { '#text': 'https://blog1.example.com/trackback/456' },
+        { '#text': 'https://blog2.example.com/trackback/789' },
       ],
     }
     const expected = {
-      abouts: ['https://blog1.com/trackback/456', 'https://blog2.com/trackback/789'],
+      abouts: [
+        'https://blog1.example.com/trackback/456',
+        'https://blog2.example.com/trackback/789',
+      ],
     }
 
     expect(retrieveItem(value)).toEqual(expected)
@@ -206,16 +224,19 @@ describe('retrieveItem', () => {
       },
       'trackback:about': [
         {
-          '@rdf:resource': 'https://blog1.com/trackback/456',
+          '@rdf:resource': 'https://blog1.example.com/trackback/456',
         },
         {
-          '@rdf:resource': 'https://blog2.com/trackback/789',
+          '@rdf:resource': 'https://blog2.example.com/trackback/789',
         },
       ],
     }
     const expected = {
       ping: 'https://example.com/trackback/123',
-      abouts: ['https://blog1.com/trackback/456', 'https://blog2.com/trackback/789'],
+      abouts: [
+        'https://blog1.example.com/trackback/456',
+        'https://blog2.example.com/trackback/789',
+      ],
     }
 
     expect(retrieveItem(value)).toEqual(expected)
@@ -240,11 +261,17 @@ describe('retrieveItem', () => {
       'trackback:ping': {
         '@rdf:resource': 'https://example.com/trackback/123',
       },
-      'trackback:about': ['https://blog1.com/trackback/456', 'https://blog2.com/trackback/789'],
+      'trackback:about': [
+        'https://blog1.example.com/trackback/456',
+        'https://blog2.example.com/trackback/789',
+      ],
     }
     const expected = {
       ping: 'https://example.com/trackback/123',
-      abouts: ['https://blog1.com/trackback/456', 'https://blog2.com/trackback/789'],
+      abouts: [
+        'https://blog1.example.com/trackback/456',
+        'https://blog2.example.com/trackback/789',
+      ],
     }
 
     expect(retrieveItem(value)).toEqual(expected)
@@ -254,19 +281,19 @@ describe('retrieveItem', () => {
     const value = {
       'trackback:about': [
         {
-          '@rdf:resource': 'https://blog1.com/trackback/456',
+          '@rdf:resource': 'https://blog1.example.com/trackback/456',
         },
-        'https://blog2.com/trackback/789',
+        'https://blog2.example.com/trackback/789',
         {
-          '#text': 'https://blog3.com/trackback/abc',
+          '#text': 'https://blog3.example.com/trackback/abc',
         },
       ],
     }
     const expected = {
       abouts: [
-        'https://blog1.com/trackback/456',
-        'https://blog2.com/trackback/789',
-        'https://blog3.com/trackback/abc',
+        'https://blog1.example.com/trackback/456',
+        'https://blog2.example.com/trackback/789',
+        'https://blog3.example.com/trackback/abc',
       ],
     }
 
@@ -277,17 +304,20 @@ describe('retrieveItem', () => {
     const value = {
       'trackback:about': [
         {
-          '@rdf:resource': 'https://blog1.com/trackback/456',
-          '#text': 'https://blog1.com/other',
+          '@rdf:resource': 'https://blog1.example.com/trackback/456',
+          '#text': 'https://blog1.example.com/other',
         },
         {
-          '@rdf:resource': 'https://blog2.com/trackback/789',
-          '#text': 'https://blog2.com/other',
+          '@rdf:resource': 'https://blog2.example.com/trackback/789',
+          '#text': 'https://blog2.example.com/other',
         },
       ],
     }
     const expected = {
-      abouts: ['https://blog1.com/trackback/456', 'https://blog2.com/trackback/789'],
+      abouts: [
+        'https://blog1.example.com/trackback/456',
+        'https://blog2.example.com/trackback/789',
+      ],
     }
 
     expect(retrieveItem(value)).toEqual(expected)

--- a/src/opml/generate/index.test.ts
+++ b/src/opml/generate/index.test.ts
@@ -12,7 +12,7 @@ describe('generate', () => {
       const value = await Bun.file(`${path}.json`).json()
       const expected = await Bun.file(`${path}.opml`).text()
 
-      expect(generate(value)).toEqual(expected)
+      expect(generate(value)).toBe(expected)
     })
   }
 
@@ -30,7 +30,7 @@ describe('generate', () => {
 </opml>
 `
 
-    expect(generate(value)).toEqual(expected)
+    expect(generate(value)).toBe(expected)
   })
 
   it('should generate OPML with head information', () => {
@@ -62,7 +62,7 @@ describe('generate', () => {
 </opml>
 `
 
-    expect(generate(value)).toEqual(expected)
+    expect(generate(value)).toBe(expected)
   })
 
   it('should generate OPML with nested outlines', () => {
@@ -96,7 +96,7 @@ describe('generate', () => {
 </opml>
 `
 
-    expect(generate(value)).toEqual(expected)
+    expect(generate(value)).toBe(expected)
   })
 
   it('should generate OPML with boolean attributes', () => {
@@ -119,13 +119,13 @@ describe('generate', () => {
 </opml>
 `
 
-    expect(generate(value)).toEqual(expected)
+    expect(generate(value)).toBe(expected)
   })
 
   it('should generate complete OPML with all fields', () => {
     const now = new Date('2023-03-15T12:00:00Z')
 
-    const opml = {
+    const value = {
       head: {
         title: 'Complete OPML Example',
         dateCreated: now,
@@ -193,7 +193,7 @@ describe('generate', () => {
 </opml>
 `
 
-    expect(generate(opml)).toEqual(expected)
+    expect(generate(value)).toBe(expected)
   })
 
   it('should handle outlines with empty arrays', () => {
@@ -215,7 +215,7 @@ describe('generate', () => {
 </opml>
 `
 
-    expect(generate(value)).toEqual(expected)
+    expect(generate(value)).toBe(expected)
   })
 
   describe('error types', () => {
@@ -230,10 +230,22 @@ describe('generate', () => {
       expect(throwing).toThrow(GenerateError)
       expect(throwing).toThrow(locales.invalidInputOpml)
     })
+
+    it('should throw GenerateError for body with empty outlines', () => {
+      const value = {
+        body: {
+          outlines: [],
+        },
+      }
+      const throwing = () => generate(value)
+
+      expect(throwing).toThrow(GenerateError)
+      expect(throwing).toThrow(locales.invalidInputOpml)
+    })
   })
 
   it('should properly encode special characters in attributes', () => {
-    const opml = {
+    const value = {
       body: {
         outlines: [
           {
@@ -251,7 +263,7 @@ describe('generate', () => {
 </opml>
 `
 
-    expect(generate(opml)).toEqual(expected)
+    expect(generate(value)).toBe(expected)
   })
 
   it('should generate OPML with stylesheets', () => {
@@ -272,54 +284,72 @@ describe('generate', () => {
 </opml>
 `
 
-    expect(generate(value, options)).toEqual(expected)
+    expect(generate(value, options)).toBe(expected)
   })
-})
 
-describe('strict mode', () => {
-  it('should require outline text in strict mode', () => {
-    generate(
-      {
+  describe('strict mode', () => {
+    it('should require outline text in strict mode', () => {
+      const value = {
         body: {
-          // @ts-expect-error: This is for testing purposes.
           outlines: [{ type: 'rss', xmlUrl: 'https://example.com/feed.xml' }],
         },
-      },
-      { strict: true },
-    )
-  })
+      }
+      const expected = `<?xml version="1.0" encoding="utf-8"?>
+<opml version="2.0">
+  <body>
+    <outline type="rss" xmlUrl="https://example.com/feed.xml"/>
+  </body>
+</opml>
+`
 
-  it('should accept outlines with text in strict mode', () => {
-    generate(
-      {
+      // @ts-expect-error: This is for testing purposes.
+      expect(generate(value, { strict: true })).toBe(expected)
+    })
+
+    it('should accept outlines with text in strict mode', () => {
+      const value = {
         body: {
           outlines: [{ text: 'Feed', type: 'rss', xmlUrl: 'https://example.com/feed.xml' }],
         },
-      },
-      { strict: true },
-    )
-  })
+      }
+      const expected = `<?xml version="1.0" encoding="utf-8"?>
+<opml version="2.0">
+  <body>
+    <outline text="Feed" type="rss" xmlUrl="https://example.com/feed.xml"/>
+  </body>
+</opml>
+`
 
-  it('should require nested outline text in strict mode', () => {
-    generate(
-      {
+      expect(generate(value, { strict: true })).toBe(expected)
+    })
+
+    it('should require nested outline text in strict mode', () => {
+      const value = {
         body: {
           outlines: [
             {
               text: 'Category',
-              // @ts-expect-error: This is for testing purposes.
               outlines: [{ type: 'rss', xmlUrl: 'https://example.com/feed.xml' }],
             },
           ],
         },
-      },
-      { strict: true },
-    )
-  })
+      }
+      const expected = `<?xml version="1.0" encoding="utf-8"?>
+<opml version="2.0">
+  <body>
+    <outline text="Category">
+      <outline type="rss" xmlUrl="https://example.com/feed.xml"/>
+    </outline>
+  </body>
+</opml>
+`
 
-  it('should accept nested outlines with text in strict mode', () => {
-    generate(
-      {
+      // @ts-expect-error: This is for testing purposes.
+      expect(generate(value, { strict: true })).toBe(expected)
+    })
+
+    it('should accept nested outlines with text in strict mode', () => {
+      const value = {
         body: {
           outlines: [
             {
@@ -328,28 +358,46 @@ describe('strict mode', () => {
             },
           ],
         },
-      },
-      { strict: true },
-    )
-  })
+      }
+      const expected = `<?xml version="1.0" encoding="utf-8"?>
+<opml version="2.0">
+  <body>
+    <outline text="Category">
+      <outline text="Feed" type="rss" xmlUrl="https://example.com/feed.xml"/>
+    </outline>
+  </body>
+</opml>
+`
 
-  it('should accept partial document in lenient mode', () => {
-    generate({
-      body: {
-        outlines: [{ type: 'rss', xmlUrl: 'https://example.com/feed.xml' }],
-      },
+      expect(generate(value, { strict: true })).toBe(expected)
+    })
+
+    it('should accept partial document in lenient mode', () => {
+      const value = {
+        body: {
+          outlines: [{ type: 'rss', xmlUrl: 'https://example.com/feed.xml' }],
+        },
+      }
+      const expected = `<?xml version="1.0" encoding="utf-8"?>
+<opml version="2.0">
+  <body>
+    <outline type="rss" xmlUrl="https://example.com/feed.xml"/>
+  </body>
+</opml>
+`
+
+      expect(generate(value)).toBe(expected)
     })
   })
-})
 
-describe('generate with partial and string dates', () => {
-  it('should accept partial documents', () => {
-    const value = {
-      body: {
-        outlines: [{ text: 'Test Outline' }],
-      },
-    }
-    const expected = `<?xml version="1.0" encoding="utf-8"?>
+  describe('partial documents and string dates', () => {
+    it('should accept partial documents', () => {
+      const value = {
+        body: {
+          outlines: [{ text: 'Test Outline' }],
+        },
+      }
+      const expected = `<?xml version="1.0" encoding="utf-8"?>
 <opml version="2.0">
   <body>
     <outline text="Test Outline"/>
@@ -357,21 +405,21 @@ describe('generate with partial and string dates', () => {
 </opml>
 `
 
-    expect(generate(value)).toEqual(expected)
-  })
+      expect(generate(value)).toBe(expected)
+    })
 
-  it('should accept string dates', () => {
-    const value = {
-      head: {
-        title: 'Test OPML',
-        dateCreated: '2023-01-01T00:00:00.000Z',
-        dateModified: '2023-01-02T00:00:00.000Z',
-      },
-      body: {
-        outlines: [{ text: 'Test Outline' }],
-      },
-    }
-    const expected = `<?xml version="1.0" encoding="utf-8"?>
+    it('should accept string dates', () => {
+      const value = {
+        head: {
+          title: 'Test OPML',
+          dateCreated: '2023-01-01T00:00:00.000Z',
+          dateModified: '2023-01-02T00:00:00.000Z',
+        },
+        body: {
+          outlines: [{ text: 'Test Outline' }],
+        },
+      }
+      const expected = `<?xml version="1.0" encoding="utf-8"?>
 <opml version="2.0">
   <head>
     <title>Test OPML</title>
@@ -384,21 +432,21 @@ describe('generate with partial and string dates', () => {
 </opml>
 `
 
-    expect(generate(value)).toEqual(expected)
-  })
+      expect(generate(value)).toBe(expected)
+    })
 
-  it('should preserve invalid date strings', () => {
-    const value = {
-      head: {
-        title: 'Test OPML',
-        dateCreated: 'not-a-valid-date',
-        dateModified: 'also-invalid',
-      },
-      body: {
-        outlines: [{ text: 'Test Outline' }],
-      },
-    }
-    const expected = `<?xml version="1.0" encoding="utf-8"?>
+    it('should preserve invalid date strings', () => {
+      const value = {
+        head: {
+          title: 'Test OPML',
+          dateCreated: 'not-a-valid-date',
+          dateModified: 'also-invalid',
+        },
+        body: {
+          outlines: [{ text: 'Test Outline' }],
+        },
+      }
+      const expected = `<?xml version="1.0" encoding="utf-8"?>
 <opml version="2.0">
   <head>
     <title>Test OPML</title>
@@ -411,67 +459,68 @@ describe('generate with partial and string dates', () => {
 </opml>
 `
 
-    expect(generate(value)).toEqual(expected)
-  })
+      expect(generate(value)).toBe(expected)
+    })
 
-  describe('custom attributes', () => {
-    it('should generate OPML with custom attributes when specified in options', () => {
-      const opml = {
-        head: {
-          title: 'Test OPML',
-        },
-        body: {
-          outlines: [
-            {
-              text: 'Feed 1',
-              type: 'rss',
-              xmlUrl: 'https://feed1.com/rss',
-              customRating: '5',
-              customTags: 'tech,news',
-            },
-          ],
-        },
-      }
-      const options = {
-        extraOutlineAttributes: ['customRating', 'customTags'],
-      }
-      const expected = `<?xml version="1.0" encoding="utf-8"?>
+    describe('custom attributes', () => {
+      it('should generate OPML with custom attributes when specified in options', () => {
+        const value = {
+          head: {
+            title: 'Test OPML',
+          },
+          body: {
+            outlines: [
+              {
+                text: 'Feed 1',
+                type: 'rss',
+                xmlUrl: 'https://example.com/feed1.xml',
+                customRating: '5',
+                customTags: 'tech,news',
+              },
+            ],
+          },
+        }
+        const options = {
+          extraOutlineAttributes: ['customRating', 'customTags'],
+        }
+        const expected = `<?xml version="1.0" encoding="utf-8"?>
 <opml version="2.0">
   <head>
     <title>Test OPML</title>
   </head>
   <body>
-    <outline text="Feed 1" type="rss" xmlUrl="https://feed1.com/rss" customRating="5" customTags="tech,news"/>
+    <outline text="Feed 1" type="rss" xmlUrl="https://example.com/feed1.xml" customRating="5" customTags="tech,news"/>
   </body>
 </opml>
 `
 
-      expect(generate(opml, options)).toEqual(expected)
-    })
+        expect(generate(value, options)).toBe(expected)
+      })
 
-    it('should not include custom attributes when not specified in options', () => {
-      const opml = {
-        body: {
-          outlines: [
-            {
-              text: 'Feed',
-              type: 'rss',
-              xmlUrl: 'https://feed.com/rss',
-              customRating: '5',
-              customTags: 'tech',
-            },
-          ],
-        },
-      }
-      const expected = `<?xml version="1.0" encoding="utf-8"?>
+      it('should not include custom attributes when not specified in options', () => {
+        const value = {
+          body: {
+            outlines: [
+              {
+                text: 'Feed',
+                type: 'rss',
+                xmlUrl: 'https://example.com/feed.xml',
+                customRating: '5',
+                customTags: 'tech',
+              },
+            ],
+          },
+        }
+        const expected = `<?xml version="1.0" encoding="utf-8"?>
 <opml version="2.0">
   <body>
-    <outline text="Feed" type="rss" xmlUrl="https://feed.com/rss"/>
+    <outline text="Feed" type="rss" xmlUrl="https://example.com/feed.xml"/>
   </body>
 </opml>
 `
 
-      expect(generate(opml)).toEqual(expected)
+        expect(generate(value)).toBe(expected)
+      })
     })
   })
 })

--- a/src/opml/generate/utils.test.ts
+++ b/src/opml/generate/utils.test.ts
@@ -155,7 +155,7 @@ describe('generateOutline', () => {
 
   describe('custom attributes', () => {
     it('should generate outline with custom attributes when specified in options', () => {
-      const outline = {
+      const value = {
         text: 'Feed with custom attrs',
         type: 'rss',
         xmlUrl: 'https://example.com/feed.xml',
@@ -166,20 +166,20 @@ describe('generateOutline', () => {
       const options = {
         extraOutlineAttributes: ['customField1', 'customField2', 'rating'],
       }
-      const result = generateOutline(outline, options)
-
-      expect(result).toEqual({
+      const expected = {
         '@text': 'Feed with custom attrs',
         '@type': 'rss',
         '@xmlUrl': 'https://example.com/feed.xml',
         '@customField1': 'value1',
         '@customField2': 'value2',
         '@rating': '5',
-      })
+      }
+
+      expect(generateOutline(value, options)).toEqual(expected)
     })
 
     it('should not include custom attributes when not in options', () => {
-      const outline = {
+      const value = {
         text: 'Feed with custom attrs',
         type: 'rss',
         xmlUrl: 'https://example.com/feed.xml',
@@ -187,17 +187,17 @@ describe('generateOutline', () => {
         customField2: 'value2',
         rating: '5',
       }
-      const result = generateOutline(outline)
-
-      expect(result).toEqual({
+      const expected = {
         '@text': 'Feed with custom attrs',
         '@type': 'rss',
         '@xmlUrl': 'https://example.com/feed.xml',
-      })
+      }
+
+      expect(generateOutline(value)).toEqual(expected)
     })
 
     it('should handle nested outlines with custom attributes', () => {
-      const outline = {
+      const value = {
         text: 'Parent',
         customParent: 'parentValue',
         outlines: [
@@ -214,9 +214,7 @@ describe('generateOutline', () => {
       const options = {
         extraOutlineAttributes: ['customParent', 'customChild'],
       }
-      const result = generateOutline(outline, options)
-
-      expect(result).toEqual({
+      const expected = {
         '@text': 'Parent',
         '@customParent': 'parentValue',
         outline: [
@@ -229,11 +227,13 @@ describe('generateOutline', () => {
             '@customChild': 'childValue2',
           },
         ],
-      })
+      }
+
+      expect(generateOutline(value, options)).toEqual(expected)
     })
 
     it('should only include specified custom attributes', () => {
-      const outline = {
+      const value = {
         text: 'Selective',
         type: 'rss',
         customField1: 'included',
@@ -243,18 +243,18 @@ describe('generateOutline', () => {
       const options = {
         extraOutlineAttributes: ['customField1', 'customField3'],
       }
-      const result = generateOutline(outline, options)
-
-      expect(result).toEqual({
+      const expected = {
         '@text': 'Selective',
         '@type': 'rss',
         '@customField1': 'included',
         '@customField3': 'included',
-      })
+      }
+
+      expect(generateOutline(value, options)).toEqual(expected)
     })
 
     it('should handle custom attributes as strings', () => {
-      const outline = {
+      const value = {
         text: 'Test',
         stringAttr: 'text value',
         numberAttr: '123',
@@ -263,14 +263,20 @@ describe('generateOutline', () => {
       const options = {
         extraOutlineAttributes: ['stringAttr', 'numberAttr', 'boolAttr'],
       }
-      const result = generateOutline(outline, options)
-
-      expect(result).toEqual({
+      const expected = {
         '@text': 'Test',
         '@stringAttr': 'text value',
         '@numberAttr': '123',
         '@boolAttr': 'true',
-      })
+      }
+
+      expect(generateOutline(value, options)).toEqual(expected)
+    })
+
+    it.todo('should handle non-string custom attribute values', () => {
+      // generateOutline passes custom attribute values to generatePlainString as strings,
+      // so number and boolean values are currently dropped from the output.
+      // Pin the expected output for non-string custom attribute values.
     })
   })
 })
@@ -509,6 +515,16 @@ describe('generateDocument', () => {
     const value = {
       body: {
         outlines: [],
+      },
+    }
+
+    expect(generateDocument(value)).toBeUndefined()
+  })
+
+  it('should return undefined for head without body', () => {
+    const value = {
+      head: {
+        title: 'Head Only',
       },
     }
 

--- a/src/opml/parse/index.test.ts
+++ b/src/opml/parse/index.test.ts
@@ -17,7 +17,7 @@ describe('parse', () => {
   }
 
   it('should handle OPML with one outline', () => {
-    const mixedCaseOpml = `
+    const value = `
       <?xml version="1.0" encoding="UTF-8"?>
       <OPML version="2.0">
         <HEAD>
@@ -37,11 +37,11 @@ describe('parse', () => {
       },
     }
 
-    expect(parse(mixedCaseOpml)).toEqual(expected)
+    expect(parse(value)).toEqual(expected)
   })
 
   it('should handle case-insensitive XML tags and attributes', () => {
-    const mixedCaseOpml = `
+    const value = `
       <?xml version="1.0" encoding="UTF-8"?>
       <OPML version="2.0">
         <HEAD>
@@ -71,7 +71,7 @@ describe('parse', () => {
       },
     }
 
-    expect(parse(mixedCaseOpml)).toEqual(expected)
+    expect(parse(value)).toEqual(expected)
   })
 
   it('should handle alternating case outlines', () => {
@@ -100,29 +100,14 @@ describe('parse', () => {
     expect(parse(value)).toEqual(expected)
   })
 
-  it('should handle empty string input', () => {
-    const value = ''
-
-    expect(() => parse(value)).toThrow()
-  })
-
-  it('should handle invalid XML input', () => {
-    const value = `
-      <?xml version="1.0" encoding="UTF-8"?>
-      <OPML version="2.0">
-        <HEAD>
-          <title>Invalid XML Example
-        </HEAD>
-        <Body>
-          <outline TEXT="Unclosed tag
-        </Body>
-      </OPML>
-    `
-
-    expect(() => parse(value)).toThrow()
-  })
-
   describe('error types', () => {
+    it('should throw ParseError for empty string input', () => {
+      const throwing = () => parse('')
+
+      expect(throwing).toThrow(ParseError)
+      expect(throwing).toThrow(locales.invalidOpmlFormat)
+    })
+
     it('should throw MalformedError for invalid XML', () => {
       const value = `
         <?xml version="1.0"?>
@@ -149,17 +134,18 @@ describe('parse', () => {
 
   describe('custom attributes', () => {
     it('should parse OPML with custom attributes when specified in options', () => {
-      const opmlString = `<?xml version="1.0" encoding="UTF-8"?>
-<opml version="2.0">
-  <head>
-    <title>Test OPML</title>
-  </head>
-  <body>
-    <outline text="Feed 1" type="rss" xmlUrl="https://feed1.com/rss" customRating="5" customTags="tech,news" />
-    <outline text="Feed 2" type="rss" xmlUrl="https://feed2.com/rss" customRating="3" customTags="blog" />
-  </body>
-</opml>`
-
+      const value = `
+        <?xml version="1.0" encoding="UTF-8"?>
+        <opml version="2.0">
+          <head>
+            <title>Test OPML</title>
+          </head>
+          <body>
+            <outline text="Feed 1" type="rss" xmlUrl="https://example.com/feed1.xml" customRating="5" customTags="tech,news" />
+            <outline text="Feed 2" type="rss" xmlUrl="https://example.com/feed2.xml" customRating="3" customTags="blog" />
+          </body>
+        </opml>
+      `
       const options = {
         extraOutlineAttributes: ['customRating', 'customTags'],
       }
@@ -172,14 +158,14 @@ describe('parse', () => {
             {
               text: 'Feed 1',
               type: 'rss',
-              xmlUrl: 'https://feed1.com/rss',
+              xmlUrl: 'https://example.com/feed1.xml',
               customRating: '5',
               customTags: 'tech,news',
             },
             {
               text: 'Feed 2',
               type: 'rss',
-              xmlUrl: 'https://feed2.com/rss',
+              xmlUrl: 'https://example.com/feed2.xml',
               customRating: '3',
               customTags: 'blog',
             },
@@ -187,45 +173,48 @@ describe('parse', () => {
         },
       }
 
-      expect(parse(opmlString, options)).toEqual(expected)
+      expect(parse(value, options)).toEqual(expected)
     })
 
     it('should not include custom attributes when not specified in options', () => {
-      const opmlString = `<?xml version="1.0" encoding="UTF-8"?>
-<opml version="2.0">
-  <body>
-    <outline text="Feed" type="rss" xmlUrl="https://feed.com/rss" customRating="5" customTags="tech" />
-  </body>
-</opml>`
-
+      const value = `
+        <?xml version="1.0" encoding="UTF-8"?>
+        <opml version="2.0">
+          <body>
+            <outline text="Feed" type="rss" xmlUrl="https://example.com/feed.xml" customRating="5" customTags="tech" />
+          </body>
+        </opml>
+      `
       const expected = {
         body: {
           outlines: [
             {
               text: 'Feed',
               type: 'rss',
-              xmlUrl: 'https://feed.com/rss',
+              xmlUrl: 'https://example.com/feed.xml',
             },
           ],
         },
       }
 
-      expect(parse(opmlString)).toEqual(expected)
+      expect(parse(value)).toEqual(expected)
     })
   })
 
   describe('with maxItems option', () => {
-    const commonValue = `<?xml version="1.0" encoding="UTF-8"?>
-<opml version="2.0">
-  <head>
-    <title>Test OPML</title>
-  </head>
-  <body>
-    <outline text="Outline 1" type="rss" />
-    <outline text="Outline 2" type="rss" />
-    <outline text="Outline 3" type="rss" />
-  </body>
-</opml>`
+    const value = `
+      <?xml version="1.0" encoding="UTF-8"?>
+      <opml version="2.0">
+        <head>
+          <title>Test OPML</title>
+        </head>
+        <body>
+          <outline text="Outline 1" type="rss" />
+          <outline text="Outline 2" type="rss" />
+          <outline text="Outline 3" type="rss" />
+        </body>
+      </opml>
+    `
 
     it('should limit outlines to specified number', () => {
       const expected = {
@@ -246,7 +235,7 @@ describe('parse', () => {
         },
       }
 
-      expect(parse(commonValue, { maxItems: 2 })).toEqual(expected)
+      expect(parse(value, { maxItems: 2 })).toEqual(expected)
     })
 
     it('should skip all outlines when maxItems is 0', () => {
@@ -256,7 +245,7 @@ describe('parse', () => {
         },
       }
 
-      expect(parse(commonValue, { maxItems: 0 })).toEqual(expected)
+      expect(parse(value, { maxItems: 0 })).toEqual(expected)
     })
 
     it('should return all outlines when maxItems is undefined', () => {
@@ -282,7 +271,7 @@ describe('parse', () => {
         },
       }
 
-      expect(parse(commonValue, { maxItems: undefined })).toEqual(expected)
+      expect(parse(value, { maxItems: undefined })).toEqual(expected)
     })
   })
 
@@ -312,9 +301,13 @@ describe('parse', () => {
           ],
         },
       }
-      const result = parse(value, { parseDateFn: (raw) => new Date(raw) })
 
-      expect(result).toEqual(expected)
+      expect(parse(value, { parseDateFn: (raw) => new Date(raw) })).toEqual(expected)
     })
+  })
+
+  it.todo('should parse OPML with version 1.0 or missing version attribute', () => {
+    // The parser currently ignores the version attribute entirely.
+    // Pin the behavior for OPML 1.0 documents and for documents without a version attribute.
   })
 })

--- a/src/opml/parse/utils.test.ts
+++ b/src/opml/parse/utils.test.ts
@@ -57,6 +57,21 @@ describe('parseOutline', () => {
     expect(parseOutline(value)).toEqual(expected)
   })
 
+  it('should handle created and category attributes', () => {
+    const value = {
+      '@text': 'Outline with date and category',
+      '@created': 'Mon, 15 Mar 2023 12:00:00 GMT',
+      '@category': '/Technology/Feeds',
+    }
+    const expected = {
+      text: 'Outline with date and category',
+      created: 'Mon, 15 Mar 2023 12:00:00 GMT',
+      category: '/Technology/Feeds',
+    }
+
+    expect(parseOutline(value)).toEqual(expected)
+  })
+
   it('should handle coercible values', () => {
     const value = {
       '@text': 123,
@@ -150,6 +165,12 @@ describe('parseOutline', () => {
     expect(parseOutline(null)).toBeUndefined()
   })
 
+  it.todo('should handle whitespace-only outline text', () => {
+    // '@text': '   ' parses to undefined, so the text key is dropped while other attributes
+    // are kept.
+    // Pin whether an outline without usable text should still be returned.
+  })
+
   describe('custom attributes', () => {
     it('should extract specified custom attributes', () => {
       const value = {
@@ -163,16 +184,16 @@ describe('parseOutline', () => {
       const options = {
         extraOutlineAttributes: ['customField1', 'customField2', 'rating'],
       }
-      const result = parseOutline(value, options)
-
-      expect(result).toEqual({
+      const expected = {
         text: 'Feed with custom attrs',
         type: 'rss',
         xmlUrl: 'https://example.com/feed.xml',
         customField1: 'value1',
         customField2: 'value2',
         rating: '5',
-      })
+      }
+
+      expect(parseOutline(value, options)).toEqual(expected)
     })
 
     it('should only extract attributes listed in options', () => {
@@ -185,13 +206,13 @@ describe('parseOutline', () => {
       const options = {
         extraOutlineAttributes: ['customField1', 'customField3'],
       }
-      const result = parseOutline(value, options)
-
-      expect(result).toEqual({
+      const expected = {
         text: 'Selective extraction',
         customField1: 'value1',
         customField3: 'value3',
-      })
+      }
+
+      expect(parseOutline(value, options)).toEqual(expected)
     })
 
     it('should handle nested outlines with custom attributes', () => {
@@ -212,9 +233,7 @@ describe('parseOutline', () => {
       const options = {
         extraOutlineAttributes: ['customParent', 'customChild'],
       }
-      const result = parseOutline(value, options)
-
-      expect(result).toEqual({
+      const expected = {
         text: 'Parent',
         customParent: 'parentValue',
         outlines: [
@@ -227,7 +246,9 @@ describe('parseOutline', () => {
             customChild: 'childValue2',
           },
         ],
-      })
+      }
+
+      expect(parseOutline(value, options)).toEqual(expected)
     })
 
     it('should not add custom properties when no custom attributes found', () => {
@@ -238,12 +259,12 @@ describe('parseOutline', () => {
       const options = {
         extraOutlineAttributes: ['nonExistent'],
       }
-      const result = parseOutline(value, options)
-
-      expect(result).toEqual({
+      const expected = {
         text: 'No custom attrs',
         type: 'rss',
-      })
+      }
+
+      expect(parseOutline(value, options)).toEqual(expected)
     })
 
     it('should handle case-insensitive attribute matching', () => {
@@ -255,13 +276,13 @@ describe('parseOutline', () => {
       const options = {
         extraOutlineAttributes: ['customField', 'anotherField'],
       }
-      const result = parseOutline(value, options)
-
-      expect(result).toEqual({
+      const expected = {
         text: 'Test',
         customField: 'value1',
         anotherField: 'value2',
-      })
+      }
+
+      expect(parseOutline(value, options)).toEqual(expected)
     })
   })
 })
@@ -464,7 +485,7 @@ describe('parseBody', () => {
   })
 
   describe('with maxItems option', () => {
-    const commonValue = {
+    const value = {
       outline: [
         {
           '@text': 'Outline 1',
@@ -495,11 +516,11 @@ describe('parseBody', () => {
         ],
       }
 
-      expect(parseBody(commonValue, { maxItems: 2 })).toEqual(expected)
+      expect(parseBody(value, { maxItems: 2 })).toEqual(expected)
     })
 
     it('should skip all outlines when maxItems is 0', () => {
-      expect(parseBody(commonValue, { maxItems: 0 })).toBeUndefined()
+      expect(parseBody(value, { maxItems: 0 })).toBeUndefined()
     })
 
     it('should return all outlines when maxItems is undefined', () => {
@@ -520,7 +541,7 @@ describe('parseBody', () => {
         ],
       }
 
-      expect(parseBody(commonValue, { maxItems: undefined })).toEqual(expected)
+      expect(parseBody(value, { maxItems: undefined })).toEqual(expected)
     })
   })
 })


### PR DESCRIPTION
Aligns the test suite with the conventions shared across the feed* libraries and fills coverage gaps. Tests only, no source changes.

- Adds runtime assertions to the 29 strict-mode tests that previously asserted nothing
- Fixes two tests that never exercised their target code due to wrong-cased fixture keys
- Removes ~20 duplicated tests and renames misleading ones
- Converts toEqual on primitives to toBe and inline throw lambdas to throwing consts
- Types expected objects (AnyFeed) instead of as-const literals; canonicalizes ts-expect-error comments
- Replaces real third-party URLs, publications, and show data in test literals with example equivalents (reference fixtures untouched)
- Nests stray top-level describes under their function describes and moves misfiled tests
- Adds ~120 tests (untested exports in rawvoice/psc/media/googleplay, detect and parse gaps, family-standard batteries for thin namespaces, empty-object cases for podcast and media leaf generators) plus ~55 it.todo placeholders

Suite grows from 3892 to 4224 passing tests. Several source-side quirks surfaced by the audit are documented as it.todo entries rather than pinned (detector XML-comment false positives, googleplay parseExplicit type handling, spotify generateSandbox untrimmed output, atom person serialization asymmetry).