### PR TITLE
feat: Add LiveJournal namespace support

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ Feedsmith aims to fully support all major feed formats and namespaces in complet
 | [YouTube](https://feedsmith.dev/reference/namespaces/yt) | `<yt:*>` | Atom | ✅ | ✅ |
 | [W3C Basic Geo](https://feedsmith.dev/reference/namespaces/geo) | `<geo:*>` | RSS, Atom | ✅ | ✅ |
 | [GeoRSS Simple](https://feedsmith.dev/reference/namespaces/georss) | `<georss:*>` | RSS, Atom, RDF | ✅ | ✅ |
+| [LiveJournal](https://feedsmith.dev/reference/namespaces/livejournal) | `<lj:*>` | RSS | ✅ | ✅ |
 | [RDF](https://feedsmith.dev/reference/namespaces/rdf) | `<rdf:*>` | RDF | ✅ | ✅ |
 | [XML](https://feedsmith.dev/reference/namespaces/xml) | `<xml:*>` | RSS, Atom, RDF | ✅ | ✅ |
 

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -141,6 +141,7 @@ export default defineConfig({
               { text: 'YouTube', link: '/reference/namespaces/yt' },
               { text: 'W3C Basic Geo', link: '/reference/namespaces/geo' },
               { text: 'GeoRSS Simple', link: '/reference/namespaces/georss' },
+              { text: 'LiveJournal', link: '/reference/namespaces/livejournal' },
               { text: 'RDF', link: '/reference/namespaces/rdf' },
               { text: 'XML', link: '/reference/namespaces/xml' },
             ],

--- a/docs/index.md
+++ b/docs/index.md
@@ -93,6 +93,7 @@ Feedsmith aims to fully support all major feed formats and namespaces in complet
 | [YouTube](/reference/namespaces/yt) | `<yt:*>` | Atom | ✅ | ✅ |
 | [W3C Basic Geo](/reference/namespaces/geo) | `<geo:*>` | RSS, Atom | ✅ | ✅ |
 | [GeoRSS Simple](/reference/namespaces/georss) | `<georss:*>` | RSS, Atom, RDF | ✅ | ✅ |
+| [LiveJournal](/reference/namespaces/livejournal) | `<lj:*>` | RSS | ✅ | ✅ |
 | [RDF](/reference/namespaces/rdf) | `<rdf:*>` | RDF | ✅ | ✅ |
 
 ## Why Feedsmith?

--- a/docs/reference/namespaces/livejournal.md
+++ b/docs/reference/namespaces/livejournal.md
@@ -1,0 +1,40 @@
+---
+title: "Reference: LiveJournal Namespace"
+---
+
+# LiveJournal Namespace
+
+The LiveJournal namespace adds journal-specific metadata to RSS feed items, such as the author's current mood and music, the entry's security level, the posting user, and the originating journal. LiveJournal (and compatible platforms like Dreamwidth and Scribbld) emit these elements on each item of a syndicated journal feed.
+
+<table>
+  <tbody>
+    <tr>
+      <th>Namespace URI</th>
+      <td><code>http://www.livejournal.org/rss/lj/1.0/</code></td>
+    </tr>
+    <tr>
+      <th>Specification</th>
+      <td><a href="https://www.livejournal.com/support/faq/149.html" target="_blank">LiveJournal Syndication FAQ</a></td>
+    </tr>
+    <tr>
+      <th>Prefix</th>
+      <td><code>&lt;lj:*&gt;</code></td>
+    </tr>
+    <tr>
+      <th>Available in</th>
+      <td><a href="/reference/feeds/rss">RSS</a></td>
+    </tr>
+    <tr>
+      <th>Property</th>
+      <td><code>livejournal</code></td>
+    </tr>
+  </tbody>
+</table>
+
+## Types
+
+<<< @/../src/namespaces/livejournal/common/types.ts#reference
+
+## Related
+
+- **[Parsing Namespaces](/parsing/namespaces)** - How namespace parsing works

--- a/src/common/config.ts
+++ b/src/common/config.ts
@@ -49,6 +49,10 @@ import {
   uris as itunesUris,
 } from '../namespaces/itunes/common/config.js'
 import {
+  stopNodes as livejournalStopNodes,
+  uris as livejournalUris,
+} from '../namespaces/livejournal/common/config.js'
+import {
   stopNodes as mediaStopNodes,
   uris as mediaUris,
 } from '../namespaces/media/common/config.js'
@@ -166,6 +170,7 @@ export const namespaceUris = {
   trackback: trackbackUris,
   prism: prismUris,
   acast: acastUris,
+  lj: livejournalUris,
 }
 
 export const namespacePrefixes = Object.entries(namespaceUris).reduce(
@@ -196,6 +201,7 @@ export const namespaceStopNodes = [
   ...georssStopNodes,
   ...googleplayStopNodes,
   ...itunesStopNodes,
+  ...livejournalStopNodes,
   ...mediaStopNodes,
   ...opensearchStopNodes,
   ...pingbackStopNodes,

--- a/src/feeds/rss/common/types.ts
+++ b/src/feeds/rss/common/types.ts
@@ -20,6 +20,7 @@ import type { GeoNs } from '../../../namespaces/geo/common/types.js'
 import type { GeoRssNs } from '../../../namespaces/georss/common/types.js'
 import type { GooglePlayNs } from '../../../namespaces/googleplay/common/types.js'
 import type { ItunesNs } from '../../../namespaces/itunes/common/types.js'
+import type { LivejournalNs } from '../../../namespaces/livejournal/common/types.js'
 import type { MediaNs } from '../../../namespaces/media/common/types.js'
 import type { OpenSearchNs } from '../../../namespaces/opensearch/common/types.js'
 import type { PingbackNs } from '../../../namespaces/pingback/common/types.js'
@@ -155,6 +156,7 @@ export namespace RssFeed {
       pingback?: PingbackNs.Item
       trackback?: TrackbackNs.Item
       acast?: AcastNs.Item
+      livejournal?: LivejournalNs.Item
       xml?: XmlNs.ItemOrFeed
     },
     TStrict

--- a/src/feeds/rss/generate/index.test.ts
+++ b/src/feeds/rss/generate/index.test.ts
@@ -1536,6 +1536,45 @@ describe('generate', () => {
       expect(generate(value)).toEqual(expected)
     })
 
+    it('should generate RSS with livejournal namespace', () => {
+      const value = {
+        title: 'Feed with livejournal namespace',
+        description: 'Test feed with LiveJournal namespace',
+        items: [
+          {
+            title: 'Journal entry',
+            livejournal: {
+              music: 'The Beatles - Hey Jude',
+              mood: 'cheerful',
+              security: 'public',
+              poster: 'johndoe',
+              journal: 'example_community',
+              replyCount: 42,
+            },
+          },
+        ],
+      }
+      const expected = `<?xml version="1.0" encoding="utf-8"?>
+<rss version="2.0" xmlns:lj="http://www.livejournal.org/rss/lj/1.0/">
+  <channel>
+    <title>Feed with livejournal namespace</title>
+    <description>Test feed with LiveJournal namespace</description>
+    <item>
+      <title>Journal entry</title>
+      <lj:music>The Beatles - Hey Jude</lj:music>
+      <lj:mood>cheerful</lj:mood>
+      <lj:security>public</lj:security>
+      <lj:poster>johndoe</lj:poster>
+      <lj:journal>example_community</lj:journal>
+      <lj:replycount>42</lj:replycount>
+    </item>
+  </channel>
+</rss>
+`
+
+      expect(generate(value)).toEqual(expected)
+    })
+
     it('should generate RSS with xml namespace', () => {
       const value = {
         title: 'Feed with xml namespace',

--- a/src/feeds/rss/generate/utils.test.ts
+++ b/src/feeds/rss/generate/utils.test.ts
@@ -1823,6 +1823,49 @@ describe('generateFeed', () => {
     expect(generateFeed(value)).toEqual(expected)
   })
 
+  it('should generate livejournal namespace properties for item', () => {
+    const value = {
+      title: 'Feed with LiveJournal items',
+      description: 'A feed with LiveJournal item properties',
+      items: [
+        {
+          title: 'Journal entry',
+          livejournal: {
+            music: 'The Beatles - Hey Jude',
+            mood: 'cheerful',
+            security: 'public',
+            poster: 'johndoe',
+            journal: 'example_community',
+            replyCount: 42,
+          },
+        },
+      ],
+    }
+    const expected = {
+      rss: {
+        '@version': '2.0',
+        '@xmlns:lj': 'http://www.livejournal.org/rss/lj/1.0/',
+        channel: {
+          title: 'Feed with LiveJournal items',
+          description: 'A feed with LiveJournal item properties',
+          item: [
+            {
+              title: 'Journal entry',
+              'lj:music': 'The Beatles - Hey Jude',
+              'lj:mood': 'cheerful',
+              'lj:security': 'public',
+              'lj:poster': 'johndoe',
+              'lj:journal': 'example_community',
+              'lj:replycount': 42,
+            },
+          ],
+        },
+      },
+    }
+
+    expect(generateFeed(value)).toEqual(expected)
+  })
+
   it('should generate RSS feed with feedpress namespace properties', () => {
     const value = {
       title: 'Podcast Feed',

--- a/src/feeds/rss/generate/utils.ts
+++ b/src/feeds/rss/generate/utils.ts
@@ -38,6 +38,7 @@ import {
   generateFeed as generateItunesFeed,
   generateItem as generateItunesItem,
 } from '../../../namespaces/itunes/generate/utils.js'
+import { generateItem as generateLivejournalItem } from '../../../namespaces/livejournal/generate/utils.js'
 import { generateItemOrFeed as generateMediaItemOrFeed } from '../../../namespaces/media/generate/utils.js'
 import { generateFeed as generateOpenSearchFeed } from '../../../namespaces/opensearch/generate/utils.js'
 import {
@@ -247,6 +248,7 @@ export const generateItem: GenerateUtil<RssFeed.Item<DateLike>> = (item) => {
     ...generatePingbackItem(item.pingback),
     ...generateTrackbackItem(item.trackback),
     ...generateAcastItem(item.acast),
+    ...generateLivejournalItem(item.livejournal),
     ...generateXmlItemOrFeed(item.xml),
   }
 

--- a/src/feeds/rss/parse/utils.ts
+++ b/src/feeds/rss/parse/utils.ts
@@ -39,6 +39,7 @@ import {
   retrieveFeed as retrieveItunesFeed,
   retrieveItem as retrieveItunesItem,
 } from '../../../namespaces/itunes/parse/utils.js'
+import { retrieveItem as retrieveLivejournalItem } from '../../../namespaces/livejournal/parse/utils.js'
 import { retrieveItemOrFeed as retrieveMediaItemOrFeed } from '../../../namespaces/media/parse/utils.js'
 import { retrieveFeed as retrieveOpenSearchFeed } from '../../../namespaces/opensearch/parse/utils.js'
 import {
@@ -417,6 +418,7 @@ export const parseItem: ParseUtilPartial<RssFeed.Item<DateAny>> = (value, option
     pingback: namespaces.has('pingback') ? retrievePingbackItem(value) : undefined,
     trackback: namespaces.has('trackback') ? retrieveTrackbackItem(value) : undefined,
     acast: namespaces.has('acast') ? retrieveAcastItem(value) : undefined,
+    livejournal: namespaces.has('lj') ? retrieveLivejournalItem(value) : undefined,
     xml: retrieveXmlItemOrFeed(value),
   }
 

--- a/src/feeds/rss/references/rss-ns.json
+++ b/src/feeds/rss/references/rss-ns.json
@@ -895,6 +895,17 @@
         "episodeUrl": "example-episode-title",
         "settings": "RXBpc29kZVNldHRpbmdzQmFzZTY0RW5jb2RlZA=="
       },
+      "livejournal": {
+        "music": "The Beatles - Hey Jude",
+        "mood": "cheerful",
+        "security": "public",
+        "poster": "johndoe",
+        "posterId": "12345",
+        "journal": "example_community",
+        "journalId": "67890",
+        "journalType": "C",
+        "replyCount": 42
+      },
       "xml": {
         "lang": "en-US",
         "base": "http://example.org/item/1/"

--- a/src/feeds/rss/references/rss-ns.xml
+++ b/src/feeds/rss/references/rss-ns.xml
@@ -32,6 +32,7 @@
      xmlns:geo="http://www.w3.org/2003/01/geo/wgs84_pos#"
      xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
      xmlns:acast="https://schema.acast.com/1.0/"
+     xmlns:lj="http://www.livejournal.org/rss/lj/1.0/"
 >
   <channel>
     <title>Example Feed</title>
@@ -869,6 +870,17 @@
       <acast:showId>abc123def456ghi789jkl012</acast:showId>
       <acast:episodeUrl>example-episode-title</acast:episodeUrl>
       <acast:settings>RXBpc29kZVNldHRpbmdzQmFzZTY0RW5jb2RlZA==</acast:settings>
+
+      <!-- LiveJournal Namespace: Item Level Tags -->
+      <lj:music>The Beatles - Hey Jude</lj:music>
+      <lj:mood>cheerful</lj:mood>
+      <lj:security>public</lj:security>
+      <lj:poster>johndoe</lj:poster>
+      <lj:posterid>12345</lj:posterid>
+      <lj:journal>example_community</lj:journal>
+      <lj:journalid>67890</lj:journalid>
+      <lj:journaltype>C</lj:journaltype>
+      <lj:replycount>42</lj:replycount>
     </item>
   </channel>
 </rss>

--- a/src/namespaces/livejournal/common/config.ts
+++ b/src/namespaces/livejournal/common/config.ts
@@ -1,0 +1,19 @@
+export const uris = [
+  'http://www.livejournal.org/rss/lj/1.0/', // Official URI.
+  'https://www.livejournal.org/rss/lj/1.0/',
+  'http://livejournal.org/rss/lj/1.0/',
+  'https://livejournal.org/rss/lj/1.0/',
+]
+
+export const stopNodes = [
+  '*.lj:music',
+  '*.lj:mood',
+  '*.lj:security',
+  '*.lj:poster',
+  '*.lj:posterid',
+  '*.lj:journal',
+  '*.lj:journalid',
+  '*.lj:journaltype',
+  '*.lj:replycount',
+  '*.lj:reply-count',
+]

--- a/src/namespaces/livejournal/common/types.ts
+++ b/src/namespaces/livejournal/common/types.ts
@@ -1,0 +1,15 @@
+// #region reference
+export namespace LivejournalNs {
+  export type Item = {
+    music?: string
+    mood?: string
+    security?: string
+    poster?: string
+    posterId?: string
+    journal?: string
+    journalId?: string
+    journalType?: string
+    replyCount?: number
+  }
+}
+// #endregion reference

--- a/src/namespaces/livejournal/generate/utils.test.ts
+++ b/src/namespaces/livejournal/generate/utils.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'bun:test'
+import { generateItem } from './utils.js'
+
+describe('generateItem', () => {
+  it('should generate valid item object with all properties', () => {
+    const value = {
+      music: 'The Beatles - Hey Jude',
+      mood: 'cheerful',
+      security: 'public',
+      poster: 'johndoe',
+      posterId: '12345',
+      journal: 'example_community',
+      journalId: '67890',
+      journalType: 'C',
+      replyCount: 42,
+    }
+    const expected = {
+      'lj:music': 'The Beatles - Hey Jude',
+      'lj:mood': 'cheerful',
+      'lj:security': 'public',
+      'lj:poster': 'johndoe',
+      'lj:posterid': '12345',
+      'lj:journal': 'example_community',
+      'lj:journalid': '67890',
+      'lj:journaltype': 'C',
+      'lj:replycount': 42,
+    }
+
+    expect(generateItem(value)).toEqual(expected)
+  })
+
+  it('should generate item with minimal properties', () => {
+    const value = {
+      mood: 'sleepy',
+    }
+    const expected = {
+      'lj:mood': 'sleepy',
+    }
+
+    expect(generateItem(value)).toEqual(expected)
+  })
+
+  it('should generate reply count of zero', () => {
+    const value = {
+      replyCount: 0,
+    }
+    const expected = {
+      'lj:replycount': 0,
+    }
+
+    expect(generateItem(value)).toEqual(expected)
+  })
+
+  it('should handle object with only undefined properties', () => {
+    const value = {
+      music: undefined,
+      mood: undefined,
+      security: undefined,
+      poster: undefined,
+      posterId: undefined,
+      journal: undefined,
+      journalId: undefined,
+      journalType: undefined,
+      replyCount: undefined,
+    }
+
+    expect(generateItem(value)).toBeUndefined()
+  })
+
+  it('should handle empty object', () => {
+    const value = {}
+
+    expect(generateItem(value)).toBeUndefined()
+  })
+
+  it('should handle non-object inputs gracefully', () => {
+    expect(generateItem(undefined)).toBeUndefined()
+  })
+})

--- a/src/namespaces/livejournal/generate/utils.ts
+++ b/src/namespaces/livejournal/generate/utils.ts
@@ -1,0 +1,24 @@
+import { isPlainObject } from 'trousse'
+import type { GenerateUtil } from '../../../common/types.js'
+import { generateCdataString, generateNumber, trimObject } from '../../../common/utils.js'
+import type { LivejournalNs } from '../common/types.js'
+
+export const generateItem: GenerateUtil<LivejournalNs.Item> = (item) => {
+  if (!isPlainObject(item)) {
+    return
+  }
+
+  const value = {
+    'lj:music': generateCdataString(item.music),
+    'lj:mood': generateCdataString(item.mood),
+    'lj:security': generateCdataString(item.security),
+    'lj:poster': generateCdataString(item.poster),
+    'lj:posterid': generateCdataString(item.posterId),
+    'lj:journal': generateCdataString(item.journal),
+    'lj:journalid': generateCdataString(item.journalId),
+    'lj:journaltype': generateCdataString(item.journalType),
+    'lj:replycount': generateNumber(item.replyCount),
+  }
+
+  return trimObject(value)
+}

--- a/src/namespaces/livejournal/parse/utils.test.ts
+++ b/src/namespaces/livejournal/parse/utils.test.ts
@@ -1,0 +1,153 @@
+import { describe, expect, it } from 'bun:test'
+import { retrieveItem } from './utils.js'
+
+describe('retrieveItem', () => {
+  const expectedFull = {
+    music: 'The Beatles - Hey Jude',
+    mood: 'cheerful',
+    security: 'public',
+    poster: 'johndoe',
+    posterId: '12345',
+    journal: 'example_community',
+    journalId: '67890',
+    journalType: 'C',
+    replyCount: 42,
+  }
+
+  it('should parse complete livejournal item (with #text)', () => {
+    const value = {
+      'lj:music': { '#text': 'The Beatles - Hey Jude' },
+      'lj:mood': { '#text': 'cheerful' },
+      'lj:security': { '#text': 'public' },
+      'lj:poster': { '#text': 'johndoe' },
+      'lj:posterid': { '#text': '12345' },
+      'lj:journal': { '#text': 'example_community' },
+      'lj:journalid': { '#text': '67890' },
+      'lj:journaltype': { '#text': 'C' },
+      'lj:replycount': { '#text': '42' },
+    }
+
+    expect(retrieveItem(value)).toEqual(expectedFull)
+  })
+
+  it('should parse complete livejournal item (without #text)', () => {
+    const value = {
+      'lj:music': 'The Beatles - Hey Jude',
+      'lj:mood': 'cheerful',
+      'lj:security': 'public',
+      'lj:poster': 'johndoe',
+      'lj:posterid': '12345',
+      'lj:journal': 'example_community',
+      'lj:journalid': '67890',
+      'lj:journaltype': 'C',
+      'lj:replycount': '42',
+    }
+
+    expect(retrieveItem(value)).toEqual(expectedFull)
+  })
+
+  it('should parse complete livejournal item (with array of values)', () => {
+    const value = {
+      'lj:music': ['The Beatles - Hey Jude', 'Queen - Bohemian Rhapsody'],
+      'lj:mood': ['cheerful', 'excited'],
+      'lj:security': ['public', 'private'],
+      'lj:poster': ['johndoe', 'janedoe'],
+      'lj:posterid': ['12345', '54321'],
+      'lj:journal': ['example_community', 'another_community'],
+      'lj:journalid': ['67890', '9876'],
+      'lj:journaltype': ['C', 'P'],
+      'lj:replycount': ['42', '7'],
+    }
+
+    expect(retrieveItem(value)).toEqual(expectedFull)
+  })
+
+  it('should read the hyphenated reply-count spelling', () => {
+    const value = {
+      'lj:reply-count': { '#text': '17' },
+    }
+    const expected = {
+      replyCount: 17,
+    }
+
+    expect(retrieveItem(value)).toEqual(expected)
+  })
+
+  it('should prefer the unhyphenated replycount over reply-count', () => {
+    const value = {
+      'lj:replycount': { '#text': '42' },
+      'lj:reply-count': { '#text': '17' },
+    }
+    const expected = {
+      replyCount: 42,
+    }
+
+    expect(retrieveItem(value)).toEqual(expected)
+  })
+
+  it('should parse item with only mood field', () => {
+    const value = {
+      'lj:mood': { '#text': 'contemplative' },
+    }
+    const expected = {
+      mood: 'contemplative',
+    }
+
+    expect(retrieveItem(value)).toEqual(expected)
+  })
+
+  it('should parse item with only music field', () => {
+    const value = {
+      'lj:music': { '#text': 'silence' },
+    }
+    const expected = {
+      music: 'silence',
+    }
+
+    expect(retrieveItem(value)).toEqual(expected)
+  })
+
+  it('should parse item with only security field', () => {
+    const value = {
+      'lj:security': { '#text': 'usemask' },
+    }
+    const expected = {
+      security: 'usemask',
+    }
+
+    expect(retrieveItem(value)).toEqual(expected)
+  })
+
+  it('should handle coercible values', () => {
+    const value = {
+      'lj:mood': { '#text': 123 },
+      'lj:replycount': { '#text': 'not-a-number' },
+    }
+    const expected = {
+      mood: '123',
+    }
+
+    expect(retrieveItem(value)).toEqual(expected)
+  })
+
+  it('should return undefined for empty object', () => {
+    const value = {}
+
+    expect(retrieveItem(value)).toBeUndefined()
+  })
+
+  it('should return undefined if no livejournal properties exist', () => {
+    const value = {
+      title: { '#text': 'Not a livejournal item' },
+    }
+
+    expect(retrieveItem(value)).toBeUndefined()
+  })
+
+  it('should return undefined for non-object input', () => {
+    expect(retrieveItem('not an object')).toBeUndefined()
+    expect(retrieveItem(undefined)).toBeUndefined()
+    expect(retrieveItem(null)).toBeUndefined()
+    expect(retrieveItem([])).toBeUndefined()
+  })
+})

--- a/src/namespaces/livejournal/parse/utils.ts
+++ b/src/namespaces/livejournal/parse/utils.ts
@@ -1,0 +1,35 @@
+import { isPlainObject } from 'trousse'
+import type { ParseUtilPartial } from '../../../common/types.js'
+import {
+  parseNumber,
+  parseSingularOf,
+  parseString,
+  retrieveText,
+  trimObject,
+} from '../../../common/utils.js'
+import type { LivejournalNs } from '../common/types.js'
+
+export const retrieveItem: ParseUtilPartial<LivejournalNs.Item> = (value) => {
+  if (!isPlainObject(value)) {
+    return
+  }
+
+  const item = {
+    music: parseSingularOf(value['lj:music'], (value) => parseString(retrieveText(value))),
+    mood: parseSingularOf(value['lj:mood'], (value) => parseString(retrieveText(value))),
+    security: parseSingularOf(value['lj:security'], (value) => parseString(retrieveText(value))),
+    poster: parseSingularOf(value['lj:poster'], (value) => parseString(retrieveText(value))),
+    posterId: parseSingularOf(value['lj:posterid'], (value) => parseString(retrieveText(value))),
+    journal: parseSingularOf(value['lj:journal'], (value) => parseString(retrieveText(value))),
+    journalId: parseSingularOf(value['lj:journalid'], (value) => parseString(retrieveText(value))),
+    journalType: parseSingularOf(value['lj:journaltype'], (value) =>
+      parseString(retrieveText(value)),
+    ),
+    // INFO: Both the unhyphenated (dominant) and hyphenated spellings appear in real feeds.
+    replyCount: parseSingularOf(value['lj:replycount'] ?? value['lj:reply-count'], (value) =>
+      parseNumber(retrieveText(value)),
+    ),
+  }
+
+  return trimObject(item)
+}


### PR DESCRIPTION
Adds the LiveJournal (`lj:`) namespace as a first-class RSS namespace. LiveJournal, and compatible platforms like Dreamwidth and Scribbld: export each journal/community as an RSS 2.0 feed that embeds item-level metadata (mood, music, security level, poster, reply count) under the `lj:` prefix. Previously these elements were dropped on parse and could not be generated.

## Namespace

- **URI:** `http://www.livejournal.org/rss/lj/1.0/` (+ https/no-www variants)
- **Prefix:** `lj:`: all elements are item-level
- **Property:** `livejournal` on RSS items

## Fields

`music`, `mood`, `security`, `poster`, `posterId`, `journal`, `journalId`, `journalType`, `replyCount`.

Two spellings of the reply count appear in real feeds: `lj:replycount` (dominant) and `lj:reply-count` (hyphenated); the parser reads both and the generator emits the dominant `lj:replycount`.

## Prevalence

Measured against the local ~4.95M-feed corpus: **29,163 feeds (0.59%)** declare `xmlns:lj` and **16,169 (0.33%)** carry at least one `lj:` element. `lj:replycount` leads (15,246 feeds), followed by `lj:mood`, `lj:music`, and `lj:security`. A one-off job-board/geo feed used unrelated `lj:` tags (`lj:salary`, `lj:city`, …) in a single feed each: these are excluded as not part of the namespace.

## Scope

RSS only: this matches real LiveJournal output (its Atom feeds don't carry `lj:`) and mirrors the Acast integration.