### PR TITLE
fix: Keep entities escaped in Atom xhtml text constructs per RFC 4287

### DIFF
--- a/docs/migration/v2-to-v3.md
+++ b/docs/migration/v2-to-v3.md
@@ -256,6 +256,41 @@ const xml = generateAtomFeed({
 2. Update generate calls: `content: 'text'` → `content: { value: 'text' }`
 3. Optionally use `type` and `src` for richer content metadata
 
+### Atom `type="xhtml"` Values Are Now Plain HTML
+
+Parsing of `type="xhtml"` text constructs and content now conforms to [RFC 4287 §3.1.1.3](https://www.rfc-editor.org/rfc/rfc4287#section-3.1.1.3), and the parsed value is the plain HTML the spec describes. Three things changed:
+
+- The wrapper `<div>` is stripped: the spec excludes it from the content
+- The `xhtml:` prefix is removed from every tag when the feed binds the XHTML namespace to a prefix
+- Escaped characters are no longer decoded: inside an xhtml construct `&lt;` stands for the literal character, so an email address like `From: Sean &lt;sean@intel.com&gt;` survives instead of becoming a tag that HTML parsers swallow. A CDATA section also means literal text, so `<![CDATA[a < b]]>` comes out as `a &lt; b`
+
+A value without the wrapper `<div>` does not follow the spec and is decoded as before, so feeds that label escaped HTML as `xhtml` keep working.
+
+```xml
+<content type="xhtml">
+  <xhtml:div xmlns:xhtml="http://www.w3.org/1999/xhtml">
+    <xhtml:p>a &lt; b</xhtml:p>
+  </xhtml:div>
+</content>
+```
+
+#### Before (2.x)
+```typescript
+const content = feed.entries?.[0]?.content?.value
+// '<xhtml:div xmlns:xhtml="http://www.w3.org/1999/xhtml"><xhtml:p>a < b</xhtml:p></xhtml:div>'
+```
+
+#### After (3.x)
+```typescript
+const content = feed.entries?.[0]?.content?.value
+// '<p>a &lt; b</p>'
+```
+
+#### Migration Steps
+1. Drop any code that strips the wrapper `<div>` or the `xhtml:` prefix: the parser does it
+2. Render the value as HTML, not as XML
+3. Note that a construct whose wrapper is empty (`<div/>`) now yields no value at all: `entry.content` keeps its other fields but loses `value`, while `title`, `summary`, `subtitle`, and `rights` become `undefined`
+
 ### RSS Person Fields Changed from Strings to Objects
 
 The `managingEditor`, `webMaster`, and `authors` fields on RSS feeds and items were previously plain strings (e.g., `'editor@example.com (Editor Name)'`). In the new version, they use the `Rss.Person` object that preserves structured data, properly representing the [RSS person construct](https://www.rssboard.org/rss-specification#ltauthorgtSubelementOfLtitemgt).

--- a/src/common/utils.test.ts
+++ b/src/common/utils.test.ts
@@ -27,11 +27,11 @@ import {
   parseCsvOf,
   parseDate,
   parseJsonObject,
-  parseJsonString,
   parseNumber,
   parseSingular,
   parseSingularOf,
   parseString,
+  parseVerbatimString,
   parseYesNoBoolean,
   retrieveRdfResourceOrText,
   retrieveText,
@@ -1056,74 +1056,74 @@ describe('parseString', () => {
   })
 })
 
-describe('parseJsonString', () => {
+describe('parseVerbatimString', () => {
   it('should return string as-is when no entities or comments are present', () => {
     const value = 'plain text'
     const expected = 'plain text'
 
-    expect(parseJsonString(value)).toBe(expected)
+    expect(parseVerbatimString(value)).toBe(expected)
   })
 
   it('should trim leading and trailing whitespace', () => {
     const value = '  hello  '
     const expected = 'hello'
 
-    expect(parseJsonString(value)).toBe(expected)
+    expect(parseVerbatimString(value)).toBe(expected)
   })
 
   it('should convert numbers to strings', () => {
     const value = 42
     const expected = '42'
 
-    expect(parseJsonString(value)).toBe(expected)
+    expect(parseVerbatimString(value)).toBe(expected)
   })
 
   it('should return undefined for empty string', () => {
     const value = ''
 
-    expect(parseJsonString(value)).toBeUndefined()
+    expect(parseVerbatimString(value)).toBeUndefined()
   })
 
   it('should return undefined for whitespace-only string', () => {
     const value = '   '
 
-    expect(parseJsonString(value)).toBeUndefined()
+    expect(parseVerbatimString(value)).toBeUndefined()
   })
 
   it('should return undefined for non-string non-number inputs', () => {
-    expect(parseJsonString(null)).toBeUndefined()
-    expect(parseJsonString(undefined)).toBeUndefined()
-    expect(parseJsonString(true)).toBeUndefined()
-    expect(parseJsonString({})).toBeUndefined()
-    expect(parseJsonString([])).toBeUndefined()
+    expect(parseVerbatimString(null)).toBeUndefined()
+    expect(parseVerbatimString(undefined)).toBeUndefined()
+    expect(parseVerbatimString(true)).toBeUndefined()
+    expect(parseVerbatimString({})).toBeUndefined()
+    expect(parseVerbatimString([])).toBeUndefined()
   })
 
   it('should preserve XML entities (no entity decoding)', () => {
     const value = '&lt;p&gt;hello&lt;/p&gt; &amp; goodbye'
     const expected = '&lt;p&gt;hello&lt;/p&gt; &amp; goodbye'
 
-    expect(parseJsonString(value)).toBe(expected)
+    expect(parseVerbatimString(value)).toBe(expected)
   })
 
   it('should preserve HTML comment markers (no comment stripping)', () => {
     const value = 'before <!-- inline note --> after'
     const expected = 'before <!-- inline note --> after'
 
-    expect(parseJsonString(value)).toBe(expected)
+    expect(parseVerbatimString(value)).toBe(expected)
   })
 
   it('should preserve CDATA markers verbatim', () => {
     const value = '<![CDATA[raw <p>text</p>]]>'
     const expected = '<![CDATA[raw <p>text</p>]]>'
 
-    expect(parseJsonString(value)).toBe(expected)
+    expect(parseVerbatimString(value)).toBe(expected)
   })
 
   it('should preserve numeric character references', () => {
     const value = '&#60;tag&#62;'
     const expected = '&#60;tag&#62;'
 
-    expect(parseJsonString(value)).toBe(expected)
+    expect(parseVerbatimString(value)).toBe(expected)
   })
 })
 

--- a/src/common/utils.ts
+++ b/src/common/utils.ts
@@ -218,11 +218,11 @@ export const parseString: ParseUtilExact<string> = (value) => {
   }
 }
 
-// Variant of parseString for JSON-sourced values: skips XML entity decoding and
-// HTML comment stripping. JSON.parse already produces the final string, so any
-// `&lt;` / `<!--` in fields like JSON Feed's `content_html` belongs to the HTML
-// payload and must be preserved verbatim.
-export const parseJsonString: ParseUtilExact<string> = (value) => {
+// Variant of parseString for values that are already final markup: skips XML entity
+// decoding and HTML comment stripping. Used where a `&lt;` / `<!--` belongs to the payload
+// rather than encoding it — JSON Feed's `content_html`, whose string comes straight out of
+// JSON.parse, and Atom's xhtml constructs, whose entities stand for literal characters.
+export const parseVerbatimString: ParseUtilExact<string> = (value) => {
   if (typeof value === 'string') {
     if (value === '') {
       return

--- a/src/feeds/atom/parse/utils.test.ts
+++ b/src/feeds/atom/parse/utils.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'bun:test'
 import {
   createNamespaceGetter,
+  escapeCdataSections,
   parseCategory,
   parseContent,
   parseEntry,
@@ -10,12 +11,12 @@ import {
   parsePerson,
   parseSource,
   parseText,
+  parseTypedText,
   retrieveFeed,
   retrieveGeneratorUri,
   retrievePersonUri,
   retrievePublished,
   retrieveSubtitle,
-  retrieveTypedText,
   retrieveUpdated,
   unwrapXhtmlDiv,
 } from './utils.js'
@@ -176,12 +177,45 @@ describe('unwrapXhtmlDiv', () => {
   })
 })
 
-describe('retrieveTypedText', () => {
+describe('escapeCdataSections', () => {
+  it('should replace a CDATA section with its entity-escaped content', () => {
+    const value = 'before <![CDATA[a < b && c]]> after'
+    const expected = 'before a &lt; b &amp;&amp; c after'
+
+    expect(escapeCdataSections(value)).toBe(expected)
+  })
+
+  it('should replace multiple CDATA sections', () => {
+    const value = '<![CDATA[<p>]]> and <![CDATA[&]]>'
+    const expected = '&lt;p> and &amp;'
+
+    expect(escapeCdataSections(value)).toBe(expected)
+  })
+
+  it('should leave an unterminated CDATA section untouched', () => {
+    const value = '<pre><![CDATA[if (a < b) return;</pre>'
+
+    expect(escapeCdataSections(value)).toBe(value)
+  })
+
+  it('should return a value without CDATA sections unchanged', () => {
+    const value = '<p>a &lt; b</p>'
+
+    expect(escapeCdataSections(value)).toBe(value)
+  })
+
+  it('should return non-string values unchanged', () => {
+    expect(escapeCdataSections(undefined)).toBeUndefined()
+    expect(escapeCdataSections(123)).toBe(123)
+  })
+})
+
+describe('parseTypedText', () => {
   it('should unwrap the div wrapper when the type is xhtml', () => {
     const value = { '#text': '<div xmlns="http://www.w3.org/1999/xhtml"><p>Text</p></div>' }
     const expected = '<p>Text</p>'
 
-    expect(retrieveTypedText(value, 'xhtml')).toBe(expected)
+    expect(parseTypedText(value, 'xhtml')).toBe(expected)
   })
 
   it('should strip the namespace prefix when the type is xhtml', () => {
@@ -191,46 +225,109 @@ describe('retrieveTypedText', () => {
     }
     const expected = '<p>Text</p>'
 
-    expect(retrieveTypedText(value, 'xhtml')).toBe(expected)
+    expect(parseTypedText(value, 'xhtml')).toBe(expected)
   })
 
   it('should return undefined when the xhtml wrapper is self-closing', () => {
     const value = { '#text': '<xhtml:div/>' }
 
-    expect(retrieveTypedText(value, 'xhtml')).toBeUndefined()
+    expect(parseTypedText(value, 'xhtml')).toBeUndefined()
   })
 
   it('should return the value unchanged when an xhtml construct has no wrapper', () => {
     const value = { '#text': '<p>Text</p>' }
     const expected = '<p>Text</p>'
 
-    expect(retrieveTypedText(value, 'xhtml')).toBe(expected)
+    expect(parseTypedText(value, 'xhtml')).toBe(expected)
   })
 
   it('should leave a div-wrapped value untouched when the type is html', () => {
     const value = { '#text': '<div><p>Text</p></div>' }
     const expected = '<div><p>Text</p></div>'
 
-    expect(retrieveTypedText(value, 'html')).toBe(expected)
+    expect(parseTypedText(value, 'html')).toBe(expected)
   })
 
   it('should leave a div-wrapped value untouched when the type is absent', () => {
     const value = { '#text': '<div><p>Text</p></div>' }
     const expected = '<div><p>Text</p></div>'
 
-    expect(retrieveTypedText(value, undefined)).toBe(expected)
+    expect(parseTypedText(value, undefined)).toBe(expected)
   })
 
   it('should retrieve the text of a bare string value', () => {
     const value = 'Plain text'
     const expected = 'Plain text'
 
-    expect(retrieveTypedText(value, 'text')).toBe(expected)
+    expect(parseTypedText(value, 'text')).toBe(expected)
   })
 
-  it('should return non-string values unchanged', () => {
-    expect(retrieveTypedText({ '#text': 123 }, 'xhtml')).toBe(123)
-    expect(retrieveTypedText(undefined, 'xhtml')).toBeUndefined()
+  it('should keep entities escaped inside a wrapped xhtml construct', () => {
+    const value = {
+      '#text':
+        '<div xmlns="http://www.w3.org/1999/xhtml"><pre>From: Sean &lt;sean@intel.com&gt;</pre></div>',
+    }
+    const expected = '<pre>From: Sean &lt;sean@intel.com&gt;</pre>'
+
+    expect(parseTypedText(value, 'xhtml')).toBe(expected)
+  })
+
+  it('should keep entities escaped inside a prefixed xhtml construct', () => {
+    const value = {
+      '#text':
+        '<xhtml:div xmlns:xhtml="http://www.w3.org/1999/xhtml"><xhtml:p>a &lt; b</xhtml:p></xhtml:div>',
+    }
+    const expected = '<p>a &lt; b</p>'
+
+    expect(parseTypedText(value, 'xhtml')).toBe(expected)
+  })
+
+  it('should turn CDATA content into entities inside a wrapped xhtml construct', () => {
+    const value = {
+      '#text':
+        '<div xmlns="http://www.w3.org/1999/xhtml"><pre><![CDATA[if (a < b && c) return;]]></pre></div>',
+    }
+    const expected = '<pre>if (a &lt; b &amp;&amp; c) return;</pre>'
+
+    expect(parseTypedText(value, 'xhtml')).toBe(expected)
+  })
+
+  it('should keep a prefix inside CDATA literal text when unwrapping a prefixed construct', () => {
+    const value = {
+      '#text':
+        '<xh:div xmlns:xh="http://www.w3.org/1999/xhtml"><xh:p><![CDATA[literal <xh:b> & stuff]]></xh:p></xh:div>',
+    }
+    const expected = '<p>literal &lt;xh:b> &amp; stuff</p>'
+
+    expect(parseTypedText(value, 'xhtml')).toBe(expected)
+  })
+
+  // Escaped markup labelled as xhtml violates the spec, but publishers ship it; without a
+  // wrapper to prove the construct is genuine, decoding stays the better guess.
+  it('should decode entities when an xhtml construct has no wrapper', () => {
+    const value = { '#text': '&lt;p&gt;Hello&lt;/p&gt;' }
+    const expected = '<p>Hello</p>'
+
+    expect(parseTypedText(value, 'xhtml')).toBe(expected)
+  })
+
+  it('should decode entities when the type is html', () => {
+    const value = { '#text': '&lt;p&gt;Hello&lt;/p&gt;' }
+    const expected = '<p>Hello</p>'
+
+    expect(parseTypedText(value, 'html')).toBe(expected)
+  })
+
+  it('should decode entities when the type is absent', () => {
+    const value = { '#text': 'a &lt; b' }
+    const expected = 'a < b'
+
+    expect(parseTypedText(value, undefined)).toBe(expected)
+  })
+
+  it('should coerce non-string values to a string', () => {
+    expect(parseTypedText({ '#text': 123 }, 'xhtml')).toBe('123')
+    expect(parseTypedText(undefined, 'xhtml')).toBeUndefined()
   })
 })
 

--- a/src/feeds/atom/parse/utils.ts
+++ b/src/feeds/atom/parse/utils.ts
@@ -7,6 +7,7 @@ import {
   parseNumber,
   parseSingularOf,
   parseString,
+  parseVerbatimString,
   retrieveText,
   trimObject,
 } from '../../../common/utils.js'
@@ -106,10 +107,42 @@ export const unwrapXhtmlDiv = (value: Unreliable): Unreliable => {
   return inner
 }
 
-export const retrieveTypedText = (value: Unreliable, type: string | undefined): Unreliable => {
+// A CDATA section is XML's other spelling for literal text, so its content becomes entities
+// in the verbatim value: dropping only the markers would hand a literal `<` to an HTML
+// parser as markup, the same corruption the verbatim path exists to avoid. A section
+// without its `]]>` terminator is malformed XML and is left untouched.
+const cdataSectionRegex = /<!\[CDATA\[([\s\S]*?)\]\]>/g
+
+export const escapeCdataSections = (value: Unreliable): Unreliable => {
+  if (!isNonEmptyString(value)) {
+    return value
+  }
+
+  return value.replace(cdataSectionRegex, (_, content: string) => {
+    return content.replace(/&/g, '&amp;').replace(/</g, '&lt;')
+  })
+}
+
+// Inside a genuine xhtml construct an escaped `&lt;` stands for that character and not for
+// markup (RFC 4287 §3.1.1.3), so decoding it would turn text into tags that an HTML parser
+// then swallows. Such a value is taken verbatim instead. The wrapper div identifies the
+// genuine case: a value without one is not a valid construct, and the spec does not say how
+// to read an invalid one, so it keeps the decoding, which suits a feed that labels escaped
+// HTML as xhtml. That is a choice, not a rule: 1 of 554 wrapper-less constructs in the
+// corpus sample carries escaped markup, and for the rest both paths produce the same string.
+export const parseTypedText = (value: Unreliable, type: string | undefined): string | undefined => {
   const text = retrieveText(value)
 
-  return type === 'xhtml' ? unwrapXhtmlDiv(text) : text
+  if (type !== 'xhtml') {
+    return parseString(text)
+  }
+
+  // CDATA is escaped before the wrapper is stripped: its content is literal text, so a
+  // `</xhtml:p>` or `<div>` inside it must not be seen as markup by the prefix strip.
+  const escaped = escapeCdataSections(text)
+  const unwrapped = unwrapXhtmlDiv(escaped)
+
+  return unwrapped === escaped ? parseString(text) : parseVerbatimString(unwrapped)
 }
 
 export const parseText: ParseUtilPartial<AtomFeed.Text> = (value) => {
@@ -124,7 +157,7 @@ export const parseText: ParseUtilPartial<AtomFeed.Text> = (value) => {
   }
 
   const type = parseString(value['@type'])
-  const parsedValue = parseString(retrieveTypedText(value, type))
+  const parsedValue = parseTypedText(value, type)
 
   if (!parsedValue) {
     return
@@ -153,7 +186,7 @@ export const parseContent: ParseUtilPartial<AtomFeed.Content> = (value) => {
   const type = parseString(value['@type'])
 
   const content = {
-    value: parseString(retrieveTypedText(value, type)),
+    value: parseTypedText(value, type),
     type,
     src: parseString(value['@src']),
     xml: retrieveXmlItemOrFeed(value),

--- a/src/feeds/json/parse/utils.ts
+++ b/src/feeds/json/parse/utils.ts
@@ -5,9 +5,9 @@ import {
   parseArrayOf,
   parseBoolean,
   parseDate,
-  parseJsonString,
   parseNumber,
   parseSingularOf,
+  parseVerbatimString,
   trimObject,
 } from '../../../common/utils.js'
 import type { JsonFeed, ParseUtilPartial } from '../common/types.js'
@@ -33,9 +33,9 @@ export const parseAuthor: ParseUtilPartial<JsonFeed.Author> = (value) => {
   if (isPlainObject(value)) {
     const get = createCaseInsensitiveGetter(value)
     const author = {
-      name: parseSingularOf(get('name'), parseJsonString),
-      url: parseSingularOf(get('url'), parseJsonString),
-      avatar: parseSingularOf(get('avatar'), parseJsonString),
+      name: parseSingularOf(get('name'), parseVerbatimString),
+      url: parseSingularOf(get('url'), parseVerbatimString),
+      avatar: parseSingularOf(get('avatar'), parseVerbatimString),
     }
 
     return trimObject(author)
@@ -43,7 +43,7 @@ export const parseAuthor: ParseUtilPartial<JsonFeed.Author> = (value) => {
 
   if (isNonEmptyStringOrNumber(value)) {
     const author = {
-      name: parseJsonString(value),
+      name: parseVerbatimString(value),
     }
 
     return trimObject(author)
@@ -72,9 +72,9 @@ export const parseAttachment: ParseUtilPartial<JsonFeed.Attachment> = (value) =>
 
   const get = createCaseInsensitiveGetter(value)
   const attachment = {
-    url: parseSingularOf(get('url'), parseJsonString),
-    mime_type: parseSingularOf(get('mime_type'), parseJsonString),
-    title: parseSingularOf(get('title'), parseJsonString),
+    url: parseSingularOf(get('url'), parseVerbatimString),
+    mime_type: parseSingularOf(get('mime_type'), parseVerbatimString),
+    title: parseSingularOf(get('title'), parseVerbatimString),
     size_in_bytes: parseSingularOf(get('size_in_bytes'), parseNumber),
     duration_in_seconds: parseSingularOf(get('duration_in_seconds'), parseNumber),
   }
@@ -89,24 +89,24 @@ export const parseItem: ParseUtilPartial<JsonFeed.Item<DateAny>> = (value, optio
 
   const get = createCaseInsensitiveGetter(value)
   const item = {
-    id: parseSingularOf(get('id'), parseJsonString),
-    url: parseSingularOf(get('url'), parseJsonString),
-    external_url: parseSingularOf(get('external_url'), parseJsonString),
-    title: parseSingularOf(get('title'), parseJsonString),
-    content_html: parseSingularOf(get('content_html'), parseJsonString),
-    content_text: parseSingularOf(get('content_text'), parseJsonString),
-    summary: parseSingularOf(get('summary'), parseJsonString),
-    image: parseSingularOf(get('image'), parseJsonString),
-    banner_image: parseSingularOf(get('banner_image'), parseJsonString),
+    id: parseSingularOf(get('id'), parseVerbatimString),
+    url: parseSingularOf(get('url'), parseVerbatimString),
+    external_url: parseSingularOf(get('external_url'), parseVerbatimString),
+    title: parseSingularOf(get('title'), parseVerbatimString),
+    content_html: parseSingularOf(get('content_html'), parseVerbatimString),
+    content_text: parseSingularOf(get('content_text'), parseVerbatimString),
+    summary: parseSingularOf(get('summary'), parseVerbatimString),
+    image: parseSingularOf(get('image'), parseVerbatimString),
+    banner_image: parseSingularOf(get('banner_image'), parseVerbatimString),
     date_published: parseSingularOf(get('date_published'), (value) =>
       parseDate(value, options?.parseDateFn),
     ),
     date_modified: parseSingularOf(get('date_modified'), (value) =>
       parseDate(value, options?.parseDateFn),
     ),
-    tags: parseArrayOf(get('tags'), parseJsonString),
+    tags: parseArrayOf(get('tags'), parseVerbatimString),
     authors: retrieveAuthors(value),
-    language: parseSingularOf(get('language'), parseJsonString),
+    language: parseSingularOf(get('language'), parseVerbatimString),
     attachments: parseArrayOf(get('attachments'), parseAttachment),
   }
 
@@ -120,8 +120,8 @@ export const parseHub: ParseUtilPartial<JsonFeed.Hub> = (value) => {
 
   const get = createCaseInsensitiveGetter(value)
   const hub = {
-    type: parseSingularOf(get('type'), parseJsonString),
-    url: parseSingularOf(get('url'), parseJsonString),
+    type: parseSingularOf(get('type'), parseVerbatimString),
+    url: parseSingularOf(get('url'), parseVerbatimString),
   }
 
   return trimObject(hub)
@@ -134,15 +134,15 @@ export const parseFeed: ParseUtilPartial<JsonFeed.Feed<DateAny>> = (value, optio
 
   const get = createCaseInsensitiveGetter(value)
   const feed = {
-    title: parseSingularOf(get('title'), parseJsonString),
-    home_page_url: parseSingularOf(get('home_page_url'), parseJsonString),
-    feed_url: parseSingularOf(get('feed_url'), parseJsonString),
-    description: parseSingularOf(get('description'), parseJsonString),
-    user_comment: parseSingularOf(get('user_comment'), parseJsonString),
-    next_url: parseSingularOf(get('next_url'), parseJsonString),
-    icon: parseSingularOf(get('icon'), parseJsonString),
-    favicon: parseSingularOf(get('favicon'), parseJsonString),
-    language: parseSingularOf(get('language'), parseJsonString),
+    title: parseSingularOf(get('title'), parseVerbatimString),
+    home_page_url: parseSingularOf(get('home_page_url'), parseVerbatimString),
+    feed_url: parseSingularOf(get('feed_url'), parseVerbatimString),
+    description: parseSingularOf(get('description'), parseVerbatimString),
+    user_comment: parseSingularOf(get('user_comment'), parseVerbatimString),
+    next_url: parseSingularOf(get('next_url'), parseVerbatimString),
+    icon: parseSingularOf(get('icon'), parseVerbatimString),
+    favicon: parseSingularOf(get('favicon'), parseVerbatimString),
+    language: parseSingularOf(get('language'), parseVerbatimString),
     expired: parseSingularOf(get('expired'), parseBoolean),
     hubs: parseArrayOf(get('hubs'), parseHub),
     authors: retrieveAuthors(value),


### PR DESCRIPTION
Stacked on #329; base retargets to `rc` when that merges. #332 handles the generate side.

RFC 4287 §3.1.1.3: inside a `type="xhtml"` construct, "escaped versions of characters such as `&` and `>` represent those characters, not markup." We decoded them, which is right for `type="html"` and wrong here, since it turns text into tags that an HTML parser then eats.

A code listing in a feed shows the damage. Source:

```
From: Sean &lt;sean@intel.com&gt;
#include &lt;linux/types.h&gt;
if (a &lt; b) return;
```

reaches consumers as `From: Sean <sean@intel.com>` and renders:

```html
<pre><code>From: Sean <sean@intel.com>
#include <linux types.h="">
if (a &lt; b) return;</linux></sean@intel.com></code></pre>
```

The address became an element; `<linux/types.h>` split at the slash into a tag with an empty attribute. Both are unclosed, so a sanitizer dropping unknown elements takes the rest of the block with them. `a &lt; b` survives because HTML only opens a tag before a letter.

## The wrapper as discriminator

Skipping the decode for every xhtml value would regress feeds that label escaped HTML as xhtml:

```xml
<content type="xhtml">&lt;p&gt;Hello&lt;/p&gt;</content>
```

Non-conformant, but they render correctly today because of the decode, and would become visible tag soup without it.

The wrapper div separates the two, and #329 already computes it: wrapped means genuine inline XHTML and goes verbatim, wrapper-less already violates §3.1.1.3 and keeps the decode instead of changing behaviour on a guess. `parseTypedText` owns the decision, so neither caller knows which branch ran.

Across the 14,000 constructs from #329:

| Bucket | Constructs | Containing escaped markup |
|---|---|---|
| With wrapper div (genuine xhtml) | 13,446 | **7,527** |
| No wrapper (non-conformant) | 554 | **1** |

7,527 constructs currently corrupted. The measurement also killed my assumption that wrapper-less constructs would be mostly mislabelled escaped HTML: exactly one contains escaped markup, so the fallback branch is precautionary, not load-bearing. It stays at two lines' cost.

## CDATA

CDATA is XML's other spelling for literal text, so it gets the same treatment. Keeping the markers leaves `<![CDATA[` in the value, which HTML reads as a bogus comment; dropping only the markers hands the literal `<` back as markup. Content is entity-escaped instead: `<![CDATA[a < b]]>` becomes `a &lt; b`. An unterminated section is malformed XML and stays untouched.

Escaping runs before the wrapper strip, so a `</xhtml:p>` inside CDATA keeps its prefix instead of being rewritten as markup.

Prevalence, 1/256 sample of 49,707 feeds: 1 of 3,348 wrapped constructs, in 1 of 163 feeds. Precautionary correctness, not a population.

## Also here

- `parseJsonString` becomes `parseVerbatimString`. Same behaviour (trim, no decode, no comment stripping), which is exactly what an xhtml value needs; the old name described where the string came from, not what the function does. Compiler-verified.
- Comments inside a wrapped value are no longer stripped, since `parseVerbatimString` leaves them alone. They do not render either way, but it is a behaviour change beyond entities.
- Migration guide gains a section covering this and #329.
