### PR TITLE
fix: Generate Atom xhtml text constructs as markup in a div wrapper

### DIFF
--- a/docs/migration/v2-to-v3.md
+++ b/docs/migration/v2-to-v3.md
@@ -286,10 +286,13 @@ const content = feed.entries?.[0]?.content?.value
 // '<p>a &lt; b</p>'
 ```
 
+Generating follows the same rule in the other direction. A text construct or content with `type="xhtml"` is emitted as markup inside a single `<div xmlns="http://www.w3.org/1999/xhtml">` wrapper, where it was previously written as escaped text or CDATA. The value must be well-formed XML for this: a value that is not (unclosed tags like `<br>`, a bare `&`) keeps the previous escaped form, which stays parseable everywhere but does not conform to the spec.
+
 #### Migration Steps
 1. Drop any code that strips the wrapper `<div>` or the `xhtml:` prefix: the parser does it
 2. Render the value as HTML, not as XML
 3. Note that a construct whose wrapper is empty (`<div/>`) now yields no value at all: `entry.content` keeps its other fields but loses `value`, while `title`, `summary`, `subtitle`, and `rights` become `undefined`
+4. When generating with `type="xhtml"`, pass the inner markup without the wrapper `<div>` and keep it well-formed (XHTML-style closed tags) so it can be embedded as XML
 
 ### RSS Person Fields Changed from Strings to Objects
 

--- a/src/common/utils.ts
+++ b/src/common/utils.ts
@@ -23,6 +23,11 @@ export const isNonEmptyStringOrNumber = (value: Unreliable): value is string | n
   return isNumber(value) || isNonEmptyString(value)
 }
 
+export const isXmlAttributeKey = (key: string) => {
+  // Matches the `@` (charCode 64) from attributeNamePrefix in config.ts.
+  return key.charCodeAt(0) === 64
+}
+
 export const retrieveText = (value: Unreliable): Unreliable => {
   return value?.['#text'] ?? value
 }
@@ -508,7 +513,7 @@ export const detectNamespaces = (value: unknown, recursive = false): Set<string>
 
         seenKeys?.add(key)
 
-        const keyWithoutAt = key.charCodeAt(0) === 64 ? key.slice(1) : key
+        const keyWithoutAt = isXmlAttributeKey(key) ? key.slice(1) : key
         const colonIndex = keyWithoutAt.indexOf(':')
 
         if (colonIndex > 0) {

--- a/src/feeds/atom/generate/config.ts
+++ b/src/feeds/atom/generate/config.ts
@@ -1,6 +1,11 @@
 import { XMLBuilder } from 'fast-xml-parser'
 import { builderConfig } from '../../../common/config.js'
+import { textConstructs } from '../../../namespaces/atom/common/config.js'
 
+// A `type="xhtml"` construct holds its value as raw markup (see generateXhtmlValue in
+// utils.ts), so the builder must not entity-encode it. Stop nodes match on the type
+// attribute, leaving constructs of every other type on the normal escaping path.
 export const builder = new XMLBuilder({
   ...builderConfig,
+  stopNodes: textConstructs.map((element) => `..${element}[type=xhtml]`),
 })

--- a/src/feeds/atom/generate/index.test.ts
+++ b/src/feeds/atom/generate/index.test.ts
@@ -35,6 +35,65 @@ describe('generate', () => {
     expect(generate(value)).toEqual(expected)
   })
 
+  it('should generate xhtml text constructs as markup inside a div wrapper', () => {
+    const value = {
+      id: 'https://example.com/feed',
+      title: {
+        value: '<p>a &lt; b <em>ok</em></p>',
+        type: 'xhtml',
+      },
+      updated: new Date('2023-03-15T12:00:00Z'),
+      entries: [
+        {
+          id: 'https://example.com/entry',
+          title: { value: 'Entry' },
+          updated: new Date('2023-03-15T12:00:00Z'),
+          content: {
+            value: '<p>Rich <strong>content</strong></p>',
+            type: 'xhtml',
+          },
+        },
+      ],
+    }
+    const expected = `<?xml version="1.0" encoding="utf-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <id>https://example.com/feed</id>
+  <title type="xhtml">
+<div xmlns="http://www.w3.org/1999/xhtml"><p>a &lt; b <em>ok</em></p></div>  </title>
+  <updated>2023-03-15T12:00:00.000Z</updated>
+  <entry>
+    <content type="xhtml">
+<div xmlns="http://www.w3.org/1999/xhtml"><p>Rich <strong>content</strong></p></div>    </content>
+    <id>https://example.com/entry</id>
+    <title>Entry</title>
+    <updated>2023-03-15T12:00:00.000Z</updated>
+  </entry>
+</feed>
+`
+
+    expect(generate(value)).toEqual(expected)
+  })
+
+  it('should escape an xhtml value that is not well-formed XML instead of wrapping it', () => {
+    const value = {
+      id: 'https://example.com/feed',
+      title: {
+        value: '<p>Hello<br>world</p>',
+        type: 'xhtml',
+      },
+      updated: new Date('2023-03-15T12:00:00Z'),
+    }
+    const expected = `<?xml version="1.0" encoding="utf-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <id>https://example.com/feed</id>
+  <title type="xhtml">&lt;p&gt;Hello&lt;br&gt;world&lt;/p&gt;</title>
+  <updated>2023-03-15T12:00:00.000Z</updated>
+</feed>
+`
+
+    expect(generate(value)).toEqual(expected)
+  })
+
   it('should generate Atom feed with entries', () => {
     const value = {
       id: 'https://example.com/feed',

--- a/src/feeds/atom/generate/utils.test.ts
+++ b/src/feeds/atom/generate/utils.test.ts
@@ -10,6 +10,7 @@ import {
   generatePerson,
   generateSource,
   generateText,
+  generateXhtmlValue,
 } from './utils.js'
 
 describe('createNamespaceSetter', () => {
@@ -48,7 +49,67 @@ describe('createNamespaceSetter', () => {
   })
 })
 
+describe('generateXhtmlValue', () => {
+  it('should wrap a well-formed value in a div', () => {
+    const value = '<p>Text</p>'
+    const expected = {
+      '#text': '<div xmlns="http://www.w3.org/1999/xhtml"><p>Text</p></div>',
+    }
+
+    expect(generateXhtmlValue(value)).toEqual(expected)
+  })
+
+  it('should escape a value that is not well-formed XML instead of wrapping it', () => {
+    const value = '<p>Hello<br>world</p>'
+    const expected = { '#text': '&lt;p&gt;Hello&lt;br&gt;world&lt;/p&gt;' }
+
+    expect(generateXhtmlValue(value)).toEqual(expected)
+  })
+
+  it('should return undefined for empty and non-string values', () => {
+    expect(generateXhtmlValue('')).toBeUndefined()
+    expect(generateXhtmlValue('   ')).toBeUndefined()
+    expect(generateXhtmlValue(undefined)).toBeUndefined()
+  })
+})
+
 describe('generateText', () => {
+  it('should escape attribute values of an xhtml construct', () => {
+    const value = {
+      value: '<p>ok</p>',
+      type: 'xhtml',
+      xml: { base: 'https://example.com/a?b=1&c=2' },
+    }
+    const expected = {
+      '#text': '<div xmlns="http://www.w3.org/1999/xhtml"><p>ok</p></div>',
+      '@type': 'xhtml',
+      '@xml:base': 'https://example.com/a?b=1&amp;c=2',
+    }
+
+    expect(generateText(value)).toEqual(expected)
+  })
+
+  it('should route a padded type to the same path as the emitted attribute', () => {
+    const value = { value: '<p>ok</p>', type: ' xhtml' }
+    const expected = {
+      '#text': '<div xmlns="http://www.w3.org/1999/xhtml"><p>ok</p></div>',
+      '@type': 'xhtml',
+    }
+
+    expect(generateText(value)).toEqual(expected)
+  })
+
+  it('should leave attributes of a non-xhtml construct to the builder', () => {
+    const value = { value: 'plain', type: 'text', xml: { base: 'https://example.com/?a=1&b=2' } }
+    const expected = {
+      '#text': 'plain',
+      '@type': 'text',
+      '@xml:base': 'https://example.com/?a=1&b=2',
+    }
+
+    expect(generateText(value)).toEqual(expected)
+  })
+
   it('should generate text with value only', () => {
     const value = { value: 'Hello World' }
     const expected = { '#text': 'Hello World' }
@@ -57,10 +118,7 @@ describe('generateText', () => {
   })
 
   it('should generate text with value and type', () => {
-    const value = {
-      value: 'HTML content',
-      type: 'html',
-    }
+    const value = { value: 'HTML content', type: 'html' }
     const expected = {
       '#text': 'HTML content',
       '@type': 'html',
@@ -186,7 +244,7 @@ describe('generateContent', () => {
       },
     }
     const expected = {
-      '#cdata': '<div>XHTML content</div>',
+      '#text': '<div xmlns="http://www.w3.org/1999/xhtml"><div>XHTML content</div></div>',
       '@type': 'xhtml',
       '@xml:base': 'http://example.org/entry/1',
       '@xml:lang': 'en-US',

--- a/src/feeds/atom/generate/utils.ts
+++ b/src/feeds/atom/generate/utils.ts
@@ -1,4 +1,5 @@
-import { isPlainObject } from 'trousse'
+import { XMLValidator } from 'fast-xml-parser'
+import { escapeHtml, isNonEmptyString, isPlainObject } from 'trousse'
 import { namespaceUris } from '../../../common/config.js'
 import type { DateLike } from '../../../common/types.js'
 import {
@@ -57,16 +58,67 @@ export const createNamespaceSetter = (prefix: string | undefined) => {
   return (key: string) => (prefix ? `${prefix}${key}` : key)
 }
 
+// A `type="xhtml"` construct must hold its markup as XML inside a single div (RFC 4287
+// §3.1.1.3), not as escaped text or CDATA, so the value is wrapped in the div. The builder
+// emits these constructs raw (see the stop nodes in config.ts), which is only correct when
+// the wrapped value is well-formed XML. A value that is not (unclosed HTML tags, bare `&`)
+// is escaped here instead, since the builder will not touch it either way: the document
+// stays valid at the cost of the construct staying non-conformant.
+export const generateXhtmlValue: GenerateUtil<string> = (value) => {
+  if (!isNonEmptyString(value)) {
+    return
+  }
+
+  const wrapped = `<div xmlns="http://www.w3.org/1999/xhtml">${value.trim()}</div>`
+
+  if (XMLValidator.validate(wrapped) !== true) {
+    return { '#text': escapeHtml(value.trim()) }
+  }
+
+  return { '#text': wrapped }
+}
+
+// A construct emitted raw by the builder (see the stop nodes in config.ts) has its
+// attributes emitted verbatim too, so their values are escaped here. Constructs of every
+// other type go through the builder's own attribute encoding, which would double-escape.
+const escapeStopNodeAttributes = <T extends Record<string, unknown>>(value: T): T => {
+  if (value['@type'] !== 'xhtml') {
+    return value
+  }
+
+  const escaped: Record<string, unknown> = {}
+
+  // biome-ignore lint/suspicious/noForIn: Plain object; avoids per-call Object.keys allocation.
+  for (const key in value) {
+    const attribute = value[key]
+
+    escaped[key] =
+      key.charCodeAt(0) === 64 && typeof attribute === 'string' ? escapeHtml(attribute) : attribute
+  }
+
+  return escaped as T
+}
+
+// The type decides both the routing and the emitted attribute, so it is normalized once:
+// a padded ` xhtml` would otherwise take the escaped path while the trimmed attribute
+// matches the stop node, and the builder would serialize the CDATA key as an element.
+const generateTypedValue = (value: string | undefined, type: string | undefined) => {
+  return type === 'xhtml' ? generateXhtmlValue(value) : generateTextOrCdataString(value)
+}
+
 export const generateText: GenerateUtil<AtomFeed.Text> = (text) => {
   if (!isPlainObject(text)) {
     return
   }
 
-  return trimObject({
-    ...generateTextOrCdataString(text.value),
-    '@type': generatePlainString(text.type),
+  const type = generatePlainString(text.type)
+  const value = {
+    ...generateTypedValue(text.value, type),
+    '@type': type,
     ...generateXmlItemOrFeed(text.xml),
-  })
+  }
+
+  return trimObject(escapeStopNodeAttributes(value))
 }
 
 export const generateContent: GenerateUtil<AtomFeed.Content> = (content) => {
@@ -74,14 +126,15 @@ export const generateContent: GenerateUtil<AtomFeed.Content> = (content) => {
     return
   }
 
+  const type = generatePlainString(content.type)
   const value = {
-    ...generateTextOrCdataString(content.value),
-    '@type': generatePlainString(content.type),
+    ...generateTypedValue(content.value, type),
+    '@type': type,
     '@src': generatePlainString(content.src),
     ...generateXmlItemOrFeed(content.xml),
   }
 
-  return trimObject(value)
+  return trimObject(escapeStopNodeAttributes(value))
 }
 
 export const generateLink: GenerateUtil<AtomFeed.Link<DateLike>> = (link) => {

--- a/src/feeds/atom/generate/utils.ts
+++ b/src/feeds/atom/generate/utils.ts
@@ -9,6 +9,7 @@ import {
   generatePlainString,
   generateRfc3339Date,
   generateTextOrCdataString,
+  isXmlAttributeKey,
   trimArray,
   trimObject,
 } from '../../../common/utils.js'
@@ -91,10 +92,9 @@ const escapeStopNodeAttributes = <T extends Record<string, unknown>>(value: T): 
   // biome-ignore lint/suspicious/noForIn: Plain object; avoids per-call Object.keys allocation.
   for (const key in value) {
     const attribute = value[key]
-    // Attribute keys start with `@` (charCode 64); everything else is element content.
-    const isStringAttribute = key.charCodeAt(0) === 64 && typeof attribute === 'string'
 
-    escaped[key] = isStringAttribute ? escapeHtml(attribute) : attribute
+    escaped[key] =
+      isXmlAttributeKey(key) && typeof attribute === 'string' ? escapeHtml(attribute) : attribute
   }
 
   return escaped as T

--- a/src/feeds/atom/generate/utils.ts
+++ b/src/feeds/atom/generate/utils.ts
@@ -91,9 +91,10 @@ const escapeStopNodeAttributes = <T extends Record<string, unknown>>(value: T): 
   // biome-ignore lint/suspicious/noForIn: Plain object; avoids per-call Object.keys allocation.
   for (const key in value) {
     const attribute = value[key]
+    // Attribute keys start with `@` (charCode 64); everything else is element content.
+    const isStringAttribute = key.charCodeAt(0) === 64 && typeof attribute === 'string'
 
-    escaped[key] =
-      key.charCodeAt(0) === 64 && typeof attribute === 'string' ? escapeHtml(attribute) : attribute
+    escaped[key] = isStringAttribute ? escapeHtml(attribute) : attribute
   }
 
   return escaped as T

--- a/src/namespaces/atom/common/config.ts
+++ b/src/namespaces/atom/common/config.ts
@@ -6,3 +6,13 @@ export const uris = [
   'http://purl.org/atom/ns#', // Official URI (Atom 0.3).
   'https://purl.org/atom/ns#',
 ]
+
+// The elements that can carry a type="xhtml" value with inline markup.
+export const textConstructs = [
+  'title',
+  'subtitle',
+  'tagline', // Atom 0.3.
+  'rights',
+  'summary',
+  'content',
+]

--- a/src/namespaces/atom/common/config.ts
+++ b/src/namespaces/atom/common/config.ts
@@ -7,12 +7,6 @@ export const uris = [
   'https://purl.org/atom/ns#',
 ]
 
-// The elements that can carry a type="xhtml" value with inline markup.
-export const textConstructs = [
-  'title',
-  'subtitle',
-  'tagline', // Atom 0.3.
-  'rights',
-  'summary',
-  'content',
-]
+// The elements that can carry a type="xhtml" value with inline markup. Atom 0.3's tagline
+// is left out: generated feeds are normalized to 1.0, so its stop node would never match.
+export const textConstructs = ['title', 'subtitle', 'rights', 'summary', 'content']

--- a/src/namespaces/rawvoice/parse/utils.ts
+++ b/src/namespaces/rawvoice/parse/utils.ts
@@ -1,6 +1,7 @@
 import { isPlainObject } from 'trousse'
 import type { DateAny, ParseMainOptions, ParseUtilPartial } from '../../../common/types.js'
 import {
+  isXmlAttributeKey,
   parseArrayOf,
   parseDate,
   parseNumber,
@@ -71,7 +72,7 @@ export const parseSubscribe: ParseUtilPartial<RawVoiceNs.Subscribe> = (value) =>
 
   // biome-ignore lint/suspicious/noForIn: Plain object; avoids per-call Object.keys allocation.
   for (const key in value) {
-    if (key.startsWith('@')) {
+    if (isXmlAttributeKey(key)) {
       const attrName = key.slice(1)
       const attrValue = parseString(value[key])
       if (attrValue) {


### PR DESCRIPTION
Stacked on #331; base retargets as the stack merges.

RFC 4287 requires a `type="xhtml"` value to be XML markup inside a single div. We emitted it as escaped text or CDATA, which is character data, so every generated xhtml construct was non-conformant. This also closes the round trip #329 opened: parse strips the div, generate has to put it back.

`generateXhtmlValue` wraps the value in `<div xmlns="http://www.w3.org/1999/xhtml">`, and the Atom builder declares stop nodes (`..title[type=xhtml]` and the other four text constructs, derived from `textConstructs`) so the builder emits the wrapped value raw. `XMLValidator` gates it: a value that is not well-formed XML falls back to the escaped form (#334 refines that fallback to `type="html"`).

Two consequences of the stop-node path, both handled here:

- The builder skips entity encoding on a stop node's attributes as well as its content, so `xml:base` and friends are escaped before they reach it. Without that, a `&` in a base URL produced malformed XML and a `"` let user data open new attributes.
- The type decides both the routing and the emitted attribute, so it is normalized once. A padded `' xhtml'` otherwise took the CDATA path while the trimmed attribute matched the stop node, and the builder serialized the `#cdata` key as a literal `<#cdata>` element.

Cosmetic trade-off: the builder gives raw content its own line and no indentation, so a construct reads `<title type="xhtml">` / `<div …>…</div>  </title>`. The whitespace sits outside the div, where §3.1.1.3 gives it no meaning, and parsing trims it.
