### PR TITLE
chore: Bump golang.org/x/net to 0.55.0 in cross-language benchmark

### DIFF
--- a/benchmarks/cross-language/go.mod
+++ b/benchmarks/cross-language/go.mod
@@ -1,6 +1,6 @@
 module parsing
 
-go 1.24.0
+go 1.25.0
 
 require github.com/mmcdole/gofeed v1.3.0
 
@@ -11,6 +11,6 @@ require (
 	github.com/mmcdole/goxpp v1.1.1 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
-	golang.org/x/net v0.46.0 // indirect
-	golang.org/x/text v0.30.0 // indirect
+	golang.org/x/net v0.55.0 // indirect
+	golang.org/x/text v0.37.0 // indirect
 )


### PR DESCRIPTION
Resolves Dependabot alert [GHSA-5cv4-jp36-h3mw](https://github.com/macieklamberski/feedsmith/security/dependabot/12) (CVE-2026-25680): a medium-severity DoS in Go's HTML parser.

Bumps `golang.org/x/net` `0.46.0` → `0.55.0` in `benchmarks/cross-language/go.mod`. It's an indirect dependency of the Go benchmark harness (via `mmcdole/gofeed`), not part of the shipped npm package, so there is no runtime impact on library consumers. `go mod tidy` also pulled `x/text` to `0.37.0` and raised the `go` directive to `1.25.0` (required by the new x/net). `go build ./...` passes.