### PR TITLE
fix: Unwrap the div wrapper of Atom xhtml text constructs

### DIFF
--- a/src/feeds/atom/parse/utils.test.ts
+++ b/src/feeds/atom/parse/utils.test.ts
@@ -15,7 +15,9 @@ import {
   retrievePersonUri,
   retrievePublished,
   retrieveSubtitle,
+  retrieveTypedText,
   retrieveUpdated,
+  unwrapXhtmlDiv,
 } from './utils.js'
 
 describe('createNamespaceGetter', () => {
@@ -114,6 +116,124 @@ describe('createNamespaceGetter', () => {
   })
 })
 
+describe('unwrapXhtmlDiv', () => {
+  it('should unwrap the wrapping div', () => {
+    const value = '<div><p>Rich content</p></div>'
+    const expected = '<p>Rich content</p>'
+
+    expect(unwrapXhtmlDiv(value)).toBe(expected)
+  })
+
+  it('should unwrap a div with attributes', () => {
+    const value = '<div xmlns="http://www.w3.org/1999/xhtml"><p>Rich content</p></div>'
+    const expected = '<p>Rich content</p>'
+
+    expect(unwrapXhtmlDiv(value)).toBe(expected)
+  })
+
+  it('should unwrap a prefixed div and strip the prefix from descendant tags', () => {
+    const value =
+      '<xhtml:div xmlns:xhtml="http://www.w3.org/1999/xhtml"><xhtml:p>Text</xhtml:p></xhtml:div>'
+    const expected = '<p>Text</p>'
+
+    expect(unwrapXhtmlDiv(value)).toBe(expected)
+  })
+
+  it('should handle surrounding whitespace', () => {
+    const value = '\n  <div>\n    <p>Text</p>\n  </div>\n'
+    const expected = '\n    <p>Text</p>\n  '
+
+    expect(unwrapXhtmlDiv(value)).toBe(expected)
+  })
+
+  it('should keep inner divs intact', () => {
+    const value = '<div><div>Inner</div></div>'
+    const expected = '<div>Inner</div>'
+
+    expect(unwrapXhtmlDiv(value)).toBe(expected)
+  })
+
+  it('should return undefined for a self-closing div', () => {
+    expect(unwrapXhtmlDiv('<xhtml:div/>')).toBeUndefined()
+    expect(unwrapXhtmlDiv('<div class="empty" />')).toBeUndefined()
+  })
+
+  it('should return value unchanged when there is no div wrapper', () => {
+    const value = '<p>Rich content</p>'
+
+    expect(unwrapXhtmlDiv(value)).toBe(value)
+  })
+
+  it('should return value unchanged when the wrapper is unterminated', () => {
+    const value = '<div><p>Text</p>'
+
+    expect(unwrapXhtmlDiv(value)).toBe(value)
+  })
+
+  it('should return non-string values unchanged', () => {
+    expect(unwrapXhtmlDiv(undefined)).toBeUndefined()
+    expect(unwrapXhtmlDiv(123)).toBe(123)
+  })
+})
+
+describe('retrieveTypedText', () => {
+  it('should unwrap the div wrapper when the type is xhtml', () => {
+    const value = { '#text': '<div xmlns="http://www.w3.org/1999/xhtml"><p>Text</p></div>' }
+    const expected = '<p>Text</p>'
+
+    expect(retrieveTypedText(value, 'xhtml')).toBe(expected)
+  })
+
+  it('should strip the namespace prefix when the type is xhtml', () => {
+    const value = {
+      '#text':
+        '<xhtml:div xmlns:xhtml="http://www.w3.org/1999/xhtml"><xhtml:p>Text</xhtml:p></xhtml:div>',
+    }
+    const expected = '<p>Text</p>'
+
+    expect(retrieveTypedText(value, 'xhtml')).toBe(expected)
+  })
+
+  it('should return undefined when the xhtml wrapper is self-closing', () => {
+    const value = { '#text': '<xhtml:div/>' }
+
+    expect(retrieveTypedText(value, 'xhtml')).toBeUndefined()
+  })
+
+  it('should return the value unchanged when an xhtml construct has no wrapper', () => {
+    const value = { '#text': '<p>Text</p>' }
+    const expected = '<p>Text</p>'
+
+    expect(retrieveTypedText(value, 'xhtml')).toBe(expected)
+  })
+
+  it('should leave a div-wrapped value untouched when the type is html', () => {
+    const value = { '#text': '<div><p>Text</p></div>' }
+    const expected = '<div><p>Text</p></div>'
+
+    expect(retrieveTypedText(value, 'html')).toBe(expected)
+  })
+
+  it('should leave a div-wrapped value untouched when the type is absent', () => {
+    const value = { '#text': '<div><p>Text</p></div>' }
+    const expected = '<div><p>Text</p></div>'
+
+    expect(retrieveTypedText(value, undefined)).toBe(expected)
+  })
+
+  it('should retrieve the text of a bare string value', () => {
+    const value = 'Plain text'
+    const expected = 'Plain text'
+
+    expect(retrieveTypedText(value, 'text')).toBe(expected)
+  })
+
+  it('should return non-string values unchanged', () => {
+    expect(retrieveTypedText({ '#text': 123 }, 'xhtml')).toBe(123)
+    expect(retrieveTypedText(undefined, 'xhtml')).toBeUndefined()
+  })
+})
+
 describe('parseText', () => {
   it('should parse simple string value', () => {
     const value = 'Simple text'
@@ -136,11 +256,20 @@ describe('parseText', () => {
     expect(parseText(value)).toEqual(expected)
   })
 
-  it('should handle xhtml type', () => {
-    const value = { '#text': '<p>XHTML content</p>', '@type': 'xhtml' }
-    const expected = { value: '<p>XHTML content</p>', type: 'xhtml' }
+  it('should unwrap the div wrapper of xhtml type', () => {
+    const value = {
+      '#text': '<div xmlns="http://www.w3.org/1999/xhtml"><p>Rich content</p></div>',
+      '@type': 'xhtml',
+    }
+    const expected = { value: '<p>Rich content</p>', type: 'xhtml' }
 
     expect(parseText(value)).toEqual(expected)
+  })
+
+  it('should return undefined for xhtml type with an empty div wrapper', () => {
+    const value = { '#text': '<xhtml:div/>', '@type': 'xhtml' }
+
+    expect(parseText(value)).toBeUndefined()
   })
 
   it('should return undefined for empty string', () => {
@@ -228,6 +357,15 @@ describe('parseContent', () => {
     expect(parseContent(value)).toEqual(expected)
   })
 
+  // Unlike parseText, which drops the whole construct when nothing is left, parseContent
+  // keeps the remaining attributes, so an empty wrapper yields a content without a value.
+  it('should keep the type but drop the value for a self-closing div wrapper', () => {
+    const value = { '#text': '<xhtml:div/>', '@type': 'xhtml' }
+    const expected = { type: 'xhtml' }
+
+    expect(parseContent(value)).toEqual(expected)
+  })
+
   it('should parse content with only src attribute', () => {
     const value = {
       '@type': 'video/mp4',
@@ -257,7 +395,7 @@ describe('parseContent', () => {
       '@xml:lang': 'en-US',
     }
     const expected = {
-      value: '<div>XHTML content</div>',
+      value: 'XHTML content',
       type: 'xhtml',
       xml: {
         base: 'http://example.org/entry/1',

--- a/src/feeds/atom/parse/utils.ts
+++ b/src/feeds/atom/parse/utils.ts
@@ -63,6 +63,55 @@ export const createNamespaceGetter = (
   return (key: string) => value[prefix + key]
 }
 
+// The value of a `type="xhtml"` text construct is the content of its single wrapping
+// <div> — RFC 4287 §3.1.1.3 requires the div itself to be excluded. The wrapper may also
+// bind the XHTML namespace to a prefix (`<xhtml:div>`), in which case every descendant tag
+// carries it too; the prefix is stripped along with the wrapper so the value is plain HTML.
+// Only the XHTML prefix gets this treatment. SVG and MathML are the two other namespaces
+// HTML represents unprefixed (foreign content — WHATWG HTML §13.2.6.5, "The rules for
+// parsing tokens in foreign content", https://html.spec.whatwg.org/multipage/parsing.html#parsing-main-inforeign),
+// but prefixed SVG/MathML inside xhtml constructs has no observed real-world usage; extend
+// to those bindings if such feeds ever appear.
+const xhtmlSelfClosingDivRegex = /^\s*<(?:[a-zA-Z][\w-]*:)?div(?:\s[^>]*)?\/>\s*$/
+const xhtmlOpeningDivRegex = /^\s*<(?:([a-zA-Z][\w-]*):)?div(?:\s[^>]*)?>/
+
+export const unwrapXhtmlDiv = (value: Unreliable): Unreliable => {
+  if (!isNonEmptyString(value)) {
+    return value
+  }
+
+  if (xhtmlSelfClosingDivRegex.test(value)) {
+    return
+  }
+
+  const match = value.match(xhtmlOpeningDivRegex)
+
+  if (!match) {
+    return value
+  }
+
+  const prefix = match[1]
+  const closingDivRegex = new RegExp(`</\\s*${prefix ? `${prefix}:` : ''}div\\s*>\\s*$`)
+
+  if (!closingDivRegex.test(value)) {
+    return value
+  }
+
+  const inner = value.slice(match[0].length).replace(closingDivRegex, '')
+
+  if (prefix) {
+    return inner.replace(new RegExp(`(</?)${prefix}:`, 'g'), '$1')
+  }
+
+  return inner
+}
+
+export const retrieveTypedText = (value: Unreliable, type: string | undefined): Unreliable => {
+  const text = retrieveText(value)
+
+  return type === 'xhtml' ? unwrapXhtmlDiv(text) : text
+}
+
 export const parseText: ParseUtilPartial<AtomFeed.Text> = (value) => {
   if (isNonEmptyString(value)) {
     const parsed = parseString(value)
@@ -74,7 +123,8 @@ export const parseText: ParseUtilPartial<AtomFeed.Text> = (value) => {
     return
   }
 
-  const parsedValue = parseString(retrieveText(value))
+  const type = parseString(value['@type'])
+  const parsedValue = parseString(retrieveTypedText(value, type))
 
   if (!parsedValue) {
     return
@@ -82,7 +132,7 @@ export const parseText: ParseUtilPartial<AtomFeed.Text> = (value) => {
 
   const text = {
     value: parsedValue,
-    type: parseString(value['@type']),
+    type,
     xml: retrieveXmlItemOrFeed(value),
   }
 
@@ -100,9 +150,11 @@ export const parseContent: ParseUtilPartial<AtomFeed.Content> = (value) => {
     return
   }
 
+  const type = parseString(value['@type'])
+
   const content = {
-    value: parseString(retrieveText(value)),
-    type: parseString(value['@type']),
+    value: parseString(retrieveTypedText(value, type)),
+    type,
     src: parseString(value['@src']),
     xml: retrieveXmlItemOrFeed(value),
   }

--- a/src/feeds/atom/references/atom-10.json
+++ b/src/feeds/atom/references/atom-10.json
@@ -97,7 +97,7 @@
         { "term": "complete", "label": "Complete Example" }
       ],
       "content": {
-        "value": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n        <h1>Comprehensive Atom 1.0 Entry</h1>\n        <p>This entry demonstrates all possible elements in an Atom 1.0 entry.</p>\n        <ul>\n          <li>Required elements: id, title, updated</li>\n          <li>Optional elements: author, category, content, contributor, link, published, rights, source, summary</li>\n        </ul>\n        <p>The content can contain rich <strong>XHTML</strong> markup.</p>\n      </div>",
+        "value": "<h1>Comprehensive Atom 1.0 Entry</h1>\n        <p>This entry demonstrates all possible elements in an Atom 1.0 entry.</p>\n        <ul>\n          <li>Required elements: id, title, updated</li>\n          <li>Optional elements: author, category, content, contributor, link, published, rights, source, summary</li>\n        </ul>\n        <p>The content can contain rich <strong>XHTML</strong> markup.</p>",
         "type": "xhtml",
         "xml": {
           "base": "http://example.org/entry/1",


### PR DESCRIPTION
RFC 4287 §3.1.1.3 requires a `type="xhtml"` value to be a single XHTML `<div>` and excludes the div from the content. We returned the raw inner XML instead: wrapper included, and `xhtml:`-prefixed tags throughout when the feed binds the namespace to a prefix. Prefixed tags are unusable as HTML, so sanitizers drop the whole entry (http://hickmanchurch.com/about/news/feed/atom lost its livestream embed that way).

`parseText` and `parseContent` now strip the wrapper and, for the prefixed form, the prefix from descendant tags. Values without a wrapper, with an unterminated one, or with a non-xhtml type pass through unchanged; a self-closing wrapper yields no value, as empty content already did.

The unwrap runs before entity decoding, so an escaped `&lt;div&gt;` is never mistaken for a wrapper.

## Prevalence

1/64 unbiased corpus sample, 198,826 feeds:

| Form | Feeds in sample | % of corpus | Extrapolated |
|---|---|---|---|
| `type="xhtml"` constructs | 668 | 0.34% | ~42,800 |
| Prefixed `<xhtml:div>` wrapper | 71 | 0.036% | ~4,500 |
| Default-namespace `<div xmlns>` wrapper | 188 | 0.095% | ~12,000 |

## Validation

All 14,000 constructs in those 668 feeds through `unwrapXhtmlDiv`:

| Outcome | Constructs | Feeds |
|---|---|---|
| Unwrapped, plain `<div>` wrapper | 12,771 | 544 |
| Unwrapped, prefixed `<xhtml:div>` wrapper | 555 | 52 |
| Passed through, no wrapper (violates §3.1.1.3) | 554 | 52 |
| Empty result, self-closing wrapper | 119 | 20 |
| Unwrapped, non-XHTML prefix left intact (`<o:p>`) | 1 | 1 |

No wrapper went unmatched, nothing truncated or corrupted. Wrappers carry `xmlns` (12,868), `xmlns:xhtml` (523), nothing (32), or `class` (23); the `class` goes with the div, per §3.1.1.3.
