### PR TITLE
refactor: Adopt trousse for shared helpers

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -11,6 +11,7 @@
       "devDependencies": {
         "@types/bun": "^1.3.14",
         "kvalita": "^1.15.1",
+        "trousse": "^1.0.0",
         "tsdown": "^0.22.0",
         "vitepress": "^2.0.0-alpha.17",
       },
@@ -952,6 +953,8 @@
     "tree-kill": ["tree-kill@1.2.2", "", { "bin": { "tree-kill": "cli.js" } }, "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A=="],
 
     "trim-lines": ["trim-lines@3.0.1", "", {}, "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg=="],
+
+    "trousse": ["trousse@1.0.0", "", {}, "sha512-7LseR5OljMoiUS84d/IgAJWvc6aw4lMFBZ9dE0LmNSNgWbFSj5luyla5qLcUER4Z6g0TRSDND+vQaj4Lr5X2xA=="],
 
     "tsdown": ["tsdown@0.22.0", "", { "dependencies": { "ansis": "^4.2.0", "cac": "^7.0.0", "defu": "^6.1.7", "empathic": "^2.0.0", "hookable": "^6.1.1", "import-without-cache": "^0.4.0", "obug": "^2.1.1", "picomatch": "^4.0.4", "rolldown": "^1.0.0", "rolldown-plugin-dts": "^0.25.0", "semver": "^7.7.4", "tinyexec": "^1.1.2", "tinyglobby": "^0.2.16", "tree-kill": "^1.2.2", "unconfig-core": "^7.5.0" }, "peerDependencies": { "@arethetypeswrong/core": "^0.18.1", "@tsdown/css": "0.22.0", "@tsdown/exe": "0.22.0", "@vitejs/devtools": "*", "publint": "^0.3.8", "tsx": "*", "typescript": "^5.0.0 || ^6.0.0", "unplugin-unused": "^0.5.0", "unrun": "*" }, "optionalPeers": ["@arethetypeswrong/core", "@tsdown/css", "@tsdown/exe", "@vitejs/devtools", "publint", "tsx", "typescript", "unplugin-unused", "unrun"], "bin": { "tsdown": "./dist/run.mjs" } }, "sha512-FgW0hHb27nGQA/+F3d5+U9wKXkfilk9DVkc5+7x/ZqF03g+Hoz/eeApT32jqxATt9eRoR+1jxk7MUMON+O4CXw=="],
 

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
   "devDependencies": {
     "@types/bun": "^1.3.14",
     "kvalita": "^1.15.1",
+    "trousse": "^1.0.0",
     "tsdown": "^0.22.0",
     "vitepress": "^2.0.0-alpha.17"
   }

