### PR TITLE
docs: Fix broken namespace specification links

### DIFF
--- a/docs/reference/namespaces/blogchannel.md
+++ b/docs/reference/namespaces/blogchannel.md
@@ -14,7 +14,7 @@ The blogChannel namespace is an RSS 2.0 module for weblogging applications, prov
     </tr>
     <tr>
       <th>Specification</th>
-      <td><a href="http://backend.userland.com/blogChannelModule" target="_blank">blogChannel RSS Module</a></td>
+      <td><a href="https://web.archive.org/web/20240625022241/http://backend.userland.com/blogChannelModule" target="_blank">blogChannel RSS Module</a> (archive)</td>
     </tr>
     <tr>
       <th>Prefix</th>

--- a/docs/reference/namespaces/creativecommons.md
+++ b/docs/reference/namespaces/creativecommons.md
@@ -14,7 +14,7 @@ The Creative Commons namespace provides elements for specifying the license unde
     </tr>
     <tr>
       <th>Specification</th>
-      <td><a href="http://cyber.law.harvard.edu/rss/creativeCommonsRssModule.html" target="_blank">Creative Commons RSS Module Specification</a></td>
+      <td><a href="https://www.rssboard.org/creative-commons" target="_blank">Creative Commons RSS Module Specification</a></td>
     </tr>
     <tr>
       <th>Prefix</th>

--- a/docs/reference/namespaces/georss.md
+++ b/docs/reference/namespaces/georss.md
@@ -14,7 +14,7 @@ The GeoRSS Simple namespace enables geographic tagging of RSS feeds and items, a
     </tr>
     <tr>
       <th>Specification</th>
-      <td><a href="http://www.georss.org/georss" target="_blank">GeoRSS Specification</a></td>
+      <td><a href="https://docs.ogc.org/cs/17-002r1/17-002r1.html" target="_blank">OGC GeoRSS Encoding Standard</a></td>
     </tr>
     <tr>
       <th>Prefix</th>

--- a/docs/reference/namespaces/pingback.md
+++ b/docs/reference/namespaces/pingback.md
@@ -14,7 +14,7 @@ The Pingback namespace provides a mechanism for notifying websites when content 
     </tr>
     <tr>
       <th>Specification</th>
-      <td>Pingback RSS Module (madskills.com)</td>
+      <td><a href="https://web.archive.org/web/20040207104933/http://madskills.com/public/xml/rss/module/pingback/" target="_blank">Pingback RSS Module</a> (archive)</td>
     </tr>
     <tr>
       <th>Prefix</th>

--- a/docs/reference/namespaces/slash.md
+++ b/docs/reference/namespaces/slash.md
@@ -14,7 +14,7 @@ The Slash namespace provides metadata about user engagement, particularly commen
     </tr>
     <tr>
       <th>Specification</th>
-      <td><a href="http://purl.org/rss/1.0/modules/slash/" target="_blank">Slash Module</a></td>
+      <td><a href="https://web.resource.org/rss/1.0/modules/slash/" target="_blank">Slash Module</a></td>
     </tr>
     <tr>
       <th>Prefix</th>

--- a/docs/reference/namespaces/wfw.md
+++ b/docs/reference/namespaces/wfw.md
@@ -14,7 +14,7 @@ The Comment API namespace provides elements for linking to comment feeds and com
     </tr>
     <tr>
       <th>Specification</th>
-      <td><a href="http://wellformedweb.org/CommentAPI/" target="_blank">Well Formed Web Comment API</a></td>
+      <td><a href="https://www.rssboard.org/comment-api" target="_blank">Comment API Namespace for RSS</a></td>
     </tr>
     <tr>
       <th>Prefix</th>


### PR DESCRIPTION
Fixes #305.

Several namespace **Specification** links in the docs had rotted: some domains are now dead, parked, or serving malicious/gambling content. Each doc's **Namespace URI** (the XML identifier used verbatim in real feeds) is left untouched; only the human-readable Specification hyperlink is updated.

| Namespace | Old link | New link | Reason |
|-----------|----------|----------|--------|
| `georss` | `georss.org/georss` | [OGC GeoRSS Encoding Standard](https://docs.ogc.org/cs/17-002r1/17-002r1.html) | Original flagged malicious; OGC adopted the georss.org content as an official standard (direct copy) |
| `wfw` | `wellformedweb.org/CommentAPI/` | [Comment API Namespace for RSS](https://www.rssboard.org/comment-api) | Original now a gambling site; RSS Advisory Board hosts the current reference |
| `creativecommons` | `cyber.law.harvard.edu/...` | [Creative Commons RSS Module](https://www.rssboard.org/creative-commons) | Harvard page dead; RSS Advisory Board hosts the current version |
| `slash` | `purl.org/rss/1.0/modules/slash/` | [Slash Module](https://web.resource.org/rss/1.0/modules/slash/) | purl.org relocated and dropped this entry (now 404); points directly at the original host |
| `pingback` | plain text (madskills.com dead) | [Wayback snapshot](https://web.archive.org/web/20040207104933/http://madskills.com/public/xml/rss/module/pingback/) `(archive)` | No live successor exists |
| `blogchannel` | `backend.userland.com/blogChannelModule` | [Wayback snapshot](https://web.archive.org/web/20240625022241/http://backend.userland.com/blogChannelModule) `(archive)` | Server dead; no live successor |

`georss` and `slash` point at the official/moved docs; `wfw` and `creativecommons` use the RSS Advisory Board's maintained restatements (originals are gone); `pingback` and `blogchannel` fall back to the Wayback Machine and are labelled `(archive)`.

Links reported in the issue but verified still working (no change): `prism` and `trackback`: the dead `prismstandard.org` / `madskills.com` domains there are only the Namespace URI identifiers, not the Specification links.