--- a/src/common/utils.test.ts
+++ b/src/common/utils.test.ts
@@ -20,10 +20,8 @@ import {
   generateXmlStylesheet,
   generateYesNoBoolean,
   hasEntities,
-  isNonEmptyString,
   isNonEmptyStringOrNumber,
   isObject,
-  isPresent,
   limitArray,
   parseArray,
   parseArrayOf,
@@ -42,69 +40,6 @@ import {
   trimArray,
   trimObject,
 } from './utils.js'
-
-describe('isPresent', () => {
-  it('should return false for null', () => {
-    expect(isPresent(null)).toBe(false)
-  })
-
-  it('should return false for undefined', () => {
-    expect(isPresent(undefined)).toBe(false)
-  })
-
-  it('should return true for empty string', () => {
-    expect(isPresent('')).toBe(true)
-  })
-
-  it('should return true for zero', () => {
-    expect(isPresent(0)).toBe(true)
-  })
-
-  it('should return true for NaN', () => {
-    expect(isPresent(Number.NaN)).toBe(true)
-  })
-
-  it('should return true for false', () => {
-    expect(isPresent(false)).toBe(true)
-  })
-
-  it('should return true for empty objects', () => {
-    expect(isPresent({})).toBe(true)
-  })
-
-  it('should return true for empty arrays', () => {
-    expect(isPresent([])).toBe(true)
-  })
-
-  it('should return true for string values', () => {
-    expect(isPresent('hello')).toBe(true)
-  })
-
-  it('should return true for number values', () => {
-    expect(isPresent(123)).toBe(true)
-  })
-
-  it('should return true for object values', () => {
-    expect(isPresent({ key: 'value' })).toBe(true)
-  })
-
-  it('should return true for array values', () => {
-    expect(isPresent([1, 2, 3])).toBe(true)
-  })
-
-  it('should return true for function values', () => {
-    expect(isPresent(() => {})).toBe(true)
-  })
-
-  it('should return true for Date objects', () => {
-    expect(isPresent(new Date())).toBe(true)
-  })
-
-  it('should return true for RegExp objects', () => {
-    // biome-ignore lint/performance/useTopLevelRegex: It's for testing purposes.
-    expect(isPresent(/test/)).toBe(true)
-  })
-})
 
 describe('isObject', () => {
   it('should return true for plain objects', () => {
@@ -164,73 +99,6 @@ describe('isObject', () => {
 
   it('should return false for objects with null prototype', () => {
     expect(isObject(Object.create(null))).toBe(false)
-  })
-})
-
-describe('isNonEmptyString', () => {
-  it('should return true for non-empty strings', () => {
-    expect(isNonEmptyString('hello')).toBe(true)
-    expect(isNonEmptyString('0')).toBe(true)
-    expect(isNonEmptyString('undefined')).toBe(true)
-    expect(isNonEmptyString('null')).toBe(true)
-  })
-
-  it('should handle edge cases', () => {
-    // biome-ignore lint/style/useConsistentBuiltinInstantiation: It's for testing purposes.
-    const stringObject = new String('hello')
-
-    expect(isNonEmptyString(stringObject)).toBe(false)
-  })
-
-  it('should return false for empty strings', () => {
-    expect(isNonEmptyString('')).toBe(false)
-    expect(isNonEmptyString(' ')).toBe(false)
-  })
-
-  it('should return false for unicode whitespace-only strings', () => {
-    expect(isNonEmptyString('\u00a0')).toBe(false)
-    expect(isNonEmptyString('\u2002\u2003')).toBe(false)
-    expect(isNonEmptyString('\u3000')).toBe(false)
-  })
-
-  it('should return false for number', () => {
-    expect(isNonEmptyString(2)).toBe(false)
-  })
-
-  it('should return false for arrays', () => {
-    expect(isNonEmptyString([])).toBe(false)
-    expect(isNonEmptyString([1, 2, 3])).toBe(false)
-    expect(isNonEmptyString(['hello'])).toBe(false)
-  })
-
-  it('should return false for objects', () => {
-    expect(isNonEmptyString({})).toBe(false)
-    expect(isNonEmptyString({ key: 'value' })).toBe(false)
-    expect(isNonEmptyString(new Date())).toBe(false)
-  })
-
-  it('should return false for null and undefined', () => {
-    expect(isNonEmptyString(null)).toBe(false)
-    expect(isNonEmptyString(undefined)).toBe(false)
-  })
-
-  it('should return false for booleans', () => {
-    expect(isNonEmptyString(true)).toBe(false)
-    expect(isNonEmptyString(false)).toBe(false)
-  })
-
-  it('should return false for functions', () => {
-    expect(isNonEmptyString(() => {})).toBe(false)
-    // biome-ignore lint/complexity/useArrowFunction: It's for testing purposes.
-    expect(isNonEmptyString(function () {})).toBe(false)
-  })
-
-  it('should return false for symbols', () => {
-    expect(isNonEmptyString(Symbol('test'))).toBe(false)
-  })
-
-  it('should return false for BigInt', () => {
-    expect(isNonEmptyString(BigInt(123))).toBe(false)
   })
 })
 

--- a/src/common/utils.test.ts
+++ b/src/common/utils.test.ts
@@ -21,7 +21,6 @@ import {
   generateYesNoBoolean,
   hasEntities,
   isNonEmptyStringOrNumber,
-  isObject,
   limitArray,
   parseArray,
   parseArrayOf,
@@ -40,67 +39,6 @@ import {
   trimArray,
   trimObject,
 } from './utils.js'
-
-describe('isObject', () => {
-  it('should return true for plain objects', () => {
-    expect(isObject({})).toBe(true)
-    expect(isObject({ a: 1 })).toBe(true)
-    expect(isObject({ a: null, b: undefined })).toBe(true)
-    expect(isObject({ toString: () => 'custom' })).toBe(true)
-  })
-
-  it('should return false for arrays', () => {
-    expect(isObject([])).toBe(false)
-    expect(isObject([1, 2, 3])).toBe(false)
-    expect(isObject(new Array(5))).toBe(false)
-  })
-
-  it('should return false for null', () => {
-    expect(isObject(null)).toBe(false)
-  })
-
-  it('should return false for undefined', () => {
-    expect(isObject(undefined)).toBe(false)
-  })
-
-  it('should return false for primitive types', () => {
-    expect(isObject(42)).toBe(false)
-    expect(isObject('string')).toBe(false)
-    expect(isObject(true)).toBe(false)
-    expect(isObject(Symbol('sym'))).toBe(false)
-    expect(isObject(BigInt(123))).toBe(false)
-  })
-
-  it('should return false for functions', () => {
-    expect(isObject(() => {})).toBe(false)
-    // biome-ignore lint/complexity/useArrowFunction: It's for testing purposes.
-    expect(isObject(function () {})).toBe(false)
-    expect(isObject(Math.sin)).toBe(false)
-  })
-
-  it('should return false for objects with custom prototypes', () => {
-    class CustomClass {}
-
-    expect(isObject(new CustomClass())).toBe(false)
-  })
-
-  it('should return false for built-in objects', () => {
-    expect(isObject(new Date())).toBe(false)
-    // biome-ignore lint/suspicious/useErrorMessage: It's for testing purposes.
-    expect(isObject(new Error())).toBe(false)
-    expect(isObject(new Map())).toBe(false)
-    expect(isObject(new Set())).toBe(false)
-    expect(isObject(new WeakMap())).toBe(false)
-    expect(isObject(new WeakSet())).toBe(false)
-    // biome-ignore lint/complexity/useRegexLiterals: It's for testing purposes.
-    expect(isObject(new RegExp('.'))).toBe(false)
-    expect(isObject(new ArrayBuffer(10))).toBe(false)
-  })
-
-  it('should return false for objects with null prototype', () => {
-    expect(isObject(Object.create(null))).toBe(false)
-  })
-})
 
 describe('isNonEmptyStringOrNumber', () => {
   it('should return true for non-empty strings', () => {

--- a/src/common/utils.ts
+++ b/src/common/utils.ts
@@ -1,5 +1,14 @@
 import { decodeHTML } from 'entities'
 import type { XMLBuilder } from 'fast-xml-parser'
+import {
+  coerceBoolean,
+  coerceNumber,
+  coerceSingular,
+  isNonEmptyString,
+  isNumber,
+  isPlainObject,
+  isPresent,
+} from 'trousse'
 import type {
   AnyOf,
   DateAny,
@@ -10,27 +19,12 @@ import type {
   XmlStylesheet,
 } from './types.js'
 
-export const isPresent = <T>(value: T): value is NonNullable<T> => {
-  return value != null
-}
-
 export const isObject = (value: Unreliable): value is Record<string, Unreliable> => {
-  return (
-    value != null &&
-    typeof value === 'object' &&
-    !Array.isArray(value) &&
-    value.constructor === Object
-  )
-}
-
-const whitespaceOnlyRegex = /^\p{White_Space}*$/u
-
-export const isNonEmptyString = (value: Unreliable): value is string => {
-  return typeof value === 'string' && value !== '' && !whitespaceOnlyRegex.test(value)
+  return isPlainObject(value)
 }
 
 export const isNonEmptyStringOrNumber = (value: Unreliable): value is string | number => {
-  return typeof value === 'number' || isNonEmptyString(value)
+  return isNumber(value) || isNonEmptyString(value)
 }
 
 export const retrieveText = (value: Unreliable): Unreliable => {
@@ -249,35 +243,13 @@ export const parseJsonString: ParseUtilExact<string> = (value) => {
 }
 
 export const parseNumber: ParseUtilExact<number> = (value) => {
-  if (typeof value === 'number') {
-    return value
-  }
-
-  if (isNonEmptyString(value)) {
-    const numeric = +value
-
-    return Number.isNaN(numeric) ? undefined : numeric
-  }
+  return coerceNumber(value)
 }
 
-const trueRegex = /^\p{White_Space}*true\p{White_Space}*$/iu
-const falseRegex = /^\p{White_Space}*false\p{White_Space}*$/iu
 const yesRegex = /^\p{White_Space}*yes\p{White_Space}*$/iu
 
 export const parseBoolean: ParseUtilExact<boolean> = (value) => {
-  if (typeof value === 'boolean') {
-    return value
-  }
-
-  if (isNonEmptyString(value)) {
-    if (trueRegex.test(value)) {
-      return true
-    }
-
-    if (falseRegex.test(value)) {
-      return false
-    }
-  }
+  return coerceBoolean(value)
 }
 
 export const parseYesNoBoolean: ParseUtilExact<boolean> = (value) => {
@@ -365,7 +337,7 @@ export const limitArray = <T>(array: Array<T>, limit: number | undefined): Array
 }
 
 export const parseSingular = <T>(value: T | Array<T>): T => {
-  return Array.isArray(value) ? value[0] : value
+  return coerceSingular(value)
 }
 
 export const parseSingularOf = <R>(value: Unreliable, parse: ParseUtilExact<R>): R | undefined => {

--- a/src/common/utils.ts
+++ b/src/common/utils.ts
@@ -19,10 +19,6 @@ import type {
   XmlStylesheet,
 } from './types.js'
 
-export const isObject = (value: Unreliable): value is Record<string, Unreliable> => {
-  return isPlainObject(value)
-}
-
 export const isNonEmptyStringOrNumber = (value: Unreliable): value is string | number => {
   return isNumber(value) || isNonEmptyString(value)
 }
@@ -35,7 +31,7 @@ export const retrieveRdfResourceOrText = <T>(
   value: Unreliable,
   parse: (value: Unreliable) => T | undefined,
 ): T | undefined => {
-  if (isObject(value)) {
+  if (isPlainObject(value)) {
     const rdfResource = parse(value['@rdf:resource'])
 
     if (isPresent(rdfResource)) {
@@ -282,7 +278,7 @@ export const parseArray: ParseUtilExact<Array<Unreliable>> = (value) => {
     return value
   }
 
-  if (!isObject(value)) {
+  if (!isPlainObject(value)) {
     return
   }
 
@@ -503,7 +499,7 @@ export const detectNamespaces = (value: unknown, recursive = false): Set<string>
       return
     }
 
-    if (isObject(current)) {
+    if (isPlainObject(current)) {
       // biome-ignore lint/suspicious/noForIn: Plain object; avoids per-call Object.keys allocation.
       for (const key in current) {
         if (seenKeys?.has(key)) {
@@ -548,7 +544,7 @@ export const generateCdataString: GenerateUtil<string> = (value) => {
 export const generateTextOrCdataString: GenerateUtil<string> = (value) => {
   const result = generateCdataString(value)
 
-  if (!result || isObject(result)) {
+  if (!result || isPlainObject(result)) {
     return result
   }
 
@@ -588,7 +584,7 @@ export const generateNamespaceAttrs = (
   value: Unreliable,
   namespaceUris: Record<string, Array<string>>,
 ): Record<string, string> | undefined => {
-  if (!isObject(value)) {
+  if (!isPlainObject(value)) {
     return
   }
 
@@ -656,14 +652,14 @@ export const createNamespaceNormalizator = <T extends Record<string, Array<strin
   const extractNamespaceDeclarations = (element: Unreliable): Record<string, string> => {
     const declarations: Record<string, string> = {}
 
-    if (isObject(element)) {
+    if (isPlainObject(element)) {
       // biome-ignore lint/suspicious/noForIn: Plain object; avoids per-call Object.keys allocation.
       for (const key in element) {
         if (key === '@xmlns') {
-          declarations[''] = normalizeNamespaceUri(element[key])
+          declarations[''] = normalizeNamespaceUri(element[key] as Unreliable)
         } else if (key.indexOf('@xmlns:') === 0) {
           const prefix = key.slice('@xmlns:'.length)
-          declarations[prefix] = normalizeNamespaceUri(element[key])
+          declarations[prefix] = normalizeNamespaceUri(element[key] as Unreliable)
         }
       }
     }
@@ -712,12 +708,12 @@ export const createNamespaceNormalizator = <T extends Record<string, Array<strin
     object: Unreliable,
     parentContext: Record<string, string> = {},
   ): Unreliable => {
-    // Check arrays first since isObject() excludes arrays.
+    // Check arrays first since isPlainObject() excludes arrays.
     if (Array.isArray(object)) {
       return object.map((item) => traverseAndNormalize(item, parentContext))
     }
 
-    if (!isObject(object)) {
+    if (!isPlainObject(object)) {
       return object
     }
 
@@ -773,7 +769,7 @@ export const createNamespaceNormalizator = <T extends Record<string, Array<strin
         return false
       }
 
-      if (!isObject(value)) {
+      if (!isPlainObject(value)) {
         return false
       }
 
@@ -782,7 +778,7 @@ export const createNamespaceNormalizator = <T extends Record<string, Array<strin
         if (key[0] === '@') {
           // Attribute key (@*) — only xmlns declarations matter.
           if (key === '@xmlns') {
-            const normalizedUri = normalizeNamespaceUri(value[key])
+            const normalizedUri = normalizeNamespaceUri(value[key] as Unreliable)
 
             if (primaryNamespaceUris?.includes(normalizedUri)) {
               // Default namespace maps to a primary namespace — unprefixed
@@ -797,7 +793,7 @@ export const createNamespaceNormalizator = <T extends Record<string, Array<strin
             }
           } else if (key.startsWith('@xmlns:')) {
             const prefix = key.slice(7)
-            const normalizedUri = normalizeNamespaceUri(value[key])
+            const normalizedUri = normalizeNamespaceUri(value[key] as Unreliable)
             const standardPrefix = namespacePrefixes[normalizedUri]
 
             if (standardPrefix) {
@@ -836,7 +832,7 @@ export const createNamespaceNormalizator = <T extends Record<string, Array<strin
   // For the root level, we need to handle the special case where the root element
   // itself has namespace declarations that apply to its own normalization.
   const normalizeRoot = (object: Unreliable): Unreliable => {
-    if (!isObject(object)) {
+    if (!isPlainObject(object)) {
       return object
     }
 
@@ -870,7 +866,7 @@ const startsWithBraceRegex = /^\s*\{/
 const endsWithBraceRegex = /\}\s*$/
 
 export const parseJsonObject = (value: unknown): unknown => {
-  if (isObject(value)) {
+  if (isPlainObject(value)) {
     return value
   }
 

--- a/src/feeds/atom/detect/index.ts
+++ b/src/feeds/atom/detect/index.ts
@@ -1,5 +1,5 @@
+import { isNonEmptyString } from 'trousse'
 import { namespaceUris } from '../../../common/config.js'
-import { isNonEmptyString } from '../../../common/utils.js'
 
 const feedElementRegex = /(?:^|[\s>])<(?:\w+:)?feed[\s>]/im
 const atomElementsRegex = /(<(?:\w+:)?(entry|title|link|id|updated|summary)[\s>])/i

--- a/src/feeds/atom/generate/utils.ts
+++ b/src/feeds/atom/generate/utils.ts
@@ -1,3 +1,4 @@
+import { isPlainObject } from 'trousse'
 import { namespaceUris } from '../../../common/config.js'
 import type { DateLike } from '../../../common/types.js'
 import {
@@ -7,7 +8,6 @@ import {
   generatePlainString,
   generateRfc3339Date,
   generateTextOrCdataString,
-  isObject,
   trimArray,
   trimObject,
 } from '../../../common/utils.js'
@@ -58,7 +58,7 @@ export const createNamespaceSetter = (prefix: string | undefined) => {
 }
 
 export const generateText: GenerateUtil<AtomFeed.Text> = (text) => {
-  if (!isObject(text)) {
+  if (!isPlainObject(text)) {
     return
   }
 
@@ -70,7 +70,7 @@ export const generateText: GenerateUtil<AtomFeed.Text> = (text) => {
 }
 
 export const generateContent: GenerateUtil<AtomFeed.Content> = (content) => {
-  if (!isObject(content)) {
+  if (!isPlainObject(content)) {
     return
   }
 
@@ -85,7 +85,7 @@ export const generateContent: GenerateUtil<AtomFeed.Content> = (content) => {
 }
 
 export const generateLink: GenerateUtil<AtomFeed.Link<DateLike>> = (link) => {
-  if (!isObject(link)) {
+  if (!isPlainObject(link)) {
     return
   }
 
@@ -103,7 +103,7 @@ export const generateLink: GenerateUtil<AtomFeed.Link<DateLike>> = (link) => {
 }
 
 export const generatePerson: GenerateUtil<AtomFeed.Person> = (person, options) => {
-  if (!isObject(person)) {
+  if (!isPlainObject(person)) {
     return
   }
 
@@ -119,7 +119,7 @@ export const generatePerson: GenerateUtil<AtomFeed.Person> = (person, options) =
 }
 
 export const generateCategory: GenerateUtil<AtomFeed.Category> = (category) => {
-  if (!isObject(category)) {
+  if (!isPlainObject(category)) {
     return
   }
 
@@ -133,7 +133,7 @@ export const generateCategory: GenerateUtil<AtomFeed.Category> = (category) => {
 }
 
 export const generateGenerator: GenerateUtil<AtomFeed.Generator> = (generator) => {
-  if (!isObject(generator)) {
+  if (!isPlainObject(generator)) {
     return
   }
 
@@ -147,7 +147,7 @@ export const generateGenerator: GenerateUtil<AtomFeed.Generator> = (generator) =
 }
 
 export const generateSource: GenerateUtil<AtomFeed.Source<DateLike>> = (source, options) => {
-  if (!isObject(source)) {
+  if (!isPlainObject(source)) {
     return
   }
 
@@ -175,7 +175,7 @@ export const generateSource: GenerateUtil<AtomFeed.Source<DateLike>> = (source, 
 }
 
 export const generateEntry: GenerateUtil<AtomFeed.Entry<DateLike>> = (entry, options) => {
-  if (!isObject(entry)) {
+  if (!isPlainObject(entry)) {
     return
   }
 
@@ -232,7 +232,7 @@ export const generateEntry: GenerateUtil<AtomFeed.Entry<DateLike>> = (entry, opt
 }
 
 export const generateFeed: GenerateUtil<AtomFeed.Feed<DateLike>> = (feed, options) => {
-  if (!isObject(feed)) {
+  if (!isPlainObject(feed)) {
     return
   }
 

--- a/src/feeds/atom/parse/utils.ts
+++ b/src/feeds/atom/parse/utils.ts
@@ -1,8 +1,7 @@
-import { isNonEmptyString } from 'trousse'
+import { isNonEmptyString, isPlainObject } from 'trousse'
 import type { DateAny, Unreliable } from '../../../common/types.js'
 import {
   detectNamespaces,
-  isObject,
   parseArrayOf,
   parseDate,
   parseNumber,
@@ -71,7 +70,7 @@ export const parseText: ParseUtilPartial<AtomFeed.Text> = (value) => {
     return parsed ? { value: parsed } : undefined
   }
 
-  if (!isObject(value)) {
+  if (!isPlainObject(value)) {
     return
   }
 
@@ -97,7 +96,7 @@ export const parseContent: ParseUtilPartial<AtomFeed.Content> = (value) => {
     return parsed ? { value: parsed } : undefined
   }
 
-  if (!isObject(value)) {
+  if (!isPlainObject(value)) {
     return
   }
 
@@ -112,7 +111,7 @@ export const parseContent: ParseUtilPartial<AtomFeed.Content> = (value) => {
 }
 
 export const parseLink: ParseUtilPartial<AtomFeed.Link<DateAny>> = (value, options) => {
-  if (!isObject(value)) {
+  if (!isPlainObject(value)) {
     return
   }
 
@@ -131,7 +130,7 @@ export const parseLink: ParseUtilPartial<AtomFeed.Link<DateAny>> = (value, optio
 }
 
 export const retrievePersonUri: ParseUtilPartial<string> = (value, options) => {
-  if (!isObject(value)) {
+  if (!isPlainObject(value)) {
     return
   }
 
@@ -143,7 +142,7 @@ export const retrievePersonUri: ParseUtilPartial<string> = (value, options) => {
 }
 
 export const parsePerson: ParseUtilPartial<AtomFeed.Person> = (value, options) => {
-  if (!isObject(value)) {
+  if (!isPlainObject(value)) {
     return
   }
 
@@ -160,7 +159,7 @@ export const parsePerson: ParseUtilPartial<AtomFeed.Person> = (value, options) =
 }
 
 export const parseCategory: ParseUtilPartial<AtomFeed.Category> = (value) => {
-  if (!isObject(value)) {
+  if (!isPlainObject(value)) {
     return
   }
 
@@ -174,7 +173,7 @@ export const parseCategory: ParseUtilPartial<AtomFeed.Category> = (value) => {
 }
 
 export const retrieveGeneratorUri: ParseUtilPartial<string> = (value) => {
-  if (!isObject(value)) {
+  if (!isPlainObject(value)) {
     return
   }
 
@@ -195,7 +194,7 @@ export const parseGenerator: ParseUtilPartial<AtomFeed.Generator> = (value) => {
 }
 
 export const parseSource: ParseUtilPartial<AtomFeed.Source<DateAny>> = (value, options) => {
-  if (!isObject(value)) {
+  if (!isPlainObject(value)) {
     return
   }
 
@@ -219,7 +218,7 @@ export const parseSource: ParseUtilPartial<AtomFeed.Source<DateAny>> = (value, o
 }
 
 export const retrievePublished: ParseUtilPartial<DateAny> = (value, options) => {
-  if (!isObject(value)) {
+  if (!isPlainObject(value)) {
     return
   }
 
@@ -241,7 +240,7 @@ export const retrievePublished: ParseUtilPartial<DateAny> = (value, options) => 
 }
 
 export const retrieveUpdated: ParseUtilPartial<DateAny> = (value, options) => {
-  if (!isObject(value)) {
+  if (!isPlainObject(value)) {
     return
   }
 
@@ -257,7 +256,7 @@ export const retrieveUpdated: ParseUtilPartial<DateAny> = (value, options) => {
 }
 
 export const retrieveSubtitle: ParseUtilPartial<AtomFeed.Text> = (value, options) => {
-  if (!isObject(value)) {
+  if (!isPlainObject(value)) {
     return
   }
 
@@ -269,7 +268,7 @@ export const retrieveSubtitle: ParseUtilPartial<AtomFeed.Text> = (value, options
 }
 
 export const parseEntry: ParseUtilPartial<AtomFeed.Entry<DateAny>> = (value, options) => {
-  if (!isObject(value)) {
+  if (!isPlainObject(value)) {
     return
   }
 
@@ -315,7 +314,7 @@ export const parseEntry: ParseUtilPartial<AtomFeed.Entry<DateAny>> = (value, opt
 }
 
 export const parseFeed: ParseUtilPartial<AtomFeed.Feed<DateAny>> = (value, options) => {
-  if (!isObject(value)) {
+  if (!isPlainObject(value)) {
     return
   }
 

--- a/src/feeds/atom/parse/utils.ts
+++ b/src/feeds/atom/parse/utils.ts
@@ -1,7 +1,7 @@
+import { isNonEmptyString } from 'trousse'
 import type { DateAny, Unreliable } from '../../../common/types.js'
 import {
   detectNamespaces,
-  isNonEmptyString,
   isObject,
   parseArrayOf,
   parseDate,

--- a/src/feeds/json/detect/index.ts
+++ b/src/feeds/json/detect/index.ts
@@ -1,4 +1,5 @@
-import { isNonEmptyString, isObject, parseJsonObject } from '../../../common/utils.js'
+import { isNonEmptyString } from 'trousse'
+import { isObject, parseJsonObject } from '../../../common/utils.js'
 import { createCaseInsensitiveGetter } from '../parse/utils.js'
 
 export const detect = (value: unknown): value is object => {

--- a/src/feeds/json/detect/index.ts
+++ b/src/feeds/json/detect/index.ts
@@ -1,11 +1,11 @@
-import { isNonEmptyString } from 'trousse'
-import { isObject, parseJsonObject } from '../../../common/utils.js'
+import { isNonEmptyString, isPlainObject } from 'trousse'
+import { parseJsonObject } from '../../../common/utils.js'
 import { createCaseInsensitiveGetter } from '../parse/utils.js'
 
 export const detect = (value: unknown): value is object => {
   const json = parseJsonObject(value)
 
-  if (!isObject(json)) {
+  if (!isPlainObject(json)) {
     return false
   }
 

--- a/src/feeds/json/generate/utils.ts
+++ b/src/feeds/json/generate/utils.ts
@@ -1,5 +1,6 @@
+import { isPlainObject } from 'trousse'
 import type { DateLike } from '../../../common/types.js'
-import { generateRfc3339Date, isObject, trimArray, trimObject } from '../../../common/utils.js'
+import { generateRfc3339Date, trimArray, trimObject } from '../../../common/utils.js'
 import type { GenerateUtil, JsonFeed } from '../common/types.js'
 
 export const generateItem: GenerateUtil<JsonFeed.Item<DateLike>> = (item) => {
@@ -13,7 +14,7 @@ export const generateItem: GenerateUtil<JsonFeed.Item<DateLike>> = (item) => {
 }
 
 export const generateFeed: GenerateUtil<JsonFeed.Feed<DateLike>> = (feed) => {
-  if (!isObject(feed)) {
+  if (!isPlainObject(feed)) {
     return
   }
 

--- a/src/feeds/json/parse/utils.ts
+++ b/src/feeds/json/parse/utils.ts
@@ -1,7 +1,7 @@
+import { isPlainObject } from 'trousse'
 import type { DateAny } from '../../../common/types.js'
 import {
   isNonEmptyStringOrNumber,
-  isObject,
   parseArrayOf,
   parseBoolean,
   parseDate,
@@ -30,7 +30,7 @@ export const createCaseInsensitiveGetter = (value: Record<string, unknown>) => {
 }
 
 export const parseAuthor: ParseUtilPartial<JsonFeed.Author> = (value) => {
-  if (isObject(value)) {
+  if (isPlainObject(value)) {
     const get = createCaseInsensitiveGetter(value)
     const author = {
       name: parseSingularOf(get('name'), parseJsonString),
@@ -51,7 +51,7 @@ export const parseAuthor: ParseUtilPartial<JsonFeed.Author> = (value) => {
 }
 
 export const retrieveAuthors: ParseUtilPartial<Array<JsonFeed.Author>> = (value) => {
-  if (!isObject(value)) {
+  if (!isPlainObject(value)) {
     return
   }
 
@@ -66,7 +66,7 @@ export const retrieveAuthors: ParseUtilPartial<Array<JsonFeed.Author>> = (value)
 }
 
 export const parseAttachment: ParseUtilPartial<JsonFeed.Attachment> = (value) => {
-  if (!isObject(value)) {
+  if (!isPlainObject(value)) {
     return
   }
 
@@ -83,7 +83,7 @@ export const parseAttachment: ParseUtilPartial<JsonFeed.Attachment> = (value) =>
 }
 
 export const parseItem: ParseUtilPartial<JsonFeed.Item<DateAny>> = (value, options) => {
-  if (!isObject(value)) {
+  if (!isPlainObject(value)) {
     return
   }
 
@@ -114,7 +114,7 @@ export const parseItem: ParseUtilPartial<JsonFeed.Item<DateAny>> = (value, optio
 }
 
 export const parseHub: ParseUtilPartial<JsonFeed.Hub> = (value) => {
-  if (!isObject(value)) {
+  if (!isPlainObject(value)) {
     return
   }
 
@@ -128,7 +128,7 @@ export const parseHub: ParseUtilPartial<JsonFeed.Hub> = (value) => {
 }
 
 export const parseFeed: ParseUtilPartial<JsonFeed.Feed<DateAny>> = (value, options) => {
-  if (!isObject(value)) {
+  if (!isPlainObject(value)) {
     return
   }
 

--- a/src/feeds/rdf/detect/index.ts
+++ b/src/feeds/rdf/detect/index.ts
@@ -1,5 +1,5 @@
+import { isNonEmptyString } from 'trousse'
 import { namespaceUris } from '../../../common/config.js'
-import { isNonEmptyString } from '../../../common/utils.js'
 
 // RSS 0.9/1.0 namespace URIs (used for detection only, not in namespacePrefixes
 // since these elements are the default/unprefixed content in RDF feeds).

--- a/src/feeds/rdf/parse/utils.ts
+++ b/src/feeds/rdf/parse/utils.ts
@@ -1,7 +1,7 @@
-import type { DateAny } from '../../../common/types.js'
+import { isPlainObject } from 'trousse'
+import type { DateAny, Unreliable } from '../../../common/types.js'
 import {
   detectNamespaces,
-  isObject,
   parseArrayOf,
   parseSingular,
   parseSingularOf,
@@ -38,11 +38,11 @@ const retrieveByAbout = (elements: unknown, resourceUri: string | undefined): un
 }
 
 const findByTocReference = (value: unknown, property: string): unknown => {
-  if (!isObject(value)) {
+  if (!isPlainObject(value)) {
     return
   }
 
-  const channel = parseSingular(value.channel)
+  const channel = parseSingular(value.channel as Unreliable)
   const resourceRef = parseSingular(channel?.[property])
   const resourceUri = parseString(resourceRef?.['@resource'])
 
@@ -50,7 +50,7 @@ const findByTocReference = (value: unknown, property: string): unknown => {
 }
 
 export const parseImage: ParseUtilPartial<RdfFeed.Image> = (value) => {
-  if (!isObject(value)) {
+  if (!isPlainObject(value)) {
     return
   }
 
@@ -69,7 +69,7 @@ export const retrieveImage: ParseUtilPartial<RdfFeed.Image> = (value) => {
 }
 
 export const parseTextInput: ParseUtilPartial<RdfFeed.TextInput> = (value) => {
-  if (!isObject(value)) {
+  if (!isPlainObject(value)) {
     return
   }
 
@@ -92,7 +92,7 @@ export const retrieveTextInput: ParseUtilPartial<RdfFeed.TextInput> = (value) =>
 }
 
 export const parseItem: ParseUtilPartial<RdfFeed.Item<DateAny>> = (value, options) => {
-  if (!isObject(value)) {
+  if (!isPlainObject(value)) {
     return
   }
 
@@ -117,11 +117,11 @@ export const parseItem: ParseUtilPartial<RdfFeed.Item<DateAny>> = (value, option
 }
 
 export const retrieveItems: ParseUtilPartial<Array<RdfFeed.Item<DateAny>>> = (value, options) => {
-  if (!isObject(value)) {
+  if (!isPlainObject(value)) {
     return
   }
 
-  const channel = parseSingular(value.channel)
+  const channel = parseSingular(value.channel as Unreliable)
   const tocItems = parseSingular(channel?.items)
   const itemsSeq = parseSingular(tocItems?.seq)
   const itemUris = parseArrayOf(
@@ -142,11 +142,11 @@ export const retrieveItems: ParseUtilPartial<Array<RdfFeed.Item<DateAny>>> = (va
 }
 
 export const parseFeed: ParseUtilPartial<RdfFeed.Feed<DateAny>> = (value, options) => {
-  if (!isObject(value)) {
+  if (!isPlainObject(value)) {
     return
   }
 
-  const channel = parseSingular(value.channel)
+  const channel = parseSingular(value.channel as Unreliable)
   const namespaces = detectNamespaces(channel)
   const feed = {
     title: parseSingularOf(channel?.title, (value) => parseString(retrieveText(value))),

--- a/src/feeds/rss/detect/index.ts
+++ b/src/feeds/rss/detect/index.ts
@@ -1,4 +1,4 @@
-import { isNonEmptyString } from '../../../common/utils.js'
+import { isNonEmptyString } from 'trousse'
 
 const rssElementRegex = /(?:^|[\s>])<(?:\w+:)?rss[\s>]/im
 const versionAttributeRegex = /version\s*=\s*["'][^"']*["']/i

--- a/src/feeds/rss/generate/utils.ts
+++ b/src/feeds/rss/generate/utils.ts
@@ -1,3 +1,4 @@
+import { isPlainObject } from 'trousse'
 import { namespaceUris } from '../../../common/config.js'
 import type { DateLike } from '../../../common/types.js'
 import {
@@ -8,7 +9,6 @@ import {
   generatePlainString,
   generateRfc822Date,
   generateTextOrCdataString,
-  isObject,
   trimArray,
   trimObject,
 } from '../../../common/utils.js'
@@ -74,7 +74,7 @@ import { generateItemOrFeed as generateXmlItemOrFeed } from '../../../namespaces
 import type { GenerateUtil, RssFeed } from '../common/types.js'
 
 export const generatePerson: GenerateUtil<RssFeed.Person> = (person) => {
-  if (!isObject(person)) {
+  if (!isPlainObject(person)) {
     return
   }
 
@@ -96,7 +96,7 @@ export const generatePerson: GenerateUtil<RssFeed.Person> = (person) => {
 }
 
 export const generateCategory: GenerateUtil<RssFeed.Category> = (category) => {
-  if (!isObject(category)) {
+  if (!isPlainObject(category)) {
     return
   }
 
@@ -109,7 +109,7 @@ export const generateCategory: GenerateUtil<RssFeed.Category> = (category) => {
 }
 
 export const generateCloud: GenerateUtil<RssFeed.Cloud> = (cloud) => {
-  if (!isObject(cloud)) {
+  if (!isPlainObject(cloud)) {
     return
   }
 
@@ -125,7 +125,7 @@ export const generateCloud: GenerateUtil<RssFeed.Cloud> = (cloud) => {
 }
 
 export const generateImage: GenerateUtil<RssFeed.Image> = (image) => {
-  if (!isObject(image)) {
+  if (!isPlainObject(image)) {
     return
   }
 
@@ -142,7 +142,7 @@ export const generateImage: GenerateUtil<RssFeed.Image> = (image) => {
 }
 
 export const generateTextInput: GenerateUtil<RssFeed.TextInput> = (textInput) => {
-  if (!isObject(textInput)) {
+  if (!isPlainObject(textInput)) {
     return
   }
 
@@ -157,7 +157,7 @@ export const generateTextInput: GenerateUtil<RssFeed.TextInput> = (textInput) =>
 }
 
 export const generateEnclosure: GenerateUtil<RssFeed.Enclosure> = (enclosure) => {
-  if (!isObject(enclosure)) {
+  if (!isPlainObject(enclosure)) {
     return
   }
 
@@ -196,7 +196,7 @@ export const generateGuid: GenerateUtil<RssFeed.Guid> = (guid) => {
 }
 
 export const generateSource: GenerateUtil<RssFeed.Source> = (source) => {
-  if (!isObject(source)) {
+  if (!isPlainObject(source)) {
     return
   }
 
@@ -209,7 +209,7 @@ export const generateSource: GenerateUtil<RssFeed.Source> = (source) => {
 }
 
 export const generateItem: GenerateUtil<RssFeed.Item<DateLike>> = (item) => {
-  if (!isObject(item)) {
+  if (!isPlainObject(item)) {
     return
   }
 
@@ -254,7 +254,7 @@ export const generateItem: GenerateUtil<RssFeed.Item<DateLike>> = (item) => {
 }
 
 export const generateFeed: GenerateUtil<RssFeed.Feed<DateLike>> = (feed) => {
-  if (!isObject(feed)) {
+  if (!isPlainObject(feed)) {
     return
   }
 

--- a/src/feeds/rss/parse/utils.ts
+++ b/src/feeds/rss/parse/utils.ts
@@ -1,7 +1,7 @@
+import { isPlainObject } from 'trousse'
 import type { DateAny } from '../../../common/types.js'
 import {
   detectNamespaces,
-  isObject,
   parseArrayOf,
   parseBoolean,
   parseDate,
@@ -262,7 +262,7 @@ export const parseCategory: ParseUtilPartial<RssFeed.Category> = (value) => {
 }
 
 export const parseCloud: ParseUtilPartial<RssFeed.Cloud> = (value) => {
-  if (!isObject(value)) {
+  if (!isPlainObject(value)) {
     return
   }
 
@@ -278,7 +278,7 @@ export const parseCloud: ParseUtilPartial<RssFeed.Cloud> = (value) => {
 }
 
 export const parseImage: ParseUtilPartial<RssFeed.Image> = (value) => {
-  if (!isObject(value)) {
+  if (!isPlainObject(value)) {
     return
   }
 
@@ -295,7 +295,7 @@ export const parseImage: ParseUtilPartial<RssFeed.Image> = (value) => {
 }
 
 export const parseTextInput: ParseUtilPartial<RssFeed.TextInput> = (value) => {
-  if (!isObject(value)) {
+  if (!isPlainObject(value)) {
     return
   }
 
@@ -342,7 +342,7 @@ export const parseSkipDays: ParseUtilPartial<Array<string>> = (value) => {
 }
 
 export const parseEnclosure: ParseUtilPartial<RssFeed.Enclosure> = (value) => {
-  if (!isObject(value)) {
+  if (!isPlainObject(value)) {
     return
   }
 
@@ -374,7 +374,7 @@ export const parseSource: ParseUtilPartial<RssFeed.Source> = (value) => {
 }
 
 export const parseItem: ParseUtilPartial<RssFeed.Item<DateAny>> = (value, options) => {
-  if (!isObject(value)) {
+  if (!isPlainObject(value)) {
     return
   }
 
@@ -426,7 +426,7 @@ export const parseItem: ParseUtilPartial<RssFeed.Item<DateAny>> = (value, option
 export const parseFeed: ParseUtilPartial<RssFeed.Feed<DateAny>> = (value, options) => {
   const channel = parseSingular(value?.channel)
 
-  if (!isObject(channel)) {
+  if (!isPlainObject(channel)) {
     return
   }
   const namespaces = detectNamespaces(channel)

--- a/src/namespaces/acast/generate/utils.ts
+++ b/src/namespaces/acast/generate/utils.ts
@@ -1,15 +1,15 @@
+import { isPlainObject } from 'trousse'
 import type { GenerateUtil } from '../../../common/types.js'
 import {
   generateCdataString,
   generatePlainString,
   generateTextOrCdataString,
-  isObject,
   trimObject,
 } from '../../../common/utils.js'
 import type { AcastNs } from '../common/types.js'
 
 export const generateSignature: GenerateUtil<AcastNs.Signature> = (signature) => {
-  if (!isObject(signature)) {
+  if (!isPlainObject(signature)) {
     return
   }
 
@@ -23,7 +23,7 @@ export const generateSignature: GenerateUtil<AcastNs.Signature> = (signature) =>
 }
 
 export const generateNetwork: GenerateUtil<AcastNs.Network> = (network) => {
-  if (!isObject(network)) {
+  if (!isPlainObject(network)) {
     return
   }
 
@@ -37,7 +37,7 @@ export const generateNetwork: GenerateUtil<AcastNs.Network> = (network) => {
 }
 
 export const generateFeed: GenerateUtil<AcastNs.Feed> = (feed) => {
-  if (!isObject(feed)) {
+  if (!isPlainObject(feed)) {
     return
   }
 
@@ -54,7 +54,7 @@ export const generateFeed: GenerateUtil<AcastNs.Feed> = (feed) => {
 }
 
 export const generateItem: GenerateUtil<AcastNs.Item> = (item) => {
-  if (!isObject(item)) {
+  if (!isPlainObject(item)) {
     return
   }
 

--- a/src/namespaces/acast/parse/utils.ts
+++ b/src/namespaces/acast/parse/utils.ts
@@ -1,15 +1,10 @@
+import { isPlainObject } from 'trousse'
 import type { ParseUtilPartial } from '../../../common/types.js'
-import {
-  isObject,
-  parseSingularOf,
-  parseString,
-  retrieveText,
-  trimObject,
-} from '../../../common/utils.js'
+import { parseSingularOf, parseString, retrieveText, trimObject } from '../../../common/utils.js'
 import type { AcastNs } from '../common/types.js'
 
 export const parseSignature: ParseUtilPartial<AcastNs.Signature> = (value) => {
-  if (!isObject(value)) {
+  if (!isPlainObject(value)) {
     return
   }
 
@@ -23,7 +18,7 @@ export const parseSignature: ParseUtilPartial<AcastNs.Signature> = (value) => {
 }
 
 export const parseNetwork: ParseUtilPartial<AcastNs.Network> = (value) => {
-  if (!isObject(value)) {
+  if (!isPlainObject(value)) {
     return
   }
 
@@ -37,7 +32,7 @@ export const parseNetwork: ParseUtilPartial<AcastNs.Network> = (value) => {
 }
 
 export const retrieveFeed: ParseUtilPartial<AcastNs.Feed> = (value) => {
-  if (!isObject(value)) {
+  if (!isPlainObject(value)) {
     return
   }
 
@@ -56,7 +51,7 @@ export const retrieveFeed: ParseUtilPartial<AcastNs.Feed> = (value) => {
 }
 
 export const retrieveItem: ParseUtilPartial<AcastNs.Item> = (value) => {
-  if (!isObject(value)) {
+  if (!isPlainObject(value)) {
     return
   }
 

--- a/src/namespaces/admin/generate/utils.ts
+++ b/src/namespaces/admin/generate/utils.ts
@@ -1,14 +1,10 @@
+import { isPlainObject } from 'trousse'
 import type { GenerateUtil } from '../../../common/types.js'
-import {
-  generatePlainString,
-  generateRdfResource,
-  isObject,
-  trimObject,
-} from '../../../common/utils.js'
+import { generatePlainString, generateRdfResource, trimObject } from '../../../common/utils.js'
 import type { AdminNs } from '../common/types.js'
 
 export const generateFeed: GenerateUtil<AdminNs.Feed> = (feed) => {
-  if (!isObject(feed)) {
+  if (!isPlainObject(feed)) {
     return
   }
 

--- a/src/namespaces/admin/parse/utils.ts
+++ b/src/namespaces/admin/parse/utils.ts
@@ -1,6 +1,6 @@
+import { isPlainObject } from 'trousse'
 import type { ParseUtilPartial } from '../../../common/types.js'
 import {
-  isObject,
   parseSingularOf,
   parseString,
   retrieveRdfResourceOrText,
@@ -9,7 +9,7 @@ import {
 import type { AdminNs } from '../common/types.js'
 
 export const retrieveFeed: ParseUtilPartial<AdminNs.Feed> = (value) => {
-  if (!isObject(value)) {
+  if (!isPlainObject(value)) {
     return
   }
 

--- a/src/namespaces/app/generate/utils.ts
+++ b/src/namespaces/app/generate/utils.ts
@@ -1,14 +1,10 @@
+import { isPlainObject } from 'trousse'
 import type { DateLike, GenerateUtil } from '../../../common/types.js'
-import {
-  generateRfc3339Date,
-  generateYesNoBoolean,
-  isObject,
-  trimObject,
-} from '../../../common/utils.js'
+import { generateRfc3339Date, generateYesNoBoolean, trimObject } from '../../../common/utils.js'
 import type { AppNs } from '../common/types.js'
 
 export const generateControl: GenerateUtil<AppNs.Control> = (control) => {
-  if (!isObject(control)) {
+  if (!isPlainObject(control)) {
     return
   }
 
@@ -20,7 +16,7 @@ export const generateControl: GenerateUtil<AppNs.Control> = (control) => {
 }
 
 export const generateEntry: GenerateUtil<AppNs.Entry<DateLike>> = (entry) => {
-  if (!isObject(entry)) {
+  if (!isPlainObject(entry)) {
     return
   }
 

--- a/src/namespaces/app/parse/utils.ts
+++ b/src/namespaces/app/parse/utils.ts
@@ -1,6 +1,6 @@
+import { isPlainObject } from 'trousse'
 import type { DateAny, ParseMainOptions, ParseUtilPartial } from '../../../common/types.js'
 import {
-  isObject,
   parseDate,
   parseSingularOf,
   parseYesNoBoolean,
@@ -10,7 +10,7 @@ import {
 import type { AppNs } from '../common/types.js'
 
 export const parseControl: ParseUtilPartial<AppNs.Control> = (value) => {
-  if (!isObject(value)) {
+  if (!isPlainObject(value)) {
     return
   }
 
@@ -25,7 +25,7 @@ export const retrieveEntry: ParseUtilPartial<AppNs.Entry<DateAny>, ParseMainOpti
   value,
   options,
 ) => {
-  if (!isObject(value)) {
+  if (!isPlainObject(value)) {
     return
   }
 

--- a/src/namespaces/arxiv/generate/utils.ts
+++ b/src/namespaces/arxiv/generate/utils.ts
@@ -1,14 +1,10 @@
+import { isPlainObject } from 'trousse'
 import type { GenerateUtil } from '../../../common/types.js'
-import {
-  generateCdataString,
-  generatePlainString,
-  isObject,
-  trimObject,
-} from '../../../common/utils.js'
+import { generateCdataString, generatePlainString, trimObject } from '../../../common/utils.js'
 import type { ArxivNs } from '../common/types.js'
 
 export const generatePrimaryCategory: GenerateUtil<ArxivNs.PrimaryCategory> = (primaryCategory) => {
-  if (!isObject(primaryCategory)) {
+  if (!isPlainObject(primaryCategory)) {
     return
   }
 
@@ -22,7 +18,7 @@ export const generatePrimaryCategory: GenerateUtil<ArxivNs.PrimaryCategory> = (p
 }
 
 export const generateAuthor: GenerateUtil<ArxivNs.Author> = (author) => {
-  if (!isObject(author)) {
+  if (!isPlainObject(author)) {
     return
   }
 
@@ -34,7 +30,7 @@ export const generateAuthor: GenerateUtil<ArxivNs.Author> = (author) => {
 }
 
 export const generateEntry: GenerateUtil<ArxivNs.Entry> = (entry) => {
-  if (!isObject(entry)) {
+  if (!isPlainObject(entry)) {
     return
   }
 

--- a/src/namespaces/arxiv/parse/utils.ts
+++ b/src/namespaces/arxiv/parse/utils.ts
@@ -1,15 +1,10 @@
+import { isPlainObject } from 'trousse'
 import type { ParseUtilPartial } from '../../../common/types.js'
-import {
-  isObject,
-  parseSingularOf,
-  parseString,
-  retrieveText,
-  trimObject,
-} from '../../../common/utils.js'
+import { parseSingularOf, parseString, retrieveText, trimObject } from '../../../common/utils.js'
 import type { ArxivNs } from '../common/types.js'
 
 export const parsePrimaryCategory: ParseUtilPartial<ArxivNs.PrimaryCategory> = (value) => {
-  if (!isObject(value)) {
+  if (!isPlainObject(value)) {
     return
   }
 
@@ -23,7 +18,7 @@ export const parsePrimaryCategory: ParseUtilPartial<ArxivNs.PrimaryCategory> = (
 }
 
 export const retrieveAuthor: ParseUtilPartial<ArxivNs.Author> = (value) => {
-  if (!isObject(value)) {
+  if (!isPlainObject(value)) {
     return
   }
 
@@ -37,7 +32,7 @@ export const retrieveAuthor: ParseUtilPartial<ArxivNs.Author> = (value) => {
 }
 
 export const retrieveEntry: ParseUtilPartial<ArxivNs.Entry> = (value) => {
-  if (!isObject(value)) {
+  if (!isPlainObject(value)) {
     return
   }
 

--- a/src/namespaces/blogchannel/generate/utils.ts
+++ b/src/namespaces/blogchannel/generate/utils.ts
@@ -1,9 +1,10 @@
+import { isPlainObject } from 'trousse'
 import type { GenerateUtil } from '../../../common/types.js'
-import { generateCdataString, isObject, trimObject } from '../../../common/utils.js'
+import { generateCdataString, trimObject } from '../../../common/utils.js'
 import type { BlogChannelNs } from '../common/types.js'
 
 export const generateFeed: GenerateUtil<BlogChannelNs.Feed> = (feed) => {
-  if (!isObject(feed)) {
+  if (!isPlainObject(feed)) {
     return
   }
 

--- a/src/namespaces/blogchannel/parse/utils.ts
+++ b/src/namespaces/blogchannel/parse/utils.ts
@@ -1,15 +1,10 @@
+import { isPlainObject } from 'trousse'
 import type { ParseUtilPartial } from '../../../common/types.js'
-import {
-  isObject,
-  parseSingularOf,
-  parseString,
-  retrieveText,
-  trimObject,
-} from '../../../common/utils.js'
+import { parseSingularOf, parseString, retrieveText, trimObject } from '../../../common/utils.js'
 import type { BlogChannelNs } from '../common/types.js'
 
 export const retrieveFeed: ParseUtilPartial<BlogChannelNs.Feed> = (value) => {
-  if (!isObject(value)) {
+  if (!isPlainObject(value)) {
     return
   }
 

--- a/src/namespaces/cc/generate/utils.ts
+++ b/src/namespaces/cc/generate/utils.ts
@@ -1,9 +1,10 @@
+import { isPlainObject } from 'trousse'
 import type { GenerateUtil } from '../../../common/types.js'
-import { generateCdataString, isObject, trimObject } from '../../../common/utils.js'
+import { generateCdataString, trimObject } from '../../../common/utils.js'
 import type { CcNs } from '../common/types.js'
 
 export const generateItemOrFeed: GenerateUtil<CcNs.ItemOrFeed> = (data) => {
-  if (!isObject(data)) {
+  if (!isPlainObject(data)) {
     return
   }
 

--- a/src/namespaces/cc/parse/utils.ts
+++ b/src/namespaces/cc/parse/utils.ts
@@ -1,6 +1,6 @@
+import { isPlainObject } from 'trousse'
 import type { ParseUtilPartial } from '../../../common/types.js'
 import {
-  isObject,
   parseSingularOf,
   parseString,
   retrieveRdfResourceOrText,
@@ -9,7 +9,7 @@ import {
 import type { CcNs } from '../common/types.js'
 
 export const retrieveItemOrFeed: ParseUtilPartial<CcNs.ItemOrFeed> = (value) => {
-  if (!isObject(value)) {
+  if (!isPlainObject(value)) {
     return
   }
 

--- a/src/namespaces/content/generate/utils.ts
+++ b/src/namespaces/content/generate/utils.ts
@@ -1,9 +1,10 @@
+import { isPlainObject } from 'trousse'
 import type { GenerateUtil } from '../../../common/types.js'
-import { generateCdataString, isObject, trimObject } from '../../../common/utils.js'
+import { generateCdataString, trimObject } from '../../../common/utils.js'
 import type { ContentNs } from '../common/types.js'
 
 export const generateItem: GenerateUtil<ContentNs.Item> = (item) => {
-  if (!isObject(item)) {
+  if (!isPlainObject(item)) {
     return
   }
 

--- a/src/namespaces/content/parse/utils.ts
+++ b/src/namespaces/content/parse/utils.ts
@@ -1,15 +1,10 @@
+import { isPlainObject } from 'trousse'
 import type { ParseUtilPartial } from '../../../common/types.js'
-import {
-  isObject,
-  parseSingularOf,
-  parseString,
-  retrieveText,
-  trimObject,
-} from '../../../common/utils.js'
+import { parseSingularOf, parseString, retrieveText, trimObject } from '../../../common/utils.js'
 import type { ContentNs } from '../common/types.js'
 
 export const retrieveItem: ParseUtilPartial<ContentNs.Item> = (value) => {
-  if (!isObject(value)) {
+  if (!isPlainObject(value)) {
     return
   }
 

--- a/src/namespaces/creativecommons/generate/utils.ts
+++ b/src/namespaces/creativecommons/generate/utils.ts
@@ -1,9 +1,10 @@
+import { isPlainObject } from 'trousse'
 import type { GenerateUtil } from '../../../common/types.js'
-import { generateCdataString, isObject, trimArray, trimObject } from '../../../common/utils.js'
+import { generateCdataString, trimArray, trimObject } from '../../../common/utils.js'
 import type { CreativeCommonsNs } from '../common/types.js'
 
 export const generateItemOrFeed: GenerateUtil<CreativeCommonsNs.ItemOrFeed> = (itemOrFeed) => {
-  if (!isObject(itemOrFeed)) {
+  if (!isPlainObject(itemOrFeed)) {
     return
   }
 

--- a/src/namespaces/creativecommons/parse/utils.ts
+++ b/src/namespaces/creativecommons/parse/utils.ts
@@ -1,15 +1,10 @@
+import { isPlainObject } from 'trousse'
 import type { ParseUtilPartial } from '../../../common/types.js'
-import {
-  isObject,
-  parseArrayOf,
-  parseString,
-  retrieveText,
-  trimObject,
-} from '../../../common/utils.js'
+import { parseArrayOf, parseString, retrieveText, trimObject } from '../../../common/utils.js'
 import type { CreativeCommonsNs } from '../common/types.js'
 
 export const retrieveItemOrFeed: ParseUtilPartial<CreativeCommonsNs.ItemOrFeed> = (value) => {
-  if (!isObject(value)) {
+  if (!isPlainObject(value)) {
     return
   }
 

--- a/src/namespaces/dc/generate/utils.ts
+++ b/src/namespaces/dc/generate/utils.ts
@@ -1,15 +1,15 @@
+import { isPlainObject } from 'trousse'
 import type { DateLike, GenerateUtil } from '../../../common/types.js'
 import {
   generateCdataString,
   generateRfc3339Date,
-  isObject,
   trimArray,
   trimObject,
 } from '../../../common/utils.js'
 import type { DcNs } from '../common/types.js'
 
 export const generateItemOrFeed: GenerateUtil<DcNs.ItemOrFeed<DateLike>> = (itemOrFeed) => {
-  if (!isObject(itemOrFeed)) {
+  if (!isPlainObject(itemOrFeed)) {
     return
   }
 

--- a/src/namespaces/dc/parse/utils.ts
+++ b/src/namespaces/dc/parse/utils.ts
@@ -1,6 +1,6 @@
+import { isPlainObject } from 'trousse'
 import type { DateAny, ParseMainOptions, ParseUtilPartial } from '../../../common/types.js'
 import {
-  isObject,
   parseArrayOf,
   parseDate,
   parseString,
@@ -13,7 +13,7 @@ export const retrieveItemOrFeed: ParseUtilPartial<
   DcNs.ItemOrFeed<DateAny>,
   ParseMainOptions<DateAny>
 > = (value, options) => {
-  if (!isObject(value)) {
+  if (!isPlainObject(value)) {
     return
   }
 

--- a/src/namespaces/dcterms/generate/utils.ts
+++ b/src/namespaces/dcterms/generate/utils.ts
@@ -1,15 +1,15 @@
+import { isPlainObject } from 'trousse'
 import type { DateLike, GenerateUtil } from '../../../common/types.js'
 import {
   generateCdataString,
   generateRfc3339Date,
-  isObject,
   trimArray,
   trimObject,
 } from '../../../common/utils.js'
 import type { DcTermsNs } from '../common/types.js'
 
 export const generateItemOrFeed: GenerateUtil<DcTermsNs.ItemOrFeed<DateLike>> = (itemOrFeed) => {
-  if (!isObject(itemOrFeed)) {
+  if (!isPlainObject(itemOrFeed)) {
     return
   }
 

--- a/src/namespaces/dcterms/parse/utils.ts
+++ b/src/namespaces/dcterms/parse/utils.ts
@@ -1,6 +1,6 @@
+import { isPlainObject } from 'trousse'
 import type { DateAny, ParseMainOptions, ParseUtilPartial } from '../../../common/types.js'
 import {
-  isObject,
   parseArrayOf,
   parseDate,
   parseString,
@@ -13,7 +13,7 @@ export const retrieveItemOrFeed: ParseUtilPartial<
   DcTermsNs.ItemOrFeed<DateAny>,
   ParseMainOptions<DateAny>
 > = (value, options) => {
-  if (!isObject(value)) {
+  if (!isPlainObject(value)) {
     return
   }
 

--- a/src/namespaces/feedpress/generate/utils.ts
+++ b/src/namespaces/feedpress/generate/utils.ts
@@ -1,9 +1,10 @@
+import { isPlainObject } from 'trousse'
 import type { GenerateUtil } from '../../../common/types.js'
-import { generateCdataString, isObject, trimObject } from '../../../common/utils.js'
+import { generateCdataString, trimObject } from '../../../common/utils.js'
 import type { FeedPressNs } from '../common/types.js'
 
 export const generateFeed: GenerateUtil<FeedPressNs.Feed> = (feed) => {
-  if (!isObject(feed)) {
+  if (!isPlainObject(feed)) {
     return
   }
 

--- a/src/namespaces/feedpress/parse/utils.ts
+++ b/src/namespaces/feedpress/parse/utils.ts
@@ -1,15 +1,10 @@
+import { isPlainObject } from 'trousse'
 import type { ParseUtilPartial } from '../../../common/types.js'
-import {
-  isObject,
-  parseSingularOf,
-  parseString,
-  retrieveText,
-  trimObject,
-} from '../../../common/utils.js'
+import { parseSingularOf, parseString, retrieveText, trimObject } from '../../../common/utils.js'
 import type { FeedPressNs } from '../common/types.js'
 
 export const retrieveFeed: ParseUtilPartial<FeedPressNs.Feed> = (value) => {
-  if (!isObject(value)) {
+  if (!isPlainObject(value)) {
     return
   }
 

--- a/src/namespaces/geo/generate/utils.ts
+++ b/src/namespaces/geo/generate/utils.ts
@@ -1,9 +1,10 @@
+import { isPlainObject } from 'trousse'
 import type { GenerateUtil } from '../../../common/types.js'
-import { generateNumber, isObject, trimObject } from '../../../common/utils.js'
+import { generateNumber, trimObject } from '../../../common/utils.js'
 import type { GeoNs } from '../common/types.js'
 
 export const generateItemOrFeed: GenerateUtil<GeoNs.ItemOrFeed> = (geo) => {
-  if (!isObject(geo)) {
+  if (!isPlainObject(geo)) {
     return
   }
 

--- a/src/namespaces/geo/parse/utils.ts
+++ b/src/namespaces/geo/parse/utils.ts
@@ -1,15 +1,10 @@
+import { isPlainObject } from 'trousse'
 import type { ParseUtilPartial } from '../../../common/types.js'
-import {
-  isObject,
-  parseNumber,
-  parseSingularOf,
-  retrieveText,
-  trimObject,
-} from '../../../common/utils.js'
+import { parseNumber, parseSingularOf, retrieveText, trimObject } from '../../../common/utils.js'
 import type { GeoNs } from '../common/types.js'
 
 export const retrieveItemOrFeed: ParseUtilPartial<GeoNs.ItemOrFeed> = (value) => {
-  if (!isObject(value)) {
+  if (!isPlainObject(value)) {
     return
   }
 

--- a/src/namespaces/georss/generate/utils.ts
+++ b/src/namespaces/georss/generate/utils.ts
@@ -1,5 +1,6 @@
+import { isPlainObject } from 'trousse'
 import type { GenerateUtil } from '../../../common/types.js'
-import { generateCdataString, generateNumber, isObject, trimObject } from '../../../common/utils.js'
+import { generateCdataString, generateNumber, trimObject } from '../../../common/utils.js'
 import type { GeoRssNs } from '../common/types.js'
 
 export const generateLatLngPairs = (
@@ -31,7 +32,7 @@ export const generateLatLngPairs = (
 }
 
 export const generatePoint: GenerateUtil<GeoRssNs.Point> = (point) => {
-  if (!isObject(point)) {
+  if (!isPlainObject(point)) {
     return
   }
 
@@ -39,7 +40,7 @@ export const generatePoint: GenerateUtil<GeoRssNs.Point> = (point) => {
 }
 
 export const generateLine: GenerateUtil<GeoRssNs.Line> = (line) => {
-  if (!isObject(line) || !line.points) {
+  if (!isPlainObject(line) || !line.points) {
     return
   }
 
@@ -47,7 +48,7 @@ export const generateLine: GenerateUtil<GeoRssNs.Line> = (line) => {
 }
 
 export const generatePolygon: GenerateUtil<GeoRssNs.Polygon> = (polygon) => {
-  if (!isObject(polygon) || !polygon.points) {
+  if (!isPlainObject(polygon) || !polygon.points) {
     return
   }
 
@@ -55,7 +56,7 @@ export const generatePolygon: GenerateUtil<GeoRssNs.Polygon> = (polygon) => {
 }
 
 export const generateBox: GenerateUtil<GeoRssNs.Box> = (box) => {
-  if (!isObject(box) || !box.lowerCorner || !box.upperCorner) {
+  if (!isPlainObject(box) || !box.lowerCorner || !box.upperCorner) {
     return
   }
 
@@ -63,7 +64,7 @@ export const generateBox: GenerateUtil<GeoRssNs.Box> = (box) => {
 }
 
 export const generateItemOrFeed: GenerateUtil<GeoRssNs.ItemOrFeed> = (itemOrFeed) => {
-  if (!isObject(itemOrFeed)) {
+  if (!isPlainObject(itemOrFeed)) {
     return
   }
 

--- a/src/namespaces/georss/parse/utils.ts
+++ b/src/namespaces/georss/parse/utils.ts
@@ -1,8 +1,7 @@
+import { isNonEmptyString, isPresent } from 'trousse'
 import type { ParseUtilExact, ParseUtilPartial, Unreliable } from '../../../common/types.js'
 import {
-  isNonEmptyString,
   isObject,
-  isPresent,
   parseArrayOf,
   parseNumber,
   parseSingularOf,

--- a/src/namespaces/georss/parse/utils.ts
+++ b/src/namespaces/georss/parse/utils.ts
@@ -1,7 +1,6 @@
-import { isNonEmptyString, isPresent } from 'trousse'
+import { isNonEmptyString, isPlainObject, isPresent } from 'trousse'
 import type { ParseUtilExact, ParseUtilPartial, Unreliable } from '../../../common/types.js'
 import {
-  isObject,
   parseArrayOf,
   parseNumber,
   parseSingularOf,
@@ -82,7 +81,7 @@ export const parseBox: ParseUtilExact<GeoRssNs.Box> = (value) => {
 }
 
 export const retrieveItemOrFeed: ParseUtilPartial<GeoRssNs.ItemOrFeed> = (value) => {
-  if (!isObject(value)) {
+  if (!isPlainObject(value)) {
     return
   }
 

--- a/src/namespaces/googleplay/generate/utils.ts
+++ b/src/namespaces/googleplay/generate/utils.ts
@@ -1,16 +1,16 @@
+import { isPlainObject } from 'trousse'
 import type { GenerateUtil } from '../../../common/types.js'
 import {
   generateCdataString,
   generatePlainString,
   generateYesNoBoolean,
-  isObject,
   trimArray,
   trimObject,
 } from '../../../common/utils.js'
 import type { GooglePlayNs } from '../common/types.js'
 
 const generateImage: GenerateUtil<GooglePlayNs.Image> = (image) => {
-  if (!isObject(image)) {
+  if (!isPlainObject(image)) {
     return
   }
 
@@ -38,7 +38,7 @@ const generateExplicit: GenerateUtil<boolean | 'clean'> = (explicit) => {
 }
 
 export const generateItem: GenerateUtil<GooglePlayNs.Item> = (item) => {
-  if (!isObject(item)) {
+  if (!isPlainObject(item)) {
     return
   }
 
@@ -52,7 +52,7 @@ export const generateItem: GenerateUtil<GooglePlayNs.Item> = (item) => {
 }
 
 export const generateFeed: GenerateUtil<GooglePlayNs.Feed> = (feed) => {
-  if (!isObject(feed)) {
+  if (!isPlainObject(feed)) {
     return
   }
 

--- a/src/namespaces/googleplay/parse/utils.ts
+++ b/src/namespaces/googleplay/parse/utils.ts
@@ -1,6 +1,6 @@
+import { isPlainObject } from 'trousse'
 import type { ParseUtilPartial } from '../../../common/types.js'
 import {
-  isObject,
   parseArrayOf,
   parseSingularOf,
   parseString,
@@ -11,7 +11,7 @@ import {
 import type { GooglePlayNs } from '../common/types.js'
 
 export const parseImage: ParseUtilPartial<GooglePlayNs.Image> = (value) => {
-  if (isObject(value) && value['@href']) {
+  if (isPlainObject(value) && value['@href']) {
     const image = {
       href: parseString(value['@href']),
     }
@@ -30,7 +30,7 @@ export const parseImage: ParseUtilPartial<GooglePlayNs.Image> = (value) => {
 }
 
 export const parseCategory: ParseUtilPartial<string> = (value) => {
-  if (isObject(value) && value['@text']) {
+  if (isPlainObject(value) && value['@text']) {
     return parseString(value['@text'])
   }
 
@@ -48,7 +48,7 @@ export const parseExplicit: ParseUtilPartial<boolean | 'clean'> = (value) => {
 }
 
 export const retrieveItem: ParseUtilPartial<GooglePlayNs.Item> = (value) => {
-  if (!isObject(value)) {
+  if (!isPlainObject(value)) {
     return
   }
 
@@ -70,7 +70,7 @@ export const retrieveItem: ParseUtilPartial<GooglePlayNs.Item> = (value) => {
 }
 
 export const retrieveFeed: ParseUtilPartial<GooglePlayNs.Feed> = (value) => {
-  if (!isObject(value)) {
+  if (!isPlainObject(value)) {
     return
   }
 

--- a/src/namespaces/itunes/generate/utils.ts
+++ b/src/namespaces/itunes/generate/utils.ts
@@ -1,3 +1,4 @@
+import { isNonEmptyString } from 'trousse'
 import type { GenerateUtil } from '../../../common/types.js'
 import {
   generateCdataString,
@@ -5,7 +6,6 @@ import {
   generateNumber,
   generatePlainString,
   generateYesNoBoolean,
-  isNonEmptyString,
   isObject,
   trimArray,
   trimObject,

--- a/src/namespaces/itunes/generate/utils.ts
+++ b/src/namespaces/itunes/generate/utils.ts
@@ -1,4 +1,4 @@
-import { isNonEmptyString } from 'trousse'
+import { isNonEmptyString, isPlainObject } from 'trousse'
 import type { GenerateUtil } from '../../../common/types.js'
 import {
   generateCdataString,
@@ -6,7 +6,6 @@ import {
   generateNumber,
   generatePlainString,
   generateYesNoBoolean,
-  isObject,
   trimArray,
   trimObject,
 } from '../../../common/utils.js'
@@ -23,7 +22,7 @@ export const generateImage: GenerateUtil<string> = (image) => {
 }
 
 export const generateCategory: GenerateUtil<ItunesNs.Category> = (category) => {
-  if (!isObject(category)) {
+  if (!isPlainObject(category)) {
     return
   }
 
@@ -36,7 +35,7 @@ export const generateCategory: GenerateUtil<ItunesNs.Category> = (category) => {
 }
 
 export const generateOwner: GenerateUtil<ItunesNs.Owner> = (owner) => {
-  if (!isObject(owner)) {
+  if (!isPlainObject(owner)) {
     return
   }
 
@@ -49,7 +48,7 @@ export const generateOwner: GenerateUtil<ItunesNs.Owner> = (owner) => {
 }
 
 export const generateItem: GenerateUtil<ItunesNs.Item> = (item) => {
-  if (!isObject(item)) {
+  if (!isPlainObject(item)) {
     return
   }
 
@@ -72,7 +71,7 @@ export const generateItem: GenerateUtil<ItunesNs.Item> = (item) => {
 }
 
 export const generateFeed: GenerateUtil<ItunesNs.Feed> = (feed) => {
-  if (!isObject(feed)) {
+  if (!isPlainObject(feed)) {
     return
   }
 

--- a/src/namespaces/itunes/parse/utils.ts
+++ b/src/namespaces/itunes/parse/utils.ts
@@ -1,7 +1,7 @@
+import { isPlainObject } from 'trousse'
 import type { ParseUtilPartial } from '../../../common/types.js'
 import {
   isNonEmptyStringOrNumber,
-  isObject,
   parseArrayOf,
   parseBoolean,
   parseCsvOf,
@@ -18,7 +18,7 @@ const explicitOrYesRegex = /^\p{White_Space}*(explicit|yes)\p{White_Space}*$/iu
 const durationRegex = /^(?:(\d+):)?(\d+):(\d+)$/
 
 export const parseCategory: ParseUtilPartial<ItunesNs.Category> = (value) => {
-  if (!isObject(value)) {
+  if (!isPlainObject(value)) {
     return
   }
 
@@ -31,7 +31,7 @@ export const parseCategory: ParseUtilPartial<ItunesNs.Category> = (value) => {
 }
 
 export const parseOwner: ParseUtilPartial<ItunesNs.Owner> = (value) => {
-  if (!isObject(value)) {
+  if (!isPlainObject(value)) {
     return
   }
 
@@ -83,7 +83,7 @@ export const parseImage: ParseUtilPartial<string> = (value) => {
     return parseString(value)
   }
 
-  if (!isObject(value)) {
+  if (!isPlainObject(value)) {
     return
   }
 
@@ -91,7 +91,7 @@ export const parseImage: ParseUtilPartial<string> = (value) => {
 }
 
 export const retrieveItem: ParseUtilPartial<ItunesNs.Item> = (value) => {
-  if (!isObject(value)) {
+  if (!isPlainObject(value)) {
     return
   }
 
@@ -126,7 +126,7 @@ export const retrieveItem: ParseUtilPartial<ItunesNs.Item> = (value) => {
 }
 
 export const retrieveFeed: ParseUtilPartial<ItunesNs.Feed> = (value) => {
-  if (!isObject(value)) {
+  if (!isPlainObject(value)) {
     return
   }
 

--- a/src/namespaces/media/generate/utils.ts
+++ b/src/namespaces/media/generate/utils.ts
@@ -1,3 +1,4 @@
+import { isPlainObject } from 'trousse'
 import type { GenerateUtil } from '../../../common/types.js'
 import {
   generateCdataString,
@@ -6,14 +7,13 @@ import {
   generatePlainString,
   generateTextOrCdataString,
   generateYesNoBoolean,
-  isObject,
   trimArray,
   trimObject,
 } from '../../../common/utils.js'
 import type { MediaNs } from '../common/types.js'
 
 export const generateRating: GenerateUtil<MediaNs.Rating> = (rating) => {
-  if (!isObject(rating)) {
+  if (!isPlainObject(rating)) {
     return
   }
 
@@ -28,7 +28,7 @@ export const generateRating: GenerateUtil<MediaNs.Rating> = (rating) => {
 export const generateTitleOrDescription: GenerateUtil<MediaNs.TitleOrDescription> = (
   titleOrDescription,
 ) => {
-  if (!isObject(titleOrDescription)) {
+  if (!isPlainObject(titleOrDescription)) {
     return
   }
 
@@ -41,7 +41,7 @@ export const generateTitleOrDescription: GenerateUtil<MediaNs.TitleOrDescription
 }
 
 export const generateThumbnail: GenerateUtil<MediaNs.Thumbnail> = (thumbnail) => {
-  if (!isObject(thumbnail)) {
+  if (!isPlainObject(thumbnail)) {
     return
   }
 
@@ -56,7 +56,7 @@ export const generateThumbnail: GenerateUtil<MediaNs.Thumbnail> = (thumbnail) =>
 }
 
 export const generateCategory: GenerateUtil<MediaNs.Category> = (category) => {
-  if (!isObject(category)) {
+  if (!isPlainObject(category)) {
     return
   }
 
@@ -70,7 +70,7 @@ export const generateCategory: GenerateUtil<MediaNs.Category> = (category) => {
 }
 
 export const generateHash: GenerateUtil<MediaNs.Hash> = (hash) => {
-  if (!isObject(hash)) {
+  if (!isPlainObject(hash)) {
     return
   }
 
@@ -83,7 +83,7 @@ export const generateHash: GenerateUtil<MediaNs.Hash> = (hash) => {
 }
 
 export const generatePlayer: GenerateUtil<MediaNs.Player> = (player) => {
-  if (!isObject(player)) {
+  if (!isPlainObject(player)) {
     return
   }
 
@@ -97,7 +97,7 @@ export const generatePlayer: GenerateUtil<MediaNs.Player> = (player) => {
 }
 
 export const generateCredit: GenerateUtil<MediaNs.Credit> = (credit) => {
-  if (!isObject(credit)) {
+  if (!isPlainObject(credit)) {
     return
   }
 
@@ -111,7 +111,7 @@ export const generateCredit: GenerateUtil<MediaNs.Credit> = (credit) => {
 }
 
 export const generateCopyright: GenerateUtil<MediaNs.Copyright> = (copyright) => {
-  if (!isObject(copyright)) {
+  if (!isPlainObject(copyright)) {
     return
   }
 
@@ -124,7 +124,7 @@ export const generateCopyright: GenerateUtil<MediaNs.Copyright> = (copyright) =>
 }
 
 export const generateText: GenerateUtil<MediaNs.Text> = (text) => {
-  if (!isObject(text)) {
+  if (!isPlainObject(text)) {
     return
   }
 
@@ -140,7 +140,7 @@ export const generateText: GenerateUtil<MediaNs.Text> = (text) => {
 }
 
 export const generateRestriction: GenerateUtil<MediaNs.Restriction> = (restriction) => {
-  if (!isObject(restriction)) {
+  if (!isPlainObject(restriction)) {
     return
   }
 
@@ -154,7 +154,7 @@ export const generateRestriction: GenerateUtil<MediaNs.Restriction> = (restricti
 }
 
 export const generateStarRating: GenerateUtil<MediaNs.StarRating> = (starRating) => {
-  if (!isObject(starRating)) {
+  if (!isPlainObject(starRating)) {
     return
   }
 
@@ -169,7 +169,7 @@ export const generateStarRating: GenerateUtil<MediaNs.StarRating> = (starRating)
 }
 
 export const generateStatistics: GenerateUtil<MediaNs.Statistics> = (statistics) => {
-  if (!isObject(statistics)) {
+  if (!isPlainObject(statistics)) {
     return
   }
 
@@ -182,7 +182,7 @@ export const generateStatistics: GenerateUtil<MediaNs.Statistics> = (statistics)
 }
 
 export const generateTag: GenerateUtil<MediaNs.Tag> = (tag) => {
-  if (!isObject(tag)) {
+  if (!isPlainObject(tag)) {
     return
   }
 
@@ -198,7 +198,7 @@ export const generateTag: GenerateUtil<MediaNs.Tag> = (tag) => {
 }
 
 export const generateCommunity: GenerateUtil<MediaNs.Community> = (community) => {
-  if (!isObject(community)) {
+  if (!isPlainObject(community)) {
     return
   }
 
@@ -244,7 +244,7 @@ export const generateScenes: GenerateUtil<Array<MediaNs.Scene>> = (scenes) => {
 }
 
 export const generateParam: GenerateUtil<MediaNs.Param> = (param) => {
-  if (!isObject(param)) {
+  if (!isPlainObject(param)) {
     return
   }
 
@@ -257,7 +257,7 @@ export const generateParam: GenerateUtil<MediaNs.Param> = (param) => {
 }
 
 export const generateEmbed: GenerateUtil<MediaNs.Embed> = (embed) => {
-  if (!isObject(embed)) {
+  if (!isPlainObject(embed)) {
     return
   }
 
@@ -272,7 +272,7 @@ export const generateEmbed: GenerateUtil<MediaNs.Embed> = (embed) => {
 }
 
 export const generateStatus: GenerateUtil<MediaNs.Status> = (status) => {
-  if (!isObject(status)) {
+  if (!isPlainObject(status)) {
     return
   }
 
@@ -285,7 +285,7 @@ export const generateStatus: GenerateUtil<MediaNs.Status> = (status) => {
 }
 
 export const generatePrice: GenerateUtil<MediaNs.Price> = (price) => {
-  if (!isObject(price)) {
+  if (!isPlainObject(price)) {
     return
   }
 
@@ -300,7 +300,7 @@ export const generatePrice: GenerateUtil<MediaNs.Price> = (price) => {
 }
 
 export const generateLicense: GenerateUtil<MediaNs.License> = (license) => {
-  if (!isObject(license)) {
+  if (!isPlainObject(license)) {
     return
   }
 
@@ -314,7 +314,7 @@ export const generateLicense: GenerateUtil<MediaNs.License> = (license) => {
 }
 
 export const generateSubTitle: GenerateUtil<MediaNs.SubTitle> = (subTitle) => {
-  if (!isObject(subTitle)) {
+  if (!isPlainObject(subTitle)) {
     return
   }
 
@@ -328,7 +328,7 @@ export const generateSubTitle: GenerateUtil<MediaNs.SubTitle> = (subTitle) => {
 }
 
 export const generatePeerLink: GenerateUtil<MediaNs.PeerLink> = (peerLink) => {
-  if (!isObject(peerLink)) {
+  if (!isPlainObject(peerLink)) {
     return
   }
 
@@ -341,7 +341,7 @@ export const generatePeerLink: GenerateUtil<MediaNs.PeerLink> = (peerLink) => {
 }
 
 export const generateRights: GenerateUtil<MediaNs.Rights> = (rights) => {
-  if (!isObject(rights)) {
+  if (!isPlainObject(rights)) {
     return
   }
 
@@ -353,7 +353,7 @@ export const generateRights: GenerateUtil<MediaNs.Rights> = (rights) => {
 }
 
 export const generateScene: GenerateUtil<MediaNs.Scene> = (scene) => {
-  if (!isObject(scene)) {
+  if (!isPlainObject(scene)) {
     return
   }
 
@@ -368,7 +368,7 @@ export const generateScene: GenerateUtil<MediaNs.Scene> = (scene) => {
 }
 
 export const generateLocation: GenerateUtil<MediaNs.Location> = (location) => {
-  if (!isObject(location)) {
+  if (!isPlainObject(location)) {
     return
   }
 
@@ -384,7 +384,7 @@ export const generateLocation: GenerateUtil<MediaNs.Location> = (location) => {
 }
 
 export const generateCommonElements: GenerateUtil<MediaNs.CommonElements> = (elements) => {
-  if (!isObject(elements)) {
+  if (!isPlainObject(elements)) {
     return
   }
 
@@ -420,7 +420,7 @@ export const generateCommonElements: GenerateUtil<MediaNs.CommonElements> = (ele
 }
 
 export const generateContent: GenerateUtil<MediaNs.Content> = (content) => {
-  if (!isObject(content)) {
+  if (!isPlainObject(content)) {
     return
   }
 
@@ -446,7 +446,7 @@ export const generateContent: GenerateUtil<MediaNs.Content> = (content) => {
 }
 
 export const generateGroup: GenerateUtil<MediaNs.Group> = (group) => {
-  if (!isObject(group)) {
+  if (!isPlainObject(group)) {
     return
   }
 
@@ -459,7 +459,7 @@ export const generateGroup: GenerateUtil<MediaNs.Group> = (group) => {
 }
 
 export const generateItemOrFeed: GenerateUtil<MediaNs.ItemOrFeed> = (itemOrFeed) => {
-  if (!isObject(itemOrFeed)) {
+  if (!isPlainObject(itemOrFeed)) {
     return
   }
 

--- a/src/namespaces/media/parse/utils.ts
+++ b/src/namespaces/media/parse/utils.ts
@@ -1,7 +1,7 @@
+import { isPlainObject } from 'trousse'
 import type { ParseUtilPartial } from '../../../common/types.js'
 import {
   isNonEmptyStringOrNumber,
-  isObject,
   parseArrayOf,
   parseBoolean,
   parseCsvOf,
@@ -23,7 +23,7 @@ export const parseRating: ParseUtilPartial<MediaNs.Rating> = (value) => {
 }
 
 export const retrieveRatings: ParseUtilPartial<Array<MediaNs.Rating>> = (value) => {
-  if (!isObject(value)) {
+  if (!isPlainObject(value)) {
     return
   }
 
@@ -56,7 +56,7 @@ export const parseTitleOrDescription: ParseUtilPartial<MediaNs.TitleOrDescriptio
 }
 
 export const parseThumbnail: ParseUtilPartial<MediaNs.Thumbnail> = (value) => {
-  if (!isObject(value)) {
+  if (!isPlainObject(value)) {
     return
   }
 
@@ -90,7 +90,7 @@ export const parseHash: ParseUtilPartial<MediaNs.Hash> = (value) => {
 }
 
 export const parsePlayer: ParseUtilPartial<MediaNs.Player> = (value) => {
-  if (!isObject(value)) {
+  if (!isPlainObject(value)) {
     return
   }
 
@@ -135,7 +135,7 @@ export const parseText: ParseUtilPartial<MediaNs.Text> = (value) => {
 }
 
 export const parseRestriction: ParseUtilPartial<MediaNs.Restriction> = (value) => {
-  if (!isObject(value)) {
+  if (!isPlainObject(value)) {
     return
   }
 
@@ -149,7 +149,7 @@ export const parseRestriction: ParseUtilPartial<MediaNs.Restriction> = (value) =
 }
 
 export const parseCommunity: ParseUtilPartial<MediaNs.Community> = (value) => {
-  if (!isObject(value)) {
+  if (!isPlainObject(value)) {
     return
   }
 
@@ -163,7 +163,7 @@ export const parseCommunity: ParseUtilPartial<MediaNs.Community> = (value) => {
 }
 
 export const parseStarRating: ParseUtilPartial<MediaNs.StarRating> = (value) => {
-  if (!isObject(value)) {
+  if (!isPlainObject(value)) {
     return
   }
 
@@ -178,7 +178,7 @@ export const parseStarRating: ParseUtilPartial<MediaNs.StarRating> = (value) => 
 }
 
 export const parseStatistics: ParseUtilPartial<MediaNs.Statistics> = (value) => {
-  if (!isObject(value)) {
+  if (!isPlainObject(value)) {
     return
   }
 
@@ -206,7 +206,7 @@ export const parseComments: ParseUtilPartial<Array<string>> = (value) => {
 }
 
 export const parseEmbed: ParseUtilPartial<MediaNs.Embed> = (value) => {
-  if (!isObject(value)) {
+  if (!isPlainObject(value)) {
     return
   }
 
@@ -221,7 +221,7 @@ export const parseEmbed: ParseUtilPartial<MediaNs.Embed> = (value) => {
 }
 
 export const parseParam: ParseUtilPartial<MediaNs.Param> = (value) => {
-  if (!isObject(value)) {
+  if (!isPlainObject(value)) {
     return
   }
 
@@ -242,7 +242,7 @@ export const parseBackLinks: ParseUtilPartial<Array<string>> = (value) => {
 }
 
 export const parseStatus: ParseUtilPartial<MediaNs.Status> = (value) => {
-  if (!isObject(value)) {
+  if (!isPlainObject(value)) {
     return
   }
 
@@ -255,7 +255,7 @@ export const parseStatus: ParseUtilPartial<MediaNs.Status> = (value) => {
 }
 
 export const parsePrice: ParseUtilPartial<MediaNs.Price> = (value) => {
-  if (!isObject(value)) {
+  if (!isPlainObject(value)) {
     return
   }
 
@@ -280,7 +280,7 @@ export const parseLicense: ParseUtilPartial<MediaNs.License> = (value) => {
 }
 
 export const parseSubTitle: ParseUtilPartial<MediaNs.SubTitle> = (value) => {
-  if (!isObject(value)) {
+  if (!isPlainObject(value)) {
     return
   }
 
@@ -294,7 +294,7 @@ export const parseSubTitle: ParseUtilPartial<MediaNs.SubTitle> = (value) => {
 }
 
 export const parsePeerLink: ParseUtilPartial<MediaNs.PeerLink> = (value) => {
-  if (!isObject(value)) {
+  if (!isPlainObject(value)) {
     return
   }
 
@@ -307,7 +307,7 @@ export const parsePeerLink: ParseUtilPartial<MediaNs.PeerLink> = (value) => {
 }
 
 export const parseRights: ParseUtilPartial<MediaNs.Rights> = (value) => {
-  if (!isObject(value)) {
+  if (!isPlainObject(value)) {
     return
   }
 
@@ -319,7 +319,7 @@ export const parseRights: ParseUtilPartial<MediaNs.Rights> = (value) => {
 }
 
 export const parseScene: ParseUtilPartial<MediaNs.Scene> = (value) => {
-  if (!isObject(value)) {
+  if (!isPlainObject(value)) {
     return
   }
 
@@ -341,7 +341,7 @@ export const parseScenes: ParseUtilPartial<Array<MediaNs.Scene>> = (value) => {
 
 export const parseLocation: ParseUtilPartial<MediaNs.Location> = (value) => {
   // For cases where the location is simply a string within the <media:location> tag.
-  if (isNonEmptyStringOrNumber(value) || isObject(value)) {
+  if (isNonEmptyStringOrNumber(value) || isPlainObject(value)) {
     const location = {
       description: ((value) => parseString(retrieveText(value)))(value),
     }
@@ -354,7 +354,7 @@ export const parseLocation: ParseUtilPartial<MediaNs.Location> = (value) => {
 }
 
 export const retrieveCommonElements: ParseUtilPartial<MediaNs.CommonElements> = (value) => {
-  if (!isObject(value)) {
+  if (!isPlainObject(value)) {
     return
   }
 
@@ -392,7 +392,7 @@ export const retrieveCommonElements: ParseUtilPartial<MediaNs.CommonElements> = 
 }
 
 export const parseContent: ParseUtilPartial<MediaNs.Content> = (value) => {
-  if (!isObject(value)) {
+  if (!isPlainObject(value)) {
     return
   }
 
@@ -418,7 +418,7 @@ export const parseContent: ParseUtilPartial<MediaNs.Content> = (value) => {
 }
 
 export const parseGroup: ParseUtilPartial<MediaNs.Group> = (value) => {
-  if (!isObject(value)) {
+  if (!isPlainObject(value)) {
     return
   }
 
@@ -431,7 +431,7 @@ export const parseGroup: ParseUtilPartial<MediaNs.Group> = (value) => {
 }
 
 export const retrieveItemOrFeed: ParseUtilPartial<MediaNs.ItemOrFeed> = (value) => {
-  if (!isObject(value)) {
+  if (!isPlainObject(value)) {
     return
   }
 

--- a/src/namespaces/opensearch/generate/utils.ts
+++ b/src/namespaces/opensearch/generate/utils.ts
@@ -1,15 +1,15 @@
+import { isPlainObject } from 'trousse'
 import type { GenerateUtil } from '../../../common/types.js'
 import {
   generateNumber,
   generatePlainString,
-  isObject,
   trimArray,
   trimObject,
 } from '../../../common/utils.js'
 import type { OpenSearchNs } from '../common/types.js'
 
 export const generateQuery: GenerateUtil<OpenSearchNs.Query> = (query) => {
-  if (!isObject(query)) {
+  if (!isPlainObject(query)) {
     return
   }
 
@@ -28,7 +28,7 @@ export const generateQuery: GenerateUtil<OpenSearchNs.Query> = (query) => {
 }
 
 export const generateFeed: GenerateUtil<OpenSearchNs.Feed> = (feed) => {
-  if (!isObject(feed)) {
+  if (!isPlainObject(feed)) {
     return
   }
 

--- a/src/namespaces/opensearch/parse/utils.ts
+++ b/src/namespaces/opensearch/parse/utils.ts
@@ -1,6 +1,6 @@
+import { isPlainObject } from 'trousse'
 import type { ParseUtilPartial } from '../../../common/types.js'
 import {
-  isObject,
   parseArrayOf,
   parseNumber,
   parseSingularOf,
@@ -11,7 +11,7 @@ import {
 import type { OpenSearchNs } from '../common/types.js'
 
 export const parseQuery: ParseUtilPartial<OpenSearchNs.Query> = (value) => {
-  if (!isObject(value)) {
+  if (!isPlainObject(value)) {
     return
   }
 
@@ -30,7 +30,7 @@ export const parseQuery: ParseUtilPartial<OpenSearchNs.Query> = (value) => {
 }
 
 export const retrieveFeed: ParseUtilPartial<OpenSearchNs.Feed> = (value) => {
-  if (!isObject(value)) {
+  if (!isPlainObject(value)) {
     return
   }
 

--- a/src/namespaces/pingback/generate/utils.ts
+++ b/src/namespaces/pingback/generate/utils.ts
@@ -1,9 +1,10 @@
+import { isPlainObject } from 'trousse'
 import type { GenerateUtil } from '../../../common/types.js'
-import { generateCdataString, isObject, trimObject } from '../../../common/utils.js'
+import { generateCdataString, trimObject } from '../../../common/utils.js'
 import type { PingbackNs } from '../common/types.js'
 
 export const generateItem: GenerateUtil<PingbackNs.Item> = (item) => {
-  if (!isObject(item)) {
+  if (!isPlainObject(item)) {
     return
   }
 
@@ -16,7 +17,7 @@ export const generateItem: GenerateUtil<PingbackNs.Item> = (item) => {
 }
 
 export const generateFeed: GenerateUtil<PingbackNs.Feed> = (feed) => {
-  if (!isObject(feed)) {
+  if (!isPlainObject(feed)) {
     return
   }
 

--- a/src/namespaces/pingback/parse/utils.ts
+++ b/src/namespaces/pingback/parse/utils.ts
@@ -1,6 +1,6 @@
+import { isPlainObject } from 'trousse'
 import type { ParseUtilPartial } from '../../../common/types.js'
 import {
-  isObject,
   parseSingularOf,
   parseString,
   retrieveRdfResourceOrText,
@@ -9,7 +9,7 @@ import {
 import type { PingbackNs } from '../common/types.js'
 
 export const retrieveItem: ParseUtilPartial<PingbackNs.Item> = (value) => {
-  if (!isObject(value)) {
+  if (!isPlainObject(value)) {
     return
   }
 
@@ -26,7 +26,7 @@ export const retrieveItem: ParseUtilPartial<PingbackNs.Item> = (value) => {
 }
 
 export const retrieveFeed: ParseUtilPartial<PingbackNs.Feed> = (value) => {
-  if (!isObject(value)) {
+  if (!isPlainObject(value)) {
     return
   }
 

--- a/src/namespaces/podcast/generate/utils.ts
+++ b/src/namespaces/podcast/generate/utils.ts
@@ -1,3 +1,4 @@
+import { isPlainObject } from 'trousse'
 import type { DateLike, GenerateUtil } from '../../../common/types.js'
 import {
   generateBoolean,
@@ -8,14 +9,13 @@ import {
   generateRfc3339Date,
   generateTextOrCdataString,
   generateYesNoBoolean,
-  isObject,
   trimArray,
   trimObject,
 } from '../../../common/utils.js'
 import type { PodcastNs } from '../common/types.js'
 
 export const generateBaseItem: GenerateUtil<PodcastNs.BaseItem> = (baseItem) => {
-  if (!isObject(baseItem)) {
+  if (!isPlainObject(baseItem)) {
     return
   }
 
@@ -43,7 +43,7 @@ export const generateBaseItem: GenerateUtil<PodcastNs.BaseItem> = (baseItem) => 
 }
 
 export const generateTranscript: GenerateUtil<PodcastNs.Transcript> = (transcript) => {
-  if (!isObject(transcript)) {
+  if (!isPlainObject(transcript)) {
     return
   }
 
@@ -58,7 +58,7 @@ export const generateTranscript: GenerateUtil<PodcastNs.Transcript> = (transcrip
 }
 
 export const generateLocked: GenerateUtil<PodcastNs.Locked> = (locked) => {
-  if (!isObject(locked)) {
+  if (!isPlainObject(locked)) {
     return
   }
 
@@ -71,7 +71,7 @@ export const generateLocked: GenerateUtil<PodcastNs.Locked> = (locked) => {
 }
 
 export const generateFunding: GenerateUtil<PodcastNs.Funding> = (funding) => {
-  if (!isObject(funding)) {
+  if (!isPlainObject(funding)) {
     return
   }
 
@@ -84,7 +84,7 @@ export const generateFunding: GenerateUtil<PodcastNs.Funding> = (funding) => {
 }
 
 export const generateChapters: GenerateUtil<PodcastNs.Chapters> = (chapters) => {
-  if (!isObject(chapters)) {
+  if (!isPlainObject(chapters)) {
     return
   }
 
@@ -97,7 +97,7 @@ export const generateChapters: GenerateUtil<PodcastNs.Chapters> = (chapters) => 
 }
 
 export const generateSoundbite: GenerateUtil<PodcastNs.Soundbite> = (soundbite) => {
-  if (!isObject(soundbite)) {
+  if (!isPlainObject(soundbite)) {
     return
   }
 
@@ -111,7 +111,7 @@ export const generateSoundbite: GenerateUtil<PodcastNs.Soundbite> = (soundbite) 
 }
 
 export const generatePerson: GenerateUtil<PodcastNs.Person> = (person) => {
-  if (!isObject(person)) {
+  if (!isPlainObject(person)) {
     return
   }
 
@@ -127,7 +127,7 @@ export const generatePerson: GenerateUtil<PodcastNs.Person> = (person) => {
 }
 
 export const generateLocation: GenerateUtil<PodcastNs.Location> = (location) => {
-  if (!isObject(location)) {
+  if (!isPlainObject(location)) {
     return
   }
 
@@ -143,7 +143,7 @@ export const generateLocation: GenerateUtil<PodcastNs.Location> = (location) => 
 }
 
 export const generateSeason: GenerateUtil<PodcastNs.Season> = (season) => {
-  if (!isObject(season)) {
+  if (!isPlainObject(season)) {
     return
   }
 
@@ -156,7 +156,7 @@ export const generateSeason: GenerateUtil<PodcastNs.Season> = (season) => {
 }
 
 export const generateEpisode: GenerateUtil<PodcastNs.Episode> = (episode) => {
-  if (!isObject(episode)) {
+  if (!isPlainObject(episode)) {
     return
   }
 
@@ -169,7 +169,7 @@ export const generateEpisode: GenerateUtil<PodcastNs.Episode> = (episode) => {
 }
 
 export const generateTrailer: GenerateUtil<PodcastNs.Trailer<DateLike>> = (trailer) => {
-  if (!isObject(trailer)) {
+  if (!isPlainObject(trailer)) {
     return
   }
 
@@ -186,7 +186,7 @@ export const generateTrailer: GenerateUtil<PodcastNs.Trailer<DateLike>> = (trail
 }
 
 export const generateLicense: GenerateUtil<PodcastNs.License> = (license) => {
-  if (!isObject(license)) {
+  if (!isPlainObject(license)) {
     return
   }
 
@@ -199,7 +199,7 @@ export const generateLicense: GenerateUtil<PodcastNs.License> = (license) => {
 }
 
 export const generateSource: GenerateUtil<PodcastNs.Source> = (source) => {
-  if (!isObject(source)) {
+  if (!isPlainObject(source)) {
     return
   }
 
@@ -212,7 +212,7 @@ export const generateSource: GenerateUtil<PodcastNs.Source> = (source) => {
 }
 
 export const generateIntegrity: GenerateUtil<PodcastNs.Integrity> = (integrity) => {
-  if (!isObject(integrity)) {
+  if (!isPlainObject(integrity)) {
     return
   }
 
@@ -227,7 +227,7 @@ export const generateIntegrity: GenerateUtil<PodcastNs.Integrity> = (integrity) 
 export const generateAlternateEnclosure: GenerateUtil<PodcastNs.AlternateEnclosure> = (
   alternateEnclosure,
 ) => {
-  if (!isObject(alternateEnclosure)) {
+  if (!isPlainObject(alternateEnclosure)) {
     return
   }
 
@@ -249,7 +249,7 @@ export const generateAlternateEnclosure: GenerateUtil<PodcastNs.AlternateEnclosu
 }
 
 export const generateValueRecipient: GenerateUtil<PodcastNs.ValueRecipient> = (valueRecipient) => {
-  if (!isObject(valueRecipient)) {
+  if (!isPlainObject(valueRecipient)) {
     return
   }
 
@@ -267,7 +267,7 @@ export const generateValueRecipient: GenerateUtil<PodcastNs.ValueRecipient> = (v
 }
 
 export const generateValueTimeSplit: GenerateUtil<PodcastNs.ValueTimeSplit> = (valueTimeSplit) => {
-  if (!isObject(valueTimeSplit)) {
+  if (!isPlainObject(valueTimeSplit)) {
     return
   }
 
@@ -284,7 +284,7 @@ export const generateValueTimeSplit: GenerateUtil<PodcastNs.ValueTimeSplit> = (v
 }
 
 export const generateValue: GenerateUtil<PodcastNs.Value> = (value) => {
-  if (!isObject(value)) {
+  if (!isPlainObject(value)) {
     return
   }
 
@@ -300,7 +300,7 @@ export const generateValue: GenerateUtil<PodcastNs.Value> = (value) => {
 }
 
 export const generateImage: GenerateUtil<PodcastNs.Image> = (image) => {
-  if (!isObject(image)) {
+  if (!isPlainObject(image)) {
     return
   }
 
@@ -318,7 +318,7 @@ export const generateImage: GenerateUtil<PodcastNs.Image> = (image) => {
 }
 
 export const generateContentLink: GenerateUtil<PodcastNs.ContentLink> = (contentLink) => {
-  if (!isObject(contentLink)) {
+  if (!isPlainObject(contentLink)) {
     return
   }
 
@@ -331,7 +331,7 @@ export const generateContentLink: GenerateUtil<PodcastNs.ContentLink> = (content
 }
 
 export const generateLiveItem: GenerateUtil<PodcastNs.LiveItem<DateLike>> = (liveItem) => {
-  if (!isObject(liveItem)) {
+  if (!isPlainObject(liveItem)) {
     return
   }
 
@@ -347,7 +347,7 @@ export const generateLiveItem: GenerateUtil<PodcastNs.LiveItem<DateLike>> = (liv
 }
 
 export const generateSocialInteract: GenerateUtil<PodcastNs.SocialInteract> = (socialInteract) => {
-  if (!isObject(socialInteract)) {
+  if (!isPlainObject(socialInteract)) {
     return
   }
 
@@ -363,7 +363,7 @@ export const generateSocialInteract: GenerateUtil<PodcastNs.SocialInteract> = (s
 }
 
 export const generateChat: GenerateUtil<PodcastNs.Chat> = (chat) => {
-  if (!isObject(chat)) {
+  if (!isPlainObject(chat)) {
     return
   }
 
@@ -378,7 +378,7 @@ export const generateChat: GenerateUtil<PodcastNs.Chat> = (chat) => {
 }
 
 export const generateBlock: GenerateUtil<PodcastNs.Block> = (block) => {
-  if (!isObject(block)) {
+  if (!isPlainObject(block)) {
     return
   }
 
@@ -391,7 +391,7 @@ export const generateBlock: GenerateUtil<PodcastNs.Block> = (block) => {
 }
 
 export const generateTxt: GenerateUtil<PodcastNs.Txt> = (txt) => {
-  if (!isObject(txt)) {
+  if (!isPlainObject(txt)) {
     return
   }
 
@@ -404,7 +404,7 @@ export const generateTxt: GenerateUtil<PodcastNs.Txt> = (txt) => {
 }
 
 export const generateRemoteItem: GenerateUtil<PodcastNs.RemoteItem> = (remoteItem) => {
-  if (!isObject(remoteItem)) {
+  if (!isPlainObject(remoteItem)) {
     return
   }
 
@@ -420,7 +420,7 @@ export const generateRemoteItem: GenerateUtil<PodcastNs.RemoteItem> = (remoteIte
 }
 
 export const generatePodroll: GenerateUtil<PodcastNs.Podroll> = (podroll) => {
-  if (!isObject(podroll)) {
+  if (!isPlainObject(podroll)) {
     return
   }
 
@@ -434,7 +434,7 @@ export const generatePodroll: GenerateUtil<PodcastNs.Podroll> = (podroll) => {
 export const generateUpdateFrequency: GenerateUtil<PodcastNs.UpdateFrequency<DateLike>> = (
   updateFrequency,
 ) => {
-  if (!isObject(updateFrequency)) {
+  if (!isPlainObject(updateFrequency)) {
     return
   }
 
@@ -449,7 +449,7 @@ export const generateUpdateFrequency: GenerateUtil<PodcastNs.UpdateFrequency<Dat
 }
 
 export const generatePodping: GenerateUtil<PodcastNs.Podping> = (podping) => {
-  if (!isObject(podping)) {
+  if (!isPlainObject(podping)) {
     return
   }
 
@@ -461,7 +461,7 @@ export const generatePodping: GenerateUtil<PodcastNs.Podping> = (podping) => {
 }
 
 export const generatePublisher: GenerateUtil<PodcastNs.Publisher> = (publisher) => {
-  if (!isObject(publisher)) {
+  if (!isPlainObject(publisher)) {
     return
   }
 
@@ -473,7 +473,7 @@ export const generatePublisher: GenerateUtil<PodcastNs.Publisher> = (publisher) 
 }
 
 export const generateItem: GenerateUtil<PodcastNs.Item> = (item) => {
-  if (!isObject(item)) {
+  if (!isPlainObject(item)) {
     return
   }
 
@@ -481,7 +481,7 @@ export const generateItem: GenerateUtil<PodcastNs.Item> = (item) => {
 }
 
 export const generateFeed: GenerateUtil<PodcastNs.Feed<DateLike>> = (feed) => {
-  if (!isObject(feed)) {
+  if (!isPlainObject(feed)) {
     return
   }
 

--- a/src/namespaces/podcast/parse/utils.ts
+++ b/src/namespaces/podcast/parse/utils.ts
@@ -1,6 +1,6 @@
+import { isPlainObject } from 'trousse'
 import type { DateAny, ParseMainOptions, ParseUtilPartial } from '../../../common/types.js'
 import {
-  isObject,
   parseArrayOf,
   parseBoolean,
   parseDate,
@@ -18,7 +18,7 @@ const whitespaceRegex = /\s+/
 const trailingWRegex = /w$/
 
 export const parseTranscript: ParseUtilPartial<PodcastNs.Transcript> = (value) => {
-  if (!isObject(value)) {
+  if (!isPlainObject(value)) {
     return
   }
 
@@ -42,7 +42,7 @@ export const parseLocked: ParseUtilPartial<PodcastNs.Locked> = (value) => {
 }
 
 export const parseFunding: ParseUtilPartial<PodcastNs.Funding> = (value) => {
-  if (!isObject(value)) {
+  if (!isPlainObject(value)) {
     return
   }
 
@@ -55,7 +55,7 @@ export const parseFunding: ParseUtilPartial<PodcastNs.Funding> = (value) => {
 }
 
 export const parseChapters: ParseUtilPartial<PodcastNs.Chapters> = (value) => {
-  if (!isObject(value)) {
+  if (!isPlainObject(value)) {
     return
   }
 
@@ -68,7 +68,7 @@ export const parseChapters: ParseUtilPartial<PodcastNs.Chapters> = (value) => {
 }
 
 export const parseSoundbite: ParseUtilPartial<PodcastNs.Soundbite> = (value) => {
-  if (!isObject(value)) {
+  if (!isPlainObject(value)) {
     return
   }
 
@@ -127,7 +127,7 @@ export const parseTrailer: ParseUtilPartial<
   PodcastNs.Trailer<DateAny>,
   ParseMainOptions<DateAny>
 > = (value, options) => {
-  if (!isObject(value)) {
+  if (!isPlainObject(value)) {
     return
   }
 
@@ -153,7 +153,7 @@ export const parseLicense: ParseUtilPartial<PodcastNs.License> = (value) => {
 }
 
 export const parseAlternateEnclosure: ParseUtilPartial<PodcastNs.AlternateEnclosure> = (value) => {
-  if (!isObject(value)) {
+  if (!isPlainObject(value)) {
     return
   }
 
@@ -175,7 +175,7 @@ export const parseAlternateEnclosure: ParseUtilPartial<PodcastNs.AlternateEnclos
 }
 
 export const parseSource: ParseUtilPartial<PodcastNs.Source> = (value) => {
-  if (!isObject(value)) {
+  if (!isPlainObject(value)) {
     return
   }
 
@@ -188,7 +188,7 @@ export const parseSource: ParseUtilPartial<PodcastNs.Source> = (value) => {
 }
 
 export const parseIntegrity: ParseUtilPartial<PodcastNs.Integrity> = (value) => {
-  if (!isObject(value)) {
+  if (!isPlainObject(value)) {
     return
   }
 
@@ -201,7 +201,7 @@ export const parseIntegrity: ParseUtilPartial<PodcastNs.Integrity> = (value) => 
 }
 
 export const parseValue: ParseUtilPartial<PodcastNs.Value> = (value) => {
-  if (!isObject(value)) {
+  if (!isPlainObject(value)) {
     return
   }
 
@@ -217,7 +217,7 @@ export const parseValue: ParseUtilPartial<PodcastNs.Value> = (value) => {
 }
 
 export const parseValueRecipient: ParseUtilPartial<PodcastNs.ValueRecipient> = (value) => {
-  if (!isObject(value)) {
+  if (!isPlainObject(value)) {
     return
   }
 
@@ -235,7 +235,7 @@ export const parseValueRecipient: ParseUtilPartial<PodcastNs.ValueRecipient> = (
 }
 
 export const parseImage: ParseUtilPartial<PodcastNs.Image> = (value) => {
-  if (!isObject(value)) {
+  if (!isPlainObject(value)) {
     return
   }
 
@@ -287,7 +287,7 @@ export const parseLiveItem: ParseUtilPartial<
   PodcastNs.LiveItem<DateAny>,
   ParseMainOptions<DateAny>
 > = (value, options) => {
-  if (!isObject(value)) {
+  if (!isPlainObject(value)) {
     return
   }
 
@@ -303,7 +303,7 @@ export const parseLiveItem: ParseUtilPartial<
 }
 
 export const parseContentLink: ParseUtilPartial<PodcastNs.ContentLink> = (value) => {
-  if (!isObject(value)) {
+  if (!isPlainObject(value)) {
     return
   }
 
@@ -316,7 +316,7 @@ export const parseContentLink: ParseUtilPartial<PodcastNs.ContentLink> = (value)
 }
 
 export const parseSocialInteract: ParseUtilPartial<PodcastNs.SocialInteract> = (value) => {
-  if (!isObject(value)) {
+  if (!isPlainObject(value)) {
     return
   }
 
@@ -332,7 +332,7 @@ export const parseSocialInteract: ParseUtilPartial<PodcastNs.SocialInteract> = (
 }
 
 export const parseChat: ParseUtilPartial<PodcastNs.Chat> = (value) => {
-  if (!isObject(value)) {
+  if (!isPlainObject(value)) {
     return
   }
 
@@ -365,7 +365,7 @@ export const parseTxt: ParseUtilPartial<PodcastNs.Txt> = (value) => {
 }
 
 export const parseRemoteItem: ParseUtilPartial<PodcastNs.RemoteItem> = (value) => {
-  if (!isObject(value)) {
+  if (!isPlainObject(value)) {
     return
   }
 
@@ -381,7 +381,7 @@ export const parseRemoteItem: ParseUtilPartial<PodcastNs.RemoteItem> = (value) =
 }
 
 export const parsePodroll: ParseUtilPartial<PodcastNs.Podroll> = (value) => {
-  if (!isObject(value)) {
+  if (!isPlainObject(value)) {
     return
   }
 
@@ -407,7 +407,7 @@ export const parseUpdateFrequency: ParseUtilPartial<
 }
 
 export const parsePodping: ParseUtilPartial<PodcastNs.Podping> = (value) => {
-  if (!isObject(value)) {
+  if (!isPlainObject(value)) {
     return
   }
 
@@ -419,7 +419,7 @@ export const parsePodping: ParseUtilPartial<PodcastNs.Podping> = (value) => {
 }
 
 export const parsePublisher: ParseUtilPartial<PodcastNs.Publisher> = (value) => {
-  if (!isObject(value)) {
+  if (!isPlainObject(value)) {
     return
   }
 
@@ -431,7 +431,7 @@ export const parsePublisher: ParseUtilPartial<PodcastNs.Publisher> = (value) => 
 }
 
 export const parseValueTimeSplit: ParseUtilPartial<PodcastNs.ValueTimeSplit> = (value) => {
-  if (!isObject(value)) {
+  if (!isPlainObject(value)) {
     return
   }
 
@@ -448,7 +448,7 @@ export const parseValueTimeSplit: ParseUtilPartial<PodcastNs.ValueTimeSplit> = (
 }
 
 export const retrieveItem: ParseUtilPartial<PodcastNs.Item> = (value) => {
-  if (!isObject(value)) {
+  if (!isPlainObject(value)) {
     return
   }
 
@@ -476,7 +476,7 @@ export const retrieveFeed: ParseUtilPartial<PodcastNs.Feed<DateAny>, ParseMainOp
   value,
   options,
 ) => {
-  if (!isObject(value)) {
+  if (!isPlainObject(value)) {
     return
   }
 

--- a/src/namespaces/prism/generate/utils.ts
+++ b/src/namespaces/prism/generate/utils.ts
@@ -1,16 +1,16 @@
+import { isPlainObject } from 'trousse'
 import type { DateLike, GenerateUtil } from '../../../common/types.js'
 import {
   generateCdataString,
   generateNumber,
   generateRfc3339Date,
-  isObject,
   trimArray,
   trimObject,
 } from '../../../common/utils.js'
 import type { PrismNs } from '../common/types.js'
 
 export const generateFeed: GenerateUtil<PrismNs.Feed<DateLike>> = (feed) => {
-  if (!isObject(feed)) {
+  if (!isPlainObject(feed)) {
     return
   }
 
@@ -98,7 +98,7 @@ export const generateFeed: GenerateUtil<PrismNs.Feed<DateLike>> = (feed) => {
 }
 
 export const generateItem: GenerateUtil<PrismNs.Item<DateLike>> = (item) => {
-  if (!isObject(item)) {
+  if (!isPlainObject(item)) {
     return
   }
 

--- a/src/namespaces/prism/parse/utils.ts
+++ b/src/namespaces/prism/parse/utils.ts
@@ -1,6 +1,6 @@
+import { isPlainObject } from 'trousse'
 import type { DateAny, ParseMainOptions, ParseUtilPartial } from '../../../common/types.js'
 import {
-  isObject,
   parseArrayOf,
   parseDate,
   parseNumber,
@@ -15,7 +15,7 @@ export const retrieveFeed: ParseUtilPartial<PrismNs.Feed<DateAny>, ParseMainOpti
   value,
   options,
 ) => {
-  if (!isObject(value)) {
+  if (!isPlainObject(value)) {
     return
   }
 
@@ -208,7 +208,7 @@ export const retrieveItem: ParseUtilPartial<PrismNs.Item<DateAny>, ParseMainOpti
   value,
   options,
 ) => {
-  if (!isObject(value)) {
+  if (!isPlainObject(value)) {
     return
   }
 

--- a/src/namespaces/psc/generate/utils.ts
+++ b/src/namespaces/psc/generate/utils.ts
@@ -1,9 +1,10 @@
+import { isPlainObject } from 'trousse'
 import type { GenerateUtil } from '../../../common/types.js'
-import { generatePlainString, isObject, trimArray, trimObject } from '../../../common/utils.js'
+import { generatePlainString, trimArray, trimObject } from '../../../common/utils.js'
 import type { PscNs } from '../common/types.js'
 
 export const generateChapter: GenerateUtil<PscNs.Chapter> = (chapter) => {
-  if (!isObject(chapter)) {
+  if (!isPlainObject(chapter)) {
     return
   }
 
@@ -26,7 +27,7 @@ export const generateChapters: GenerateUtil<Array<PscNs.Chapter>> = (chapters) =
 }
 
 export const generateItem: GenerateUtil<PscNs.Item> = (item) => {
-  if (!isObject(item)) {
+  if (!isPlainObject(item)) {
     return
   }
 

--- a/src/namespaces/psc/parse/utils.ts
+++ b/src/namespaces/psc/parse/utils.ts
@@ -1,15 +1,10 @@
+import { isPlainObject } from 'trousse'
 import type { ParseUtilPartial } from '../../../common/types.js'
-import {
-  isObject,
-  parseArrayOf,
-  parseSingularOf,
-  parseString,
-  trimObject,
-} from '../../../common/utils.js'
+import { parseArrayOf, parseSingularOf, parseString, trimObject } from '../../../common/utils.js'
 import type { PscNs } from '../common/types.js'
 
 export const parseChapter: ParseUtilPartial<PscNs.Chapter> = (value) => {
-  if (!isObject(value)) {
+  if (!isPlainObject(value)) {
     return
   }
 
@@ -28,7 +23,7 @@ export const parseChapters: ParseUtilPartial<Array<PscNs.Chapter>> = (value) => 
 }
 
 export const retrieveItem: ParseUtilPartial<PscNs.Item> = (value) => {
-  if (!isObject(value)) {
+  if (!isPlainObject(value)) {
     return
   }
 

--- a/src/namespaces/rawvoice/generate/utils.ts
+++ b/src/namespaces/rawvoice/generate/utils.ts
@@ -1,3 +1,4 @@
+import { isPlainObject } from 'trousse'
 import type { DateLike, GenerateUtil } from '../../../common/types.js'
 import {
   generateCdataString,
@@ -6,14 +7,13 @@ import {
   generateRfc822Date,
   generateTextOrCdataString,
   generateYesNoBoolean,
-  isObject,
   trimArray,
   trimObject,
 } from '../../../common/utils.js'
 import type { RawVoiceNs } from '../common/types.js'
 
 export const generateRating: GenerateUtil<RawVoiceNs.Rating> = (rating) => {
-  if (!isObject(rating)) {
+  if (!isPlainObject(rating)) {
     return
   }
 
@@ -27,7 +27,7 @@ export const generateRating: GenerateUtil<RawVoiceNs.Rating> = (rating) => {
 }
 
 export const generateLiveStream: GenerateUtil<RawVoiceNs.LiveStream<DateLike>> = (liveStream) => {
-  if (!isObject(liveStream)) {
+  if (!isPlainObject(liveStream)) {
     return
   }
 
@@ -42,7 +42,7 @@ export const generateLiveStream: GenerateUtil<RawVoiceNs.LiveStream<DateLike>> =
 }
 
 export const generatePoster: GenerateUtil<RawVoiceNs.Poster> = (poster) => {
-  if (!isObject(poster)) {
+  if (!isPlainObject(poster)) {
     return
   }
 
@@ -56,7 +56,7 @@ export const generatePoster: GenerateUtil<RawVoiceNs.Poster> = (poster) => {
 export const generateAlternateEnclosure: GenerateUtil<RawVoiceNs.AlternateEnclosure> = (
   alternateEnclosure,
 ) => {
-  if (!isObject(alternateEnclosure)) {
+  if (!isPlainObject(alternateEnclosure)) {
     return
   }
 
@@ -70,7 +70,7 @@ export const generateAlternateEnclosure: GenerateUtil<RawVoiceNs.AlternateEnclos
 }
 
 export const generateSubscribe: GenerateUtil<RawVoiceNs.Subscribe> = (subscribe) => {
-  if (!isObject(subscribe)) {
+  if (!isPlainObject(subscribe)) {
     return
   }
 
@@ -85,7 +85,7 @@ export const generateSubscribe: GenerateUtil<RawVoiceNs.Subscribe> = (subscribe)
 }
 
 export const generateMetamark: GenerateUtil<RawVoiceNs.Metamark> = (metamark) => {
-  if (!isObject(metamark)) {
+  if (!isPlainObject(metamark)) {
     return
   }
 
@@ -101,7 +101,7 @@ export const generateMetamark: GenerateUtil<RawVoiceNs.Metamark> = (metamark) =>
 }
 
 export const generateDonate: GenerateUtil<RawVoiceNs.Donate> = (donate) => {
-  if (!isObject(donate)) {
+  if (!isPlainObject(donate)) {
     return
   }
 
@@ -114,7 +114,7 @@ export const generateDonate: GenerateUtil<RawVoiceNs.Donate> = (donate) => {
 }
 
 export const generateItem: GenerateUtil<RawVoiceNs.Item> = (item) => {
-  if (!isObject(item)) {
+  if (!isPlainObject(item)) {
     return
   }
 
@@ -131,7 +131,7 @@ export const generateItem: GenerateUtil<RawVoiceNs.Item> = (item) => {
 }
 
 export const generateFeed: GenerateUtil<RawVoiceNs.Feed<DateLike>> = (feed) => {
-  if (!isObject(feed)) {
+  if (!isPlainObject(feed)) {
     return
   }
 

--- a/src/namespaces/rawvoice/parse/utils.ts
+++ b/src/namespaces/rawvoice/parse/utils.ts
@@ -1,6 +1,6 @@
+import { isPlainObject } from 'trousse'
 import type { DateAny, ParseMainOptions, ParseUtilPartial } from '../../../common/types.js'
 import {
-  isObject,
   parseArrayOf,
   parseDate,
   parseNumber,
@@ -37,7 +37,7 @@ export const parseLiveStream: ParseUtilPartial<
 }
 
 export const parsePoster: ParseUtilPartial<RawVoiceNs.Poster> = (value) => {
-  if (!isObject(value)) {
+  if (!isPlainObject(value)) {
     return
   }
 
@@ -49,7 +49,7 @@ export const parsePoster: ParseUtilPartial<RawVoiceNs.Poster> = (value) => {
 }
 
 export const parseAlternateEnclosure: ParseUtilPartial<RawVoiceNs.AlternateEnclosure> = (value) => {
-  if (!isObject(value)) {
+  if (!isPlainObject(value)) {
     return
   }
 
@@ -63,7 +63,7 @@ export const parseAlternateEnclosure: ParseUtilPartial<RawVoiceNs.AlternateEnclo
 }
 
 export const parseSubscribe: ParseUtilPartial<RawVoiceNs.Subscribe> = (value) => {
-  if (!isObject(value)) {
+  if (!isPlainObject(value)) {
     return
   }
 
@@ -84,7 +84,7 @@ export const parseSubscribe: ParseUtilPartial<RawVoiceNs.Subscribe> = (value) =>
 }
 
 export const parseMetamark: ParseUtilPartial<RawVoiceNs.Metamark> = (value) => {
-  if (!isObject(value)) {
+  if (!isPlainObject(value)) {
     return
   }
 
@@ -100,7 +100,7 @@ export const parseMetamark: ParseUtilPartial<RawVoiceNs.Metamark> = (value) => {
 }
 
 export const parseDonate: ParseUtilPartial<RawVoiceNs.Donate> = (value) => {
-  if (!isObject(value)) {
+  if (!isPlainObject(value)) {
     return
   }
 
@@ -113,7 +113,7 @@ export const parseDonate: ParseUtilPartial<RawVoiceNs.Donate> = (value) => {
 }
 
 export const retrieveItem: ParseUtilPartial<RawVoiceNs.Item> = (value) => {
-  if (!isObject(value)) {
+  if (!isPlainObject(value)) {
     return
   }
 
@@ -135,7 +135,7 @@ export const retrieveFeed: ParseUtilPartial<RawVoiceNs.Feed<DateAny>, ParseMainO
   value,
   options,
 ) => {
-  if (!isObject(value)) {
+  if (!isPlainObject(value)) {
     return
   }
 

--- a/src/namespaces/rdf/generate/utils.ts
+++ b/src/namespaces/rdf/generate/utils.ts
@@ -1,9 +1,10 @@
+import { isPlainObject } from 'trousse'
 import type { GenerateUtil } from '../../../common/types.js'
-import { generatePlainString, isObject, trimArray, trimObject } from '../../../common/utils.js'
+import { generatePlainString, trimArray, trimObject } from '../../../common/utils.js'
 import type { RdfNs } from '../common/types.js'
 
 export const generateAbout: GenerateUtil<RdfNs.About> = (about) => {
-  if (!isObject(about)) {
+  if (!isPlainObject(about)) {
     return
   }
 
@@ -16,7 +17,7 @@ export const generateAbout: GenerateUtil<RdfNs.About> = (about) => {
 
 /** @internal General RDF element kept for potential future use when all RDF data is needed. */
 export const generateElement: GenerateUtil<RdfNs.Element> = (element) => {
-  if (!isObject(element)) {
+  if (!isPlainObject(element)) {
     return
   }
 

--- a/src/namespaces/rdf/parse/utils.ts
+++ b/src/namespaces/rdf/parse/utils.ts
@@ -1,6 +1,6 @@
+import { isPlainObject } from 'trousse'
 import type { ParseUtilPartial } from '../../../common/types.js'
 import {
-  isObject,
   parseArrayOf,
   parseSingularOf,
   parseString,
@@ -11,7 +11,7 @@ import {
 import type { RdfNs } from '../common/types.js'
 
 export const retrieveAbout: ParseUtilPartial<RdfNs.About> = (value) => {
-  if (!isObject(value)) {
+  if (!isPlainObject(value)) {
     return
   }
 
@@ -24,7 +24,7 @@ export const retrieveAbout: ParseUtilPartial<RdfNs.About> = (value) => {
 
 /** @internal General RDF element kept for potential future use when all RDF data is needed. */
 export const retrieveElement: ParseUtilPartial<RdfNs.Element> = (value) => {
-  if (!isObject(value)) {
+  if (!isPlainObject(value)) {
     return
   }
 

--- a/src/namespaces/slash/generate/utils.ts
+++ b/src/namespaces/slash/generate/utils.ts
@@ -1,15 +1,15 @@
+import { isPlainObject } from 'trousse'
 import type { GenerateUtil } from '../../../common/types.js'
 import {
   generateCdataString,
   generateCsvOf,
   generateNumber,
-  isObject,
   trimObject,
 } from '../../../common/utils.js'
 import type { SlashNs } from '../common/types.js'
 
 export const generateItem: GenerateUtil<SlashNs.Item> = (item) => {
-  if (!isObject(item)) {
+  if (!isPlainObject(item)) {
     return
   }
 

--- a/src/namespaces/slash/parse/utils.ts
+++ b/src/namespaces/slash/parse/utils.ts
@@ -1,6 +1,6 @@
+import { isPlainObject } from 'trousse'
 import type { ParseUtilPartial } from '../../../common/types.js'
 import {
-  isObject,
   parseCsvOf,
   parseNumber,
   parseSingularOf,
@@ -15,7 +15,7 @@ export const parseHitParade: ParseUtilPartial<SlashNs.HitParade> = (value) => {
 }
 
 export const retrieveItem: ParseUtilPartial<SlashNs.Item> = (value) => {
-  if (!isObject(value)) {
+  if (!isPlainObject(value)) {
     return
   }
 

--- a/src/namespaces/source/generate/utils.ts
+++ b/src/namespaces/source/generate/utils.ts
@@ -1,16 +1,15 @@
-import { isNonEmptyString } from 'trousse'
+import { isNonEmptyString, isPlainObject } from 'trousse'
 import type { GenerateUtil } from '../../../common/types.js'
 import {
   generateCdataString,
   generateTextOrCdataString,
-  isObject,
   trimArray,
   trimObject,
 } from '../../../common/utils.js'
 import type { SourceNs } from '../common/types.js'
 
 export const generateAccount: GenerateUtil<SourceNs.Account> = (account) => {
-  if (!isObject(account) || !isNonEmptyString(account.service)) {
+  if (!isPlainObject(account) || !isNonEmptyString(account.service)) {
     return
   }
 
@@ -23,7 +22,7 @@ export const generateAccount: GenerateUtil<SourceNs.Account> = (account) => {
 }
 
 export const generateLikes: GenerateUtil<SourceNs.Likes> = (likes) => {
-  if (!isObject(likes) || !isNonEmptyString(likes.server)) {
+  if (!isPlainObject(likes) || !isNonEmptyString(likes.server)) {
     return
   }
 
@@ -33,7 +32,11 @@ export const generateLikes: GenerateUtil<SourceNs.Likes> = (likes) => {
 }
 
 export const generateArchive: GenerateUtil<SourceNs.Archive> = (archive) => {
-  if (!isObject(archive) || !isNonEmptyString(archive.url) || !isNonEmptyString(archive.startDay)) {
+  if (
+    !isPlainObject(archive) ||
+    !isNonEmptyString(archive.url) ||
+    !isNonEmptyString(archive.startDay)
+  ) {
     return
   }
 
@@ -50,7 +53,7 @@ export const generateArchive: GenerateUtil<SourceNs.Archive> = (archive) => {
 export const generateSubscriptionList: GenerateUtil<SourceNs.SubscriptionList> = (
   subscriptionList,
 ) => {
-  if (!isObject(subscriptionList) || !isNonEmptyString(subscriptionList.url)) {
+  if (!isPlainObject(subscriptionList) || !isNonEmptyString(subscriptionList.url)) {
     return
   }
 
@@ -63,7 +66,7 @@ export const generateSubscriptionList: GenerateUtil<SourceNs.SubscriptionList> =
 }
 
 export const generateFeed: GenerateUtil<SourceNs.Feed> = (feed) => {
-  if (!isObject(feed)) {
+  if (!isPlainObject(feed)) {
     return
   }
 
@@ -81,7 +84,7 @@ export const generateFeed: GenerateUtil<SourceNs.Feed> = (feed) => {
 }
 
 export const generateItem: GenerateUtil<SourceNs.Item> = (item) => {
-  if (!isObject(item)) {
+  if (!isPlainObject(item)) {
     return
   }
 

--- a/src/namespaces/source/generate/utils.ts
+++ b/src/namespaces/source/generate/utils.ts
@@ -1,8 +1,8 @@
+import { isNonEmptyString } from 'trousse'
 import type { GenerateUtil } from '../../../common/types.js'
 import {
   generateCdataString,
   generateTextOrCdataString,
-  isNonEmptyString,
   isObject,
   trimArray,
   trimObject,

--- a/src/namespaces/source/parse/utils.ts
+++ b/src/namespaces/source/parse/utils.ts
@@ -1,6 +1,6 @@
+import { isPlainObject } from 'trousse'
 import type { ParseUtilPartial } from '../../../common/types.js'
 import {
-  isObject,
   parseArrayOf,
   parseSingularOf,
   parseString,
@@ -10,7 +10,7 @@ import {
 import type { SourceNs } from '../common/types.js'
 
 export const parseAccount: ParseUtilPartial<SourceNs.Account> = (value) => {
-  if (!isObject(value)) {
+  if (!isPlainObject(value)) {
     return
   }
 
@@ -23,7 +23,7 @@ export const parseAccount: ParseUtilPartial<SourceNs.Account> = (value) => {
 }
 
 export const parseLikes: ParseUtilPartial<SourceNs.Likes> = (value) => {
-  if (!isObject(value)) {
+  if (!isPlainObject(value)) {
     return
   }
 
@@ -35,7 +35,7 @@ export const parseLikes: ParseUtilPartial<SourceNs.Likes> = (value) => {
 }
 
 export const parseArchive: ParseUtilPartial<SourceNs.Archive> = (value) => {
-  if (!isObject(value)) {
+  if (!isPlainObject(value)) {
     return
   }
 
@@ -54,7 +54,7 @@ export const parseArchive: ParseUtilPartial<SourceNs.Archive> = (value) => {
 }
 
 export const parseSubscriptionList: ParseUtilPartial<SourceNs.SubscriptionList> = (value) => {
-  if (!isObject(value)) {
+  if (!isPlainObject(value)) {
     return
   }
 
@@ -67,7 +67,7 @@ export const parseSubscriptionList: ParseUtilPartial<SourceNs.SubscriptionList> 
 }
 
 export const retrieveFeed: ParseUtilPartial<SourceNs.Feed> = (value) => {
-  if (!isObject(value)) {
+  if (!isPlainObject(value)) {
     return
   }
 
@@ -87,7 +87,7 @@ export const retrieveFeed: ParseUtilPartial<SourceNs.Feed> = (value) => {
 }
 
 export const retrieveItem: ParseUtilPartial<SourceNs.Item> = (value) => {
-  if (!isObject(value)) {
+  if (!isPlainObject(value)) {
     return
   }
 

--- a/src/namespaces/spotify/generate/utils.ts
+++ b/src/namespaces/spotify/generate/utils.ts
@@ -1,15 +1,15 @@
+import { isPlainObject } from 'trousse'
 import type { GenerateUtil } from '../../../common/types.js'
 import {
   generateCdataString,
   generateNumber,
   generatePlainString,
-  isObject,
   trimObject,
 } from '../../../common/utils.js'
 import type { SpotifyNs } from '../common/types.js'
 
 export const generateLimit: GenerateUtil<SpotifyNs.Limit> = (limit) => {
-  if (!isObject(limit)) {
+  if (!isPlainObject(limit)) {
     return
   }
 
@@ -21,7 +21,7 @@ export const generateLimit: GenerateUtil<SpotifyNs.Limit> = (limit) => {
 }
 
 export const generatePartner: GenerateUtil<SpotifyNs.Partner> = (partner) => {
-  if (!isObject(partner)) {
+  if (!isPlainObject(partner)) {
     return
   }
 
@@ -33,7 +33,7 @@ export const generatePartner: GenerateUtil<SpotifyNs.Partner> = (partner) => {
 }
 
 export const generateSandbox: GenerateUtil<SpotifyNs.Sandbox> = (sandbox) => {
-  if (!isObject(sandbox)) {
+  if (!isPlainObject(sandbox)) {
     return
   }
 
@@ -43,7 +43,7 @@ export const generateSandbox: GenerateUtil<SpotifyNs.Sandbox> = (sandbox) => {
 }
 
 export const generateFeedAccess: GenerateUtil<SpotifyNs.FeedAccess> = (access) => {
-  if (!isObject(access)) {
+  if (!isPlainObject(access)) {
     return
   }
 
@@ -56,7 +56,7 @@ export const generateFeedAccess: GenerateUtil<SpotifyNs.FeedAccess> = (access) =
 }
 
 export const generateEntitlement: GenerateUtil<SpotifyNs.Entitlement> = (entitlement) => {
-  if (!isObject(entitlement)) {
+  if (!isPlainObject(entitlement)) {
     return
   }
 
@@ -68,7 +68,7 @@ export const generateEntitlement: GenerateUtil<SpotifyNs.Entitlement> = (entitle
 }
 
 export const generateItemAccess: GenerateUtil<SpotifyNs.ItemAccess> = (access) => {
-  if (!isObject(access)) {
+  if (!isPlainObject(access)) {
     return
   }
 
@@ -80,7 +80,7 @@ export const generateItemAccess: GenerateUtil<SpotifyNs.ItemAccess> = (access) =
 }
 
 export const generateFeed: GenerateUtil<SpotifyNs.Feed> = (feed) => {
-  if (!isObject(feed)) {
+  if (!isPlainObject(feed)) {
     return
   }
 
@@ -94,7 +94,7 @@ export const generateFeed: GenerateUtil<SpotifyNs.Feed> = (feed) => {
 }
 
 export const generateItem: GenerateUtil<SpotifyNs.Item> = (item) => {
-  if (!isObject(item)) {
+  if (!isPlainObject(item)) {
     return
   }
 

--- a/src/namespaces/spotify/parse/utils.ts
+++ b/src/namespaces/spotify/parse/utils.ts
@@ -1,6 +1,6 @@
+import { isPlainObject } from 'trousse'
 import type { ParseUtilPartial } from '../../../common/types.js'
 import {
-  isObject,
   parseBoolean,
   parseNumber,
   parseSingularOf,
@@ -11,7 +11,7 @@ import {
 import type { SpotifyNs } from '../common/types.js'
 
 export const parseLimit: ParseUtilPartial<SpotifyNs.Limit> = (value) => {
-  if (!isObject(value)) {
+  if (!isPlainObject(value)) {
     return
   }
 
@@ -23,7 +23,7 @@ export const parseLimit: ParseUtilPartial<SpotifyNs.Limit> = (value) => {
 }
 
 export const parsePartner: ParseUtilPartial<SpotifyNs.Partner> = (value) => {
-  if (!isObject(value)) {
+  if (!isPlainObject(value)) {
     return
   }
 
@@ -33,7 +33,7 @@ export const parsePartner: ParseUtilPartial<SpotifyNs.Partner> = (value) => {
 }
 
 export const parseSandbox: ParseUtilPartial<SpotifyNs.Sandbox> = (value) => {
-  if (!isObject(value)) {
+  if (!isPlainObject(value)) {
     return
   }
 
@@ -43,7 +43,7 @@ export const parseSandbox: ParseUtilPartial<SpotifyNs.Sandbox> = (value) => {
 }
 
 export const parseFeedAccess: ParseUtilPartial<SpotifyNs.FeedAccess> = (value) => {
-  if (!isObject(value)) {
+  if (!isPlainObject(value)) {
     return
   }
 
@@ -56,7 +56,7 @@ export const parseFeedAccess: ParseUtilPartial<SpotifyNs.FeedAccess> = (value) =
 }
 
 export const parseEntitlement: ParseUtilPartial<SpotifyNs.Entitlement> = (value) => {
-  if (!isObject(value)) {
+  if (!isPlainObject(value)) {
     return
   }
 
@@ -66,7 +66,7 @@ export const parseEntitlement: ParseUtilPartial<SpotifyNs.Entitlement> = (value)
 }
 
 export const parseItemAccess: ParseUtilPartial<SpotifyNs.ItemAccess> = (value) => {
-  if (!isObject(value)) {
+  if (!isPlainObject(value)) {
     return
   }
 
@@ -78,7 +78,7 @@ export const parseItemAccess: ParseUtilPartial<SpotifyNs.ItemAccess> = (value) =
 }
 
 export const retrieveFeed: ParseUtilPartial<SpotifyNs.Feed> = (value) => {
-  if (!isObject(value)) {
+  if (!isPlainObject(value)) {
     return
   }
 
@@ -94,7 +94,7 @@ export const retrieveFeed: ParseUtilPartial<SpotifyNs.Feed> = (value) => {
 }
 
 export const retrieveItem: ParseUtilPartial<SpotifyNs.Item> = (value) => {
-  if (!isObject(value)) {
+  if (!isPlainObject(value)) {
     return
   }
 

--- a/src/namespaces/sy/generate/utils.ts
+++ b/src/namespaces/sy/generate/utils.ts
@@ -1,15 +1,15 @@
+import { isPlainObject } from 'trousse'
 import type { DateLike, GenerateUtil } from '../../../common/types.js'
 import {
   generateCdataString,
   generateNumber,
   generateRfc3339Date,
-  isObject,
   trimObject,
 } from '../../../common/utils.js'
 import type { SyNs } from '../common/types.js'
 
 export const generateFeed: GenerateUtil<SyNs.Feed<DateLike>> = (feed) => {
-  if (!isObject(feed)) {
+  if (!isPlainObject(feed)) {
     return
   }
 

--- a/src/namespaces/sy/parse/utils.ts
+++ b/src/namespaces/sy/parse/utils.ts
@@ -1,6 +1,6 @@
+import { isPlainObject } from 'trousse'
 import type { DateAny, ParseMainOptions, ParseUtilPartial } from '../../../common/types.js'
 import {
-  isObject,
   parseDate,
   parseNumber,
   parseSingularOf,
@@ -14,7 +14,7 @@ export const retrieveFeed: ParseUtilPartial<SyNs.Feed<DateAny>, ParseMainOptions
   value,
   options,
 ) => {
-  if (!isObject(value)) {
+  if (!isPlainObject(value)) {
     return
   }
 

--- a/src/namespaces/thr/generate/utils.ts
+++ b/src/namespaces/thr/generate/utils.ts
@@ -1,16 +1,16 @@
+import { isPlainObject } from 'trousse'
 import type { DateLike, GenerateUtil } from '../../../common/types.js'
 import {
   generateNumber,
   generatePlainString,
   generateRfc3339Date,
-  isObject,
   trimArray,
   trimObject,
 } from '../../../common/utils.js'
 import type { ThrNs } from '../common/types.js'
 
 export const generateInReplyTo: GenerateUtil<ThrNs.InReplyTo> = (inReplyTo) => {
-  if (!isObject(inReplyTo)) {
+  if (!isPlainObject(inReplyTo)) {
     return
   }
 
@@ -25,7 +25,7 @@ export const generateInReplyTo: GenerateUtil<ThrNs.InReplyTo> = (inReplyTo) => {
 }
 
 export const generateLink: GenerateUtil<ThrNs.Link<DateLike>> = (link) => {
-  if (!isObject(link)) {
+  if (!isPlainObject(link)) {
     return
   }
 
@@ -38,7 +38,7 @@ export const generateLink: GenerateUtil<ThrNs.Link<DateLike>> = (link) => {
 }
 
 export const generateItem: GenerateUtil<ThrNs.Item> = (item) => {
-  if (!isObject(item)) {
+  if (!isPlainObject(item)) {
     return
   }
 

--- a/src/namespaces/thr/parse/utils.ts
+++ b/src/namespaces/thr/parse/utils.ts
@@ -1,6 +1,6 @@
+import { isPlainObject } from 'trousse'
 import type { DateAny, ParseMainOptions, ParseUtilPartial } from '../../../common/types.js'
 import {
-  isObject,
   parseArrayOf,
   parseDate,
   parseNumber,
@@ -12,7 +12,7 @@ import {
 import type { ThrNs } from '../common/types.js'
 
 export const parseInReplyTo: ParseUtilPartial<ThrNs.InReplyTo> = (value) => {
-  if (!isObject(value)) {
+  if (!isPlainObject(value)) {
     return
   }
 
@@ -30,7 +30,7 @@ export const retrieveLink: ParseUtilPartial<ThrNs.Link<DateAny>, ParseMainOption
   value,
   options,
 ) => {
-  if (!isObject(value)) {
+  if (!isPlainObject(value)) {
     return
   }
 
@@ -43,7 +43,7 @@ export const retrieveLink: ParseUtilPartial<ThrNs.Link<DateAny>, ParseMainOption
 }
 
 export const retrieveItem: ParseUtilPartial<ThrNs.Item> = (value) => {
-  if (!isObject(value)) {
+  if (!isPlainObject(value)) {
     return
   }
 

--- a/src/namespaces/trackback/generate/utils.ts
+++ b/src/namespaces/trackback/generate/utils.ts
@@ -1,9 +1,10 @@
+import { isPlainObject } from 'trousse'
 import type { GenerateUtil } from '../../../common/types.js'
-import { generateCdataString, isObject, trimArray, trimObject } from '../../../common/utils.js'
+import { generateCdataString, trimArray, trimObject } from '../../../common/utils.js'
 import type { TrackbackNs } from '../common/types.js'
 
 export const generateItem: GenerateUtil<TrackbackNs.Item> = (item) => {
-  if (!isObject(item)) {
+  if (!isPlainObject(item)) {
     return
   }
 

--- a/src/namespaces/trackback/parse/utils.ts
+++ b/src/namespaces/trackback/parse/utils.ts
@@ -1,6 +1,6 @@
+import { isPlainObject } from 'trousse'
 import type { ParseUtilPartial } from '../../../common/types.js'
 import {
-  isObject,
   parseArrayOf,
   parseSingularOf,
   parseString,
@@ -10,7 +10,7 @@ import {
 import type { TrackbackNs } from '../common/types.js'
 
 export const retrieveItem: ParseUtilPartial<TrackbackNs.Item> = (value) => {
-  if (!isObject(value)) {
+  if (!isPlainObject(value)) {
     return
   }
 

--- a/src/namespaces/wfw/generate/utils.ts
+++ b/src/namespaces/wfw/generate/utils.ts
@@ -1,9 +1,10 @@
+import { isPlainObject } from 'trousse'
 import type { GenerateUtil } from '../../../common/types.js'
-import { generateCdataString, isObject, trimObject } from '../../../common/utils.js'
+import { generateCdataString, trimObject } from '../../../common/utils.js'
 import type { WfwNs } from '../common/types.js'
 
 export const generateItem: GenerateUtil<WfwNs.Item> = (item) => {
-  if (!isObject(item)) {
+  if (!isPlainObject(item)) {
     return
   }
 

--- a/src/namespaces/wfw/parse/utils.ts
+++ b/src/namespaces/wfw/parse/utils.ts
@@ -1,15 +1,10 @@
+import { isPlainObject } from 'trousse'
 import type { ParseUtilPartial } from '../../../common/types.js'
-import {
-  isObject,
-  parseSingularOf,
-  parseString,
-  retrieveText,
-  trimObject,
-} from '../../../common/utils.js'
+import { parseSingularOf, parseString, retrieveText, trimObject } from '../../../common/utils.js'
 import type { WfwNs } from '../common/types.js'
 
 export const retrieveItem: ParseUtilPartial<WfwNs.Item> = (value) => {
-  if (!isObject(value)) {
+  if (!isPlainObject(value)) {
     return
   }
 

--- a/src/namespaces/xml/generate/utils.ts
+++ b/src/namespaces/xml/generate/utils.ts
@@ -1,9 +1,10 @@
+import { isPlainObject } from 'trousse'
 import type { GenerateUtil } from '../../../common/types.js'
-import { generatePlainString, isObject, trimObject } from '../../../common/utils.js'
+import { generatePlainString, trimObject } from '../../../common/utils.js'
 import type { XmlNs } from '../common/types.js'
 
 export const generateItemOrFeed: GenerateUtil<XmlNs.ItemOrFeed> = (itemOrFeed) => {
-  if (!isObject(itemOrFeed)) {
+  if (!isPlainObject(itemOrFeed)) {
     return
   }
 

--- a/src/namespaces/xml/parse/utils.ts
+++ b/src/namespaces/xml/parse/utils.ts
@@ -1,9 +1,10 @@
+import { isPlainObject } from 'trousse'
 import type { ParseUtilPartial } from '../../../common/types.js'
-import { isObject, parseString, trimObject } from '../../../common/utils.js'
+import { parseString, trimObject } from '../../../common/utils.js'
 import type { XmlNs } from '../common/types.js'
 
 export const retrieveItemOrFeed: ParseUtilPartial<XmlNs.ItemOrFeed> = (value) => {
-  if (!isObject(value)) {
+  if (!isPlainObject(value)) {
     return
   }
 

--- a/src/namespaces/yt/generate/utils.ts
+++ b/src/namespaces/yt/generate/utils.ts
@@ -1,9 +1,10 @@
+import { isPlainObject } from 'trousse'
 import type { GenerateUtil } from '../../../common/types.js'
-import { generateCdataString, isObject, trimObject } from '../../../common/utils.js'
+import { generateCdataString, trimObject } from '../../../common/utils.js'
 import type { YtNs } from '../common/types.js'
 
 export const generateItem: GenerateUtil<YtNs.Item> = (item) => {
-  if (!isObject(item)) {
+  if (!isPlainObject(item)) {
     return
   }
 
@@ -16,7 +17,7 @@ export const generateItem: GenerateUtil<YtNs.Item> = (item) => {
 }
 
 export const generateFeed: GenerateUtil<YtNs.Feed> = (feed) => {
-  if (!isObject(feed)) {
+  if (!isPlainObject(feed)) {
     return
   }
 

--- a/src/namespaces/yt/parse/utils.ts
+++ b/src/namespaces/yt/parse/utils.ts
@@ -1,15 +1,10 @@
+import { isPlainObject } from 'trousse'
 import type { ParseUtilPartial } from '../../../common/types.js'
-import {
-  isObject,
-  parseSingularOf,
-  parseString,
-  retrieveText,
-  trimObject,
-} from '../../../common/utils.js'
+import { parseSingularOf, parseString, retrieveText, trimObject } from '../../../common/utils.js'
 import type { YtNs } from '../common/types.js'
 
 export const retrieveItem: ParseUtilPartial<YtNs.Item> = (value) => {
-  if (!isObject(value)) {
+  if (!isPlainObject(value)) {
     return
   }
 
@@ -22,7 +17,7 @@ export const retrieveItem: ParseUtilPartial<YtNs.Item> = (value) => {
 }
 
 export const retrieveFeed: ParseUtilPartial<YtNs.Feed> = (value) => {
-  if (!isObject(value)) {
+  if (!isPlainObject(value)) {
     return
   }
 

--- a/src/opml/generate/utils.ts
+++ b/src/opml/generate/utils.ts
@@ -1,3 +1,4 @@
+import { isPresent } from 'trousse'
 import type { DateLike } from '../../common/types.js'
 import {
   generateBoolean,
@@ -7,7 +8,6 @@ import {
   generatePlainString,
   generateRfc822Date,
   isObject,
-  isPresent,
   trimArray,
   trimObject,
 } from '../../common/utils.js'

--- a/src/opml/generate/utils.ts
+++ b/src/opml/generate/utils.ts
@@ -1,4 +1,4 @@
-import { isPresent } from 'trousse'
+import { isPlainObject, isPresent } from 'trousse'
 import type { DateLike } from '../../common/types.js'
 import {
   generateBoolean,
@@ -7,14 +7,13 @@ import {
   generateNumber,
   generatePlainString,
   generateRfc822Date,
-  isObject,
   trimArray,
   trimObject,
 } from '../../common/utils.js'
 import type { GenerateUtil, Opml } from '../common/types.js'
 
 export const generateOutline: GenerateUtil<Opml.Outline<DateLike>> = (outline, options) => {
-  if (!isObject(outline)) {
+  if (!isPlainObject(outline)) {
     return
   }
 
@@ -51,7 +50,7 @@ export const generateOutline: GenerateUtil<Opml.Outline<DateLike>> = (outline, o
 }
 
 export const generateHead: GenerateUtil<Opml.Head<DateLike>> = (head) => {
-  if (!isObject(head)) {
+  if (!isPlainObject(head)) {
     return
   }
 
@@ -75,7 +74,7 @@ export const generateHead: GenerateUtil<Opml.Head<DateLike>> = (head) => {
 }
 
 export const generateBody: GenerateUtil<Opml.Body<DateLike>> = (body, options) => {
-  if (!isObject(body)) {
+  if (!isPlainObject(body)) {
     return
   }
 
@@ -87,7 +86,7 @@ export const generateBody: GenerateUtil<Opml.Body<DateLike>> = (body, options) =
 }
 
 export const generateDocument: GenerateUtil<Opml.Document<DateLike>> = (opml, options) => {
-  if (!isObject(opml)) {
+  if (!isPlainObject(opml)) {
     return
   }
 

--- a/src/opml/parse/utils.ts
+++ b/src/opml/parse/utils.ts
@@ -1,7 +1,6 @@
-import { isPresent } from 'trousse'
+import { isPlainObject, isPresent } from 'trousse'
 import type { DateAny } from '../../common/types.js'
 import {
-  isObject,
   parseArrayOf,
   parseBoolean,
   parseCsvOf,
@@ -15,7 +14,7 @@ import {
 import type { Opml, ParseUtilPartial } from '../common/types.js'
 
 export const parseOutline: ParseUtilPartial<Opml.Outline<DateAny>> = (value, options) => {
-  if (!isObject(value)) {
+  if (!isPlainObject(value)) {
     return
   }
 
@@ -52,7 +51,7 @@ export const parseOutline: ParseUtilPartial<Opml.Outline<DateAny>> = (value, opt
 }
 
 export const parseHead: ParseUtilPartial<Opml.Head<DateAny>> = (value, options) => {
-  if (!isObject(value)) {
+  if (!isPlainObject(value)) {
     return
   }
 
@@ -84,7 +83,7 @@ export const parseHead: ParseUtilPartial<Opml.Head<DateAny>> = (value, options) 
 }
 
 export const parseBody: ParseUtilPartial<Opml.Body<DateAny>> = (value, options) => {
-  if (!isObject(value)) {
+  if (!isPlainObject(value)) {
     return
   }
 
@@ -100,7 +99,7 @@ export const parseBody: ParseUtilPartial<Opml.Body<DateAny>> = (value, options) 
 }
 
 export const parseDocument: ParseUtilPartial<Opml.Document<DateAny>> = (value, options) => {
-  if (!isObject(value?.opml)) {
+  if (!isPlainObject(value?.opml)) {
     return
   }
 

--- a/src/opml/parse/utils.ts
+++ b/src/opml/parse/utils.ts
@@ -1,7 +1,7 @@
+import { isPresent } from 'trousse'
 import type { DateAny } from '../../common/types.js'
 import {
   isObject,
-  isPresent,
   parseArrayOf,
   parseBoolean,
   parseCsvOf,


### PR DESCRIPTION
Adopts the shared [trousse](https://github.com/macieklamberski/trousse) toolbox, bundled at build time as a dev dependency (no runtime dependency; both the ESM and CJS builds embed tree-shaken `is`/`coercions` modules under `dist/node_modules/trousse/`, verified loadable via `require` and `import`).

- `isPresent`, `isNonEmptyString`, and `isObject` removed from `common/utils.ts`; importing files pull from trousse directly, with `isObject` call sites renamed to `isPlainObject` (identical strict semantics, trousse's strict variant is feedsmith's implementation).
- `parseNumber`, `parseBoolean`, and `parseSingular` keep their names and signatures but delegate to trousse (`coerceNumber`, `coerceBoolean`, `coerceSingular`), their call sites untouched.
- `isNonEmptyStringOrNumber` reimplemented as `isNumber(value) || isNonEmptyString(value)`.
- A few `as Unreliable` casts restore the any-flow where trousse's `unknown` narrowing is stricter than the parse pipeline's typing (`normalizeNamespaceUri` attribute reads, RDF channel access): statically equivalent to the old `Record<string, Unreliable>` narrowing, runtime-identical.
- One behavior edge via delegation: `parseNumber(NaN)` now returns `undefined` instead of passing `NaN` through.
- Nothing public changes: none of these helpers were exported from the package.