### PR TITLE
fix: Harden Atom xhtml handling for real-world feed shapes

### DIFF
--- a/docs/migration/v2-to-v3.md
+++ b/docs/migration/v2-to-v3.md
@@ -258,7 +258,7 @@ const xml = generateAtomFeed({
 
 ### Atom `type="xhtml"` Values Are Now Plain HTML
 
-Parsing of `type="xhtml"` text constructs and content now conforms to [RFC 4287 §3.1.1.3](https://www.rfc-editor.org/rfc/rfc4287#section-3.1.1.3), and the parsed value is the plain HTML the spec describes. Three things changed:
+Parsing of `type="xhtml"` text constructs and content now conforms to [RFC 4287 §3.1.1.3](https://www.rfc-editor.org/rfc/rfc4287#section-3.1.1.3), and the parsed value is the plain HTML the spec describes. The same applies to `type="application/xhtml+xml"` (the Atom 0.3 spelling) and to Atom text constructs embedded in RSS items. Three things changed:
 
 - The wrapper `<div>` is stripped: the spec excludes it from the content
 - The `xhtml:` prefix is removed from every tag when the feed binds the XHTML namespace to a prefix
@@ -286,13 +286,13 @@ const content = feed.entries?.[0]?.content?.value
 // '<p>a &lt; b</p>'
 ```
 
-Generating follows the same rule in the other direction. A text construct or content with `type="xhtml"` is emitted as markup inside a single `<div xmlns="http://www.w3.org/1999/xhtml">` wrapper, where it was previously written as escaped text or CDATA. The value must be well-formed XML for this: a value that is not (unclosed tags like `<br>`, a bare `&`) keeps the previous escaped form, which stays parseable everywhere but does not conform to the spec.
+Generating works in the other direction: a `type="xhtml"` value is emitted as markup inside a single `<div xmlns="http://www.w3.org/1999/xhtml">` wrapper instead of as escaped text or CDATA. A value that is not well-formed XML (unclosed tags like `<br>`, a bare `&`, an HTML-only entity like `&nbsp;`) is emitted as escaped text under `type="html"` instead.
 
 #### Migration Steps
 1. Drop any code that strips the wrapper `<div>` or the `xhtml:` prefix: the parser does it
 2. Render the value as HTML, not as XML
 3. Note that a construct whose wrapper is empty (`<div/>`) now yields no value at all: `entry.content` keeps its other fields but loses `value`, while `title`, `summary`, `subtitle`, and `rights` become `undefined`
-4. When generating with `type="xhtml"`, pass the inner markup without the wrapper `<div>` and keep it well-formed (XHTML-style closed tags) so it can be embedded as XML
+4. When generating with `type="xhtml"`, pass the inner markup without the wrapper `<div>` and keep it well-formed (XHTML-style closed tags)
 
 ### RSS Person Fields Changed from Strings to Objects
 

--- a/src/common/config.ts
+++ b/src/common/config.ts
@@ -12,7 +12,7 @@ import {
   stopNodes as arxivStopNodes,
   uris as arxivUris,
 } from '../namespaces/arxiv/common/config.js'
-import { uris as atomUris } from '../namespaces/atom/common/config.js'
+import { stopNodes as atomStopNodes, uris as atomUris } from '../namespaces/atom/common/config.js'
 import {
   stopNodes as blogchannelStopNodes,
   uris as blogchannelUris,
@@ -185,6 +185,7 @@ export const namespaceStopNodes = [
   ...adminStopNodes,
   ...appStopNodes,
   ...arxivStopNodes,
+  ...atomStopNodes,
   ...blogchannelStopNodes,
   ...ccStopNodes,
   ...contentStopNodes,

--- a/src/feeds/atom/generate/config.ts
+++ b/src/feeds/atom/generate/config.ts
@@ -2,10 +2,10 @@ import { XMLBuilder } from 'fast-xml-parser'
 import { builderConfig } from '../../../common/config.js'
 import { textConstructs } from '../../../namespaces/atom/common/config.js'
 
-// A `type="xhtml"` construct holds its value as raw markup (see generateXhtmlValue in
-// utils.ts), so the builder must not entity-encode it. Stop nodes match on the type
-// attribute, leaving constructs of every other type on the normal escaping path.
 export const builder = new XMLBuilder({
   ...builderConfig,
+  // A `type="xhtml"` construct holds its value as raw markup (see generateXhtmlValue in
+  // utils.ts), so the builder must not entity-encode it. Stop nodes match on the type
+  // attribute, leaving constructs of every other type on the normal escaping path.
   stopNodes: textConstructs.map((element) => `..${element}[type=xhtml]`),
 })

--- a/src/feeds/atom/generate/index.test.ts
+++ b/src/feeds/atom/generate/index.test.ts
@@ -59,11 +59,13 @@ describe('generate', () => {
 <feed xmlns="http://www.w3.org/2005/Atom">
   <id>https://example.com/feed</id>
   <title type="xhtml">
-<div xmlns="http://www.w3.org/1999/xhtml"><p>a &lt; b <em>ok</em></p></div>  </title>
+<div xmlns="http://www.w3.org/1999/xhtml"><p>a &lt; b <em>ok</em></p></div>
+  </title>
   <updated>2023-03-15T12:00:00.000Z</updated>
   <entry>
     <content type="xhtml">
-<div xmlns="http://www.w3.org/1999/xhtml"><p>Rich <strong>content</strong></p></div>    </content>
+<div xmlns="http://www.w3.org/1999/xhtml"><p>Rich <strong>content</strong></p></div>
+    </content>
     <id>https://example.com/entry</id>
     <title>Entry</title>
     <updated>2023-03-15T12:00:00.000Z</updated>

--- a/src/feeds/atom/generate/index.test.ts
+++ b/src/feeds/atom/generate/index.test.ts
@@ -74,7 +74,7 @@ describe('generate', () => {
     expect(generate(value)).toEqual(expected)
   })
 
-  it('should escape an xhtml value that is not well-formed XML instead of wrapping it', () => {
+  it('should emit an xhtml value that is not well-formed XML as type html', () => {
     const value = {
       id: 'https://example.com/feed',
       title: {
@@ -86,7 +86,9 @@ describe('generate', () => {
     const expected = `<?xml version="1.0" encoding="utf-8"?>
 <feed xmlns="http://www.w3.org/2005/Atom">
   <id>https://example.com/feed</id>
-  <title type="xhtml">&lt;p&gt;Hello&lt;br&gt;world&lt;/p&gt;</title>
+  <title type="html">
+    <![CDATA[<p>Hello<br>world</p>]]>
+  </title>
   <updated>2023-03-15T12:00:00.000Z</updated>
 </feed>
 `

--- a/src/feeds/atom/generate/utils.test.ts
+++ b/src/feeds/atom/generate/utils.test.ts
@@ -59,9 +59,40 @@ describe('generateXhtmlValue', () => {
     expect(generateXhtmlValue(value)).toEqual(expected)
   })
 
-  it('should escape a value that is not well-formed XML instead of wrapping it', () => {
-    const value = '<p>Hello<br>world</p>'
-    const expected = { '#text': '&lt;p&gt;Hello&lt;br&gt;world&lt;/p&gt;' }
+  it('should return undefined when the value is not well-formed XML', () => {
+    expect(generateXhtmlValue('<p>Hello<br>world</p>')).toBeUndefined()
+  })
+
+  it('should return undefined when the value carries an HTML-only entity', () => {
+    expect(generateXhtmlValue('<p>a&nbsp;b</p>')).toBeUndefined()
+  })
+
+  it('should return undefined for entity names XML cannot resolve', () => {
+    expect(generateXhtmlValue('<p>a&_foo;b</p>')).toBeUndefined()
+    expect(generateXhtmlValue('<p>a&my-entity;b</p>')).toBeUndefined()
+  })
+
+  it('should return undefined for malformed character references', () => {
+    expect(generateXhtmlValue('<p>a&#;b</p>')).toBeUndefined()
+    expect(generateXhtmlValue('<p>a&#x;b</p>')).toBeUndefined()
+    // XML allows only a lowercase x in a character reference.
+    expect(generateXhtmlValue('<p>a&#X41;b</p>')).toBeUndefined()
+  })
+
+  it('should keep the predefined entities and valid character references', () => {
+    const value = '<p>a&amp;b &#13; &#x1F600;</p>'
+    const expected = {
+      '#text': '<div xmlns="http://www.w3.org/1999/xhtml"><p>a&amp;b &#13; &#x1F600;</p></div>',
+    }
+
+    expect(generateXhtmlValue(value)).toEqual(expected)
+  })
+
+  it('should encode a carriage return as a character reference', () => {
+    const value = '<p>a\r\nb</p>'
+    const expected = {
+      '#text': '<div xmlns="http://www.w3.org/1999/xhtml"><p>a&#13;\nb</p></div>',
+    }
 
     expect(generateXhtmlValue(value)).toEqual(expected)
   })

--- a/src/feeds/atom/generate/utils.test.ts
+++ b/src/feeds/atom/generate/utils.test.ts
@@ -59,8 +59,22 @@ describe('generateXhtmlValue', () => {
     expect(generateXhtmlValue(value)).toEqual(expected)
   })
 
+  it('should keep entities escaped in a well-formed value', () => {
+    const value = '<p>a &lt; b &amp; c &#60;d&#62;</p>'
+    const expected = {
+      '#text':
+        '<div xmlns="http://www.w3.org/1999/xhtml"><p>a &lt; b &amp; c &#60;d&#62;</p></div>',
+    }
+
+    expect(generateXhtmlValue(value)).toEqual(expected)
+  })
+
   it('should return undefined when the value is not well-formed XML', () => {
     expect(generateXhtmlValue('<p>Hello<br>world</p>')).toBeUndefined()
+  })
+
+  it('should return undefined when the value closes the wrapper early', () => {
+    expect(generateXhtmlValue('</div><p>injected</p>')).toBeUndefined()
   })
 
   it('should return undefined when the value carries an HTML-only entity', () => {
@@ -120,6 +134,28 @@ describe('generateText', () => {
     expect(generateText(value)).toEqual(expected)
   })
 
+  it('should escape a quote in attribute values of an xhtml construct', () => {
+    const value = {
+      value: '<p>ok</p>',
+      type: 'xhtml',
+      xml: { base: 'https://example.com/a"b' },
+    }
+    const expected = {
+      '#text': '<div xmlns="http://www.w3.org/1999/xhtml"><p>ok</p></div>',
+      '@type': 'xhtml',
+      '@xml:base': 'https://example.com/a&quot;b',
+    }
+
+    expect(generateText(value)).toEqual(expected)
+  })
+
+  it('should emit a value that is not well-formed XML as type html', () => {
+    const value = { value: '<p>Hello<br>world</p>', type: 'xhtml' }
+    const expected = { '#cdata': '<p>Hello<br>world</p>', '@type': 'html' }
+
+    expect(generateText(value)).toEqual(expected)
+  })
+
   it('should route a padded type to the same path as the emitted attribute', () => {
     const value = { value: '<p>ok</p>', type: ' xhtml' }
     const expected = {
@@ -168,6 +204,12 @@ describe('generateText', () => {
     const value = { value: '   ' }
 
     expect(generateText(value)).toBeUndefined()
+  })
+
+  it('should return undefined for an empty value with a type', () => {
+    expect(generateText({ value: '', type: 'xhtml' })).toBeUndefined()
+    expect(generateText({ value: '   ', type: 'xhtml' })).toBeUndefined()
+    expect(generateText({ value: '', type: 'text' })).toBeUndefined()
   })
 
   it('should return undefined for non-object input', () => {
@@ -238,6 +280,13 @@ describe('generateContent', () => {
       '@type': 'html',
       '@src': 'https://example.com/content',
     }
+
+    expect(generateContent(value)).toEqual(expected)
+  })
+
+  it('should emit a value that is not well-formed XML as type html', () => {
+    const value = { value: '<p>Hello<br>world</p>', type: 'xhtml' }
+    const expected = { '#cdata': '<p>Hello<br>world</p>', '@type': 'html' }
 
     expect(generateContent(value)).toEqual(expected)
   })

--- a/src/feeds/atom/generate/utils.test.ts
+++ b/src/feeds/atom/generate/utils.test.ts
@@ -53,7 +53,7 @@ describe('generateXhtmlValue', () => {
   it('should wrap a well-formed value in a div', () => {
     const value = '<p>Text</p>'
     const expected = {
-      '#text': '<div xmlns="http://www.w3.org/1999/xhtml"><p>Text</p></div>',
+      '#text': '<div xmlns="http://www.w3.org/1999/xhtml"><p>Text</p></div>\n',
     }
 
     expect(generateXhtmlValue(value)).toEqual(expected)
@@ -63,7 +63,7 @@ describe('generateXhtmlValue', () => {
     const value = '<p>a &lt; b &amp; c &#60;d&#62;</p>'
     const expected = {
       '#text':
-        '<div xmlns="http://www.w3.org/1999/xhtml"><p>a &lt; b &amp; c &#60;d&#62;</p></div>',
+        '<div xmlns="http://www.w3.org/1999/xhtml"><p>a &lt; b &amp; c &#60;d&#62;</p></div>\n',
     }
 
     expect(generateXhtmlValue(value)).toEqual(expected)
@@ -96,7 +96,7 @@ describe('generateXhtmlValue', () => {
   it('should keep the predefined entities and valid character references', () => {
     const value = '<p>a&amp;b &#13; &#x1F600;</p>'
     const expected = {
-      '#text': '<div xmlns="http://www.w3.org/1999/xhtml"><p>a&amp;b &#13; &#x1F600;</p></div>',
+      '#text': '<div xmlns="http://www.w3.org/1999/xhtml"><p>a&amp;b &#13; &#x1F600;</p></div>\n',
     }
 
     expect(generateXhtmlValue(value)).toEqual(expected)
@@ -105,7 +105,7 @@ describe('generateXhtmlValue', () => {
   it('should encode a carriage return as a character reference', () => {
     const value = '<p>a\r\nb</p>'
     const expected = {
-      '#text': '<div xmlns="http://www.w3.org/1999/xhtml"><p>a&#13;\nb</p></div>',
+      '#text': '<div xmlns="http://www.w3.org/1999/xhtml"><p>a&#13;\nb</p></div>\n',
     }
 
     expect(generateXhtmlValue(value)).toEqual(expected)
@@ -126,7 +126,7 @@ describe('generateText', () => {
       xml: { base: 'https://example.com/a?b=1&c=2' },
     }
     const expected = {
-      '#text': '<div xmlns="http://www.w3.org/1999/xhtml"><p>ok</p></div>',
+      '#text': '<div xmlns="http://www.w3.org/1999/xhtml"><p>ok</p></div>\n',
       '@type': 'xhtml',
       '@xml:base': 'https://example.com/a?b=1&amp;c=2',
     }
@@ -141,7 +141,7 @@ describe('generateText', () => {
       xml: { base: 'https://example.com/a"b' },
     }
     const expected = {
-      '#text': '<div xmlns="http://www.w3.org/1999/xhtml"><p>ok</p></div>',
+      '#text': '<div xmlns="http://www.w3.org/1999/xhtml"><p>ok</p></div>\n',
       '@type': 'xhtml',
       '@xml:base': 'https://example.com/a&quot;b',
     }
@@ -159,7 +159,7 @@ describe('generateText', () => {
   it('should route a padded type to the same path as the emitted attribute', () => {
     const value = { value: '<p>ok</p>', type: ' xhtml' }
     const expected = {
-      '#text': '<div xmlns="http://www.w3.org/1999/xhtml"><p>ok</p></div>',
+      '#text': '<div xmlns="http://www.w3.org/1999/xhtml"><p>ok</p></div>\n',
       '@type': 'xhtml',
     }
 
@@ -324,7 +324,7 @@ describe('generateContent', () => {
       },
     }
     const expected = {
-      '#text': '<div xmlns="http://www.w3.org/1999/xhtml"><div>XHTML content</div></div>',
+      '#text': '<div xmlns="http://www.w3.org/1999/xhtml"><div>XHTML content</div></div>\n',
       '@type': 'xhtml',
       '@xml:base': 'http://example.org/entry/1',
       '@xml:lang': 'en-US',

--- a/src/feeds/atom/generate/utils.ts
+++ b/src/feeds/atom/generate/utils.ts
@@ -85,7 +85,9 @@ export const generateXhtmlValue: GenerateUtil<string> = (value) => {
     return
   }
 
-  return { '#text': wrapped }
+  // The builder emits this value raw and puts the closing tag right after it; the newline
+  // lets that tag land indented on its own line instead of glued to the div.
+  return { '#text': `${wrapped}\n` }
 }
 
 // A construct emitted raw by the builder (see the stop nodes in config.ts) has its

--- a/src/feeds/atom/generate/utils.ts
+++ b/src/feeds/atom/generate/utils.ts
@@ -62,18 +62,27 @@ export const createNamespaceSetter = (prefix: string | undefined) => {
 // A `type="xhtml"` construct must hold its markup as XML inside a single div (RFC 4287
 // §3.1.1.3), not as escaped text or CDATA, so the value is wrapped in the div. The builder
 // emits these constructs raw (see the stop nodes in config.ts), which is only correct when
-// the wrapped value is well-formed XML. A value that is not (unclosed HTML tags, bare `&`)
-// is escaped here instead, since the builder will not touch it either way: the document
-// stays valid at the cost of the construct staying non-conformant.
+// the wrapped value is well-formed XML.
+
+// XMLValidator accepts entity references it cannot resolve, but a document without a DTD
+// can only resolve the five predefined entities and numeric references; anything else,
+// `&nbsp;` included, leaves it not well-formed for strict parsers. Any other name-shaped
+// reference is matched, since flagging one too many only routes the value to the escaped
+// fallback while missing one emits markup that will not parse.
+const nonXmlEntityRegex = /&(?!(?:amp|lt|gt|quot|apos);|#\d+;|#x[0-9a-fA-F]+;)[^;\s&<]+;/
+
 export const generateXhtmlValue: GenerateUtil<string> = (value) => {
   if (!isNonEmptyString(value)) {
     return
   }
 
-  const wrapped = `<div xmlns="http://www.w3.org/1999/xhtml">${value.trim()}</div>`
+  // A literal carriage return would be normalized away by the reading XML parser
+  // (XML §2.11); the character reference survives, so the value round-trips exactly.
+  const inner = value.trim().replace(/\r/g, '&#13;')
+  const wrapped = `<div xmlns="http://www.w3.org/1999/xhtml">${inner}</div>`
 
-  if (XMLValidator.validate(wrapped) !== true) {
-    return { '#text': escapeHtml(value.trim()) }
+  if (XMLValidator.validate(wrapped) !== true || nonXmlEntityRegex.test(wrapped)) {
+    return
   }
 
   return { '#text': wrapped }
@@ -100,11 +109,26 @@ const escapeStopNodeAttributes = <T extends Record<string, unknown>>(value: T): 
   return escaped as T
 }
 
-// The type decides both the routing and the emitted attribute, so it is normalized once:
-// a padded ` xhtml` would otherwise take the escaped path while the trimmed attribute
-// matches the stop node, and the builder would serialize the CDATA key as an element.
-const generateTypedValue = (value: string | undefined, type: string | undefined) => {
-  return type === 'xhtml' ? generateXhtmlValue(value) : generateTextOrCdataString(value)
+// A value that cannot be embedded as XML (unclosed HTML tags, a bare `&`, an HTML-only
+// entity) is emitted as type="html" instead: an xhtml construct without its div is invalid,
+// while escaped markup under type="html" is the conformant spelling of the same value.
+// The type is normalized once and decides both the routing and the emitted attribute: a
+// padded ` xhtml` would otherwise take the escaped path while the trimmed attribute matches
+// the stop node, and the builder would serialize the CDATA key as an element.
+const generateTypedText = (value: string | undefined, rawType: string | undefined) => {
+  const type = generatePlainString(rawType)
+
+  if (type !== 'xhtml') {
+    return { ...generateTextOrCdataString(value), '@type': type }
+  }
+
+  const xhtml = generateXhtmlValue(value)
+
+  if (xhtml || !isNonEmptyString(value)) {
+    return { ...xhtml, '@type': 'xhtml' }
+  }
+
+  return { ...generateTextOrCdataString(value), '@type': 'html' }
 }
 
 export const generateText: GenerateUtil<AtomFeed.Text> = (text) => {
@@ -112,10 +136,8 @@ export const generateText: GenerateUtil<AtomFeed.Text> = (text) => {
     return
   }
 
-  const type = generatePlainString(text.type)
   const value = {
-    ...generateTypedValue(text.value, type),
-    '@type': type,
+    ...generateTypedText(text.value, text.type),
     ...generateXmlItemOrFeed(text.xml),
   }
 
@@ -127,10 +149,8 @@ export const generateContent: GenerateUtil<AtomFeed.Content> = (content) => {
     return
   }
 
-  const type = generatePlainString(content.type)
   const value = {
-    ...generateTypedValue(content.value, type),
-    '@type': type,
+    ...generateTypedText(content.value, content.type),
     '@src': generatePlainString(content.src),
     ...generateXmlItemOrFeed(content.xml),
   }

--- a/src/feeds/atom/generate/utils.ts
+++ b/src/feeds/atom/generate/utils.ts
@@ -136,8 +136,17 @@ export const generateText: GenerateUtil<AtomFeed.Text> = (text) => {
     return
   }
 
+  const typed = generateTypedText(text.value, text.type)
+
+  // A text construct carries nothing but its value, so without one there is no element to
+  // emit: a bare `type="xhtml"` would even violate the single-div content model. Content
+  // differs here, since `src` makes an empty element meaningful.
+  if (!typed?.['#text'] && !typed?.['#cdata']) {
+    return
+  }
+
   const value = {
-    ...generateTypedText(text.value, text.type),
+    ...typed,
     ...generateXmlItemOrFeed(text.xml),
   }
 

--- a/src/feeds/atom/parse/config.ts
+++ b/src/feeds/atom/parse/config.ts
@@ -6,68 +6,12 @@ import {
   parserConfig,
 } from '../../../common/config.js'
 import { createNamespaceNormalizator } from '../../../common/utils.js'
+import { entryPaths, feedPaths } from '../../../namespaces/atom/common/config.js'
 
 export const stopNodes = [
   ...namespaceStopNodes,
-  'feed.author.name',
-  'feed.author.uri',
-  'feed.author.url', // Atom 0.3.
-  'feed.author.email',
-  'feed.category',
-  'feed.contributor.name',
-  'feed.contributor.uri',
-  'feed.contributor.url', // Atom 0.3.
-  'feed.contributor.email',
-  'feed.generator',
-  'feed.icon',
-  'feed.id',
-  'feed.link',
-  'feed.logo',
-  'feed.rights',
-  'feed.subtitle',
-  'feed.tagline', // Atom 0.3.
-  'feed.title',
-  'feed.updated',
-  'feed.modified', // Atom 0.3.
-  'feed.entry.author.name',
-  'feed.entry.author.uri',
-  'feed.entry.author.url', // Atom 0.3.
-  'feed.entry.author.email',
-  'feed.entry.category',
-  'feed.entry.content',
-  'feed.entry.contributor.name',
-  'feed.entry.contributor.uri',
-  'feed.entry.contributor.url', // Atom 0.3.
-  'feed.entry.contributor.email',
-  'feed.entry.id',
-  'feed.entry.link',
-  'feed.entry.published',
-  'feed.entry.issued', // Atom 0.3.
-  'feed.entry.created', // Atom 0.3.
-  'feed.entry.rights',
-  'feed.entry.source.author.name',
-  'feed.entry.source.author.uri',
-  'feed.entry.source.author.url', // Atom 0.3.
-  'feed.entry.source.author.email',
-  'feed.entry.source.category',
-  'feed.entry.source.contributor.name',
-  'feed.entry.source.contributor.uri',
-  'feed.entry.source.contributor.url', // Atom 0.3.
-  'feed.entry.source.contributor.email',
-  'feed.entry.source.generator',
-  'feed.entry.source.icon',
-  'feed.entry.source.id',
-  'feed.entry.source.link',
-  'feed.entry.source.logo',
-  'feed.entry.source.rights',
-  'feed.entry.source.subtitle',
-  'feed.entry.source.title',
-  'feed.entry.source.updated',
-  'feed.entry.source.modified', // Atom 0.3.
-  'feed.entry.summary',
-  'feed.entry.title',
-  'feed.entry.updated',
-  'feed.entry.modified', // Atom 0.3.
+  ...feedPaths.map((path) => `feed.${path}`),
+  ...entryPaths.map((path) => `feed.entry.${path}`),
 ]
 
 export const parser = new XMLParser({

--- a/src/feeds/atom/parse/index.test.ts
+++ b/src/feeds/atom/parse/index.test.ts
@@ -200,11 +200,11 @@ describe('parse', () => {
     const value = `
       <?xml version="1.0" encoding="utf-8"?>
       <atom:feed atom:xmlns="http://www.w3.org/2005/Atom">
-        <atom:title>Example Feed</title>
-        <atom:id>example-feed</id>
+        <atom:title>Example Feed</atom:title>
+        <atom:id>example-feed</atom:id>
         <atom:entry>
-          <atom:title>Example Entry</title>
-          <atom:id>example-entry</id>
+          <atom:title>Example Entry</atom:title>
+          <atom:id>example-entry</atom:id>
         </atom:entry>
       </atom:feed>
     `

--- a/src/feeds/atom/parse/utils.test.ts
+++ b/src/feeds/atom/parse/utils.test.ts
@@ -191,6 +191,12 @@ describe('unwrapXhtmlDiv', () => {
     expect(unwrapXhtmlDiv(value)).toBe(value)
   })
 
+  it('should return value unchanged when a stray closing tag splits the scan', () => {
+    const value = '<div>First</div></x-wrap><div>Second</div>'
+
+    expect(unwrapXhtmlDiv(value)).toBe(value)
+  })
+
   it('should return value unchanged when text follows the wrapper', () => {
     const value = '<div>Text</div> trailing'
 

--- a/src/feeds/atom/parse/utils.test.ts
+++ b/src/feeds/atom/parse/utils.test.ts
@@ -171,6 +171,33 @@ describe('unwrapXhtmlDiv', () => {
     expect(unwrapXhtmlDiv(value)).toBe(value)
   })
 
+  it('should unwrap when a comment holds a div-like string', () => {
+    const value = '<div>hi<!-- </div> --></div>'
+    const expected = 'hi<!-- </div> -->'
+
+    expect(unwrapXhtmlDiv(value)).toBe(expected)
+  })
+
+  it('should unwrap a prefixed div whose prefix contains a dot', () => {
+    const value = '<x.y:div xmlns:x.y="http://www.w3.org/1999/xhtml"><x.y:p>Text</x.y:p></x.y:div>'
+    const expected = '<p>Text</p>'
+
+    expect(unwrapXhtmlDiv(value)).toBe(expected)
+  })
+
+  it('should return value unchanged for sibling top-level divs', () => {
+    const value = '<div>First</div><div>Second</div>'
+
+    expect(unwrapXhtmlDiv(value)).toBe(value)
+  })
+
+  it('should unwrap a div whose attribute value contains a closing angle bracket', () => {
+    const value = '<div title="a>b"><p>Text</p></div>'
+    const expected = '<p>Text</p>'
+
+    expect(unwrapXhtmlDiv(value)).toBe(expected)
+  })
+
   it('should return non-string values unchanged', () => {
     expect(unwrapXhtmlDiv(undefined)).toBeUndefined()
     expect(unwrapXhtmlDiv(123)).toBe(123)
@@ -278,6 +305,43 @@ describe('parseTypedText', () => {
         '<xhtml:div xmlns:xhtml="http://www.w3.org/1999/xhtml"><xhtml:p>a &lt; b</xhtml:p></xhtml:div>',
     }
     const expected = '<p>a &lt; b</p>'
+
+    expect(parseTypedText(value, 'xhtml')).toBe(expected)
+  })
+
+  it('should unwrap the div wrapper when the type is application/xhtml+xml', () => {
+    const value = {
+      '#text': '<div xmlns="http://www.w3.org/1999/xhtml"><p>a &lt; b</p></div>',
+    }
+    const expected = '<p>a &lt; b</p>'
+
+    expect(parseTypedText(value, 'application/xhtml+xml')).toBe(expected)
+  })
+
+  it('should decode entities when an application/xhtml+xml construct has no wrapper', () => {
+    const value = { '#text': '&lt;p&gt;Hello&lt;/p&gt;' }
+    const expected = '<p>Hello</p>'
+
+    expect(parseTypedText(value, 'application/xhtml+xml')).toBe(expected)
+  })
+
+  it('should unwrap when a CDATA section holds a div-like string', () => {
+    const value = { '#text': '<div><p>code: <![CDATA[</div>]]></p></div>' }
+    const expected = '<p>code: &lt;/div></p>'
+
+    expect(parseTypedText(value, 'xhtml')).toBe(expected)
+  })
+
+  it('should keep an unquoted-attribute wrapper verbatim instead of decoding it', () => {
+    const value = { '#text': '<div class=foo><p>5 &lt; 6</p></div>' }
+    const expected = '<div class=foo><p>5 &lt; 6</p></div>'
+
+    expect(parseTypedText(value, 'xhtml')).toBe(expected)
+  })
+
+  it('should keep a sibling-div value verbatim without unwrapping', () => {
+    const value = { '#text': '<div>a &lt; b</div><div>Second</div>' }
+    const expected = '<div>a &lt; b</div><div>Second</div>'
 
     expect(parseTypedText(value, 'xhtml')).toBe(expected)
   })

--- a/src/feeds/atom/parse/utils.test.ts
+++ b/src/feeds/atom/parse/utils.test.ts
@@ -191,6 +191,18 @@ describe('unwrapXhtmlDiv', () => {
     expect(unwrapXhtmlDiv(value)).toBe(value)
   })
 
+  it('should return value unchanged when text follows the wrapper', () => {
+    const value = '<div>Text</div> trailing'
+
+    expect(unwrapXhtmlDiv(value)).toBe(value)
+  })
+
+  it('should return value unchanged when a comment follows the wrapper', () => {
+    const value = '<div>Text</div><!-- comment -->'
+
+    expect(unwrapXhtmlDiv(value)).toBe(value)
+  })
+
   it('should unwrap a div whose attribute value contains a closing angle bracket', () => {
     const value = '<div title="a>b"><p>Text</p></div>'
     const expected = '<p>Text</p>'
@@ -332,9 +344,9 @@ describe('parseTypedText', () => {
     expect(parseTypedText(value, 'xhtml')).toBe(expected)
   })
 
-  it('should keep an unquoted-attribute wrapper verbatim instead of decoding it', () => {
+  it('should unwrap a wrapper with an unquoted attribute value', () => {
     const value = { '#text': '<div class=foo><p>5 &lt; 6</p></div>' }
-    const expected = '<div class=foo><p>5 &lt; 6</p></div>'
+    const expected = '<p>5 &lt; 6</p>'
 
     expect(parseTypedText(value, 'xhtml')).toBe(expected)
   })

--- a/src/feeds/atom/parse/utils.ts
+++ b/src/feeds/atom/parse/utils.ts
@@ -73,8 +73,52 @@ export const createNamespaceGetter = (
 // parsing tokens in foreign content", https://html.spec.whatwg.org/multipage/parsing.html#parsing-main-inforeign),
 // but prefixed SVG/MathML inside xhtml constructs has no observed real-world usage; extend
 // to those bindings if such feeds ever appear.
-const xhtmlSelfClosingDivRegex = /^\s*<(?:[a-zA-Z][\w-]*:)?div(?:\s[^>]*)?\/>\s*$/
-const xhtmlOpeningDivRegex = /^\s*<(?:([a-zA-Z][\w-]*):)?div(?:\s[^>]*)?>/
+// The attribute part accepts only quoted values, so a `>` inside an attribute value
+// (`<div title="a>b">`) cannot end the match early and shift the slice into the attribute.
+const xhtmlDivAttrsPattern = '(?:\\s+[^\\s=>]+\\s*=\\s*(?:"[^"]*"|\'[^\']*\'))*'
+const xhtmlSelfClosingDivRegex = new RegExp(
+  `^\\s*<(?:[a-zA-Z][\\w.-]*:)?div${xhtmlDivAttrsPattern}\\s*/>\\s*$`,
+)
+const xhtmlOpeningDivRegex = new RegExp(
+  `^\\s*<(?:([a-zA-Z][\\w.-]*):)?div${xhtmlDivAttrsPattern}\\s*>`,
+)
+// Classification only: a value opening with any div tag is markup, including shapes the
+// strict wrapper pattern rejects, such as an unquoted attribute value.
+const xhtmlDivStartRegex = /^\s*<(?:[a-zA-Z][\w.-]*:)?div[\s/>]/
+const divTagRegex = new RegExp(
+  `<(/?)(?:[a-zA-Z][\\w.-]*:)?div(?=[\\s/>])${xhtmlDivAttrsPattern}\\s*(/?)>`,
+  'g',
+)
+const commentRegex = /<!--[\s\S]*?-->/g
+
+// A spec-violating construct can hold several sibling divs (`<div>a</div><div>b</div>`);
+// stripping the first opening and last closing tag there would leave unbalanced markup, so
+// the wrapper is only stripped when the remaining div tags close in order and end at depth
+// zero. Comments are dropped before counting because their text is literal, not markup;
+// CDATA is already escaped by the time this runs (see parseTypedText).
+const hasBalancedDivs = (inner: string): boolean => {
+  const scannable = inner.includes('<!--') ? inner.replace(commentRegex, '') : inner
+
+  divTagRegex.lastIndex = 0
+  let depth = 0
+  let match: RegExpExecArray | null = divTagRegex.exec(scannable)
+
+  while (match) {
+    if (match[1] === '/') {
+      depth--
+
+      if (depth < 0) {
+        return false
+      }
+    } else if (match[2] !== '/') {
+      depth++
+    }
+
+    match = divTagRegex.exec(scannable)
+  }
+
+  return depth === 0
+}
 
 export const unwrapXhtmlDiv = (value: Unreliable): Unreliable => {
   if (!isNonEmptyString(value)) {
@@ -91,7 +135,8 @@ export const unwrapXhtmlDiv = (value: Unreliable): Unreliable => {
     return value
   }
 
-  const prefix = match[1]
+  // A prefix may contain dots, which are regex metacharacters when interpolated.
+  const prefix = match[1]?.replace(/\./g, '\\.')
   const closingDivRegex = new RegExp(`</\\s*${prefix ? `${prefix}:` : ''}div\\s*>\\s*$`)
 
   if (!closingDivRegex.test(value)) {
@@ -99,6 +144,10 @@ export const unwrapXhtmlDiv = (value: Unreliable): Unreliable => {
   }
 
   const inner = value.slice(match[0].length).replace(closingDivRegex, '')
+
+  if (!hasBalancedDivs(inner)) {
+    return value
+  }
 
   if (prefix) {
     return inner.replace(new RegExp(`(</?)${prefix}:`, 'g'), '$1')
@@ -130,10 +179,12 @@ export const escapeCdataSections = (value: Unreliable): Unreliable => {
 // to read an invalid one, so it keeps the decoding, which suits a feed that labels escaped
 // HTML as xhtml. That is a choice, not a rule: 1 of 554 wrapper-less constructs in the
 // corpus sample carries escaped markup, and for the rest both paths produce the same string.
+// Atom 0.3 spelled the same construct as `type="application/xhtml+xml"`, so that type gets
+// the identical treatment.
 export const parseTypedText = (value: Unreliable, type: string | undefined): string | undefined => {
   const text = retrieveText(value)
 
-  if (type !== 'xhtml') {
+  if (type !== 'xhtml' && type !== 'application/xhtml+xml') {
     return parseString(text)
   }
 
@@ -142,7 +193,20 @@ export const parseTypedText = (value: Unreliable, type: string | undefined): str
   const escaped = escapeCdataSections(text)
   const unwrapped = unwrapXhtmlDiv(escaped)
 
-  return unwrapped === escaped ? parseString(text) : parseVerbatimString(unwrapped)
+  if (unwrapped !== escaped) {
+    return parseVerbatimString(unwrapped)
+  }
+
+  // A value that opens with a div is markup even when the wrapper cannot be stripped
+  // (sibling divs, an unterminated wrapper); only wrapper-less values keep the decoding
+  // path for feeds that label escaped HTML as xhtml. The looser test accepts shapes the
+  // strict wrapper regex rejects, such as an unquoted attribute value, so a value that is
+  // plainly markup never reaches the decoding path.
+  if (isNonEmptyString(escaped) && xhtmlDivStartRegex.test(escaped)) {
+    return parseVerbatimString(escaped)
+  }
+
+  return parseString(text)
 }
 
 export const parseText: ParseUtilPartial<AtomFeed.Text> = (value) => {

--- a/src/feeds/atom/parse/utils.ts
+++ b/src/feeds/atom/parse/utils.ts
@@ -1,3 +1,4 @@
+import { XMLParser } from 'fast-xml-parser'
 import { isNonEmptyString, isPlainObject } from 'trousse'
 import type { DateAny, Unreliable } from '../../../common/types.js'
 import {
@@ -65,92 +66,98 @@ export const createNamespaceGetter = (
 }
 
 // The value of a `type="xhtml"` text construct is the content of its single wrapping
-// <div> — RFC 4287 §3.1.1.3 requires the div itself to be excluded. The wrapper may also
+// <div>: RFC 4287 §3.1.1.3 requires the div itself to be excluded. The wrapper may also
 // bind the XHTML namespace to a prefix (`<xhtml:div>`), in which case every descendant tag
 // carries it too; the prefix is stripped along with the wrapper so the value is plain HTML.
 // Only the XHTML prefix gets this treatment. SVG and MathML are the two other namespaces
-// HTML represents unprefixed (foreign content — WHATWG HTML §13.2.6.5, "The rules for
+// HTML represents unprefixed (foreign content: WHATWG HTML §13.2.6.5, "The rules for
 // parsing tokens in foreign content", https://html.spec.whatwg.org/multipage/parsing.html#parsing-main-inforeign),
 // but prefixed SVG/MathML inside xhtml constructs has no observed real-world usage; extend
 // to those bindings if such feeds ever appear.
-// The attribute part accepts only quoted values, so a `>` inside an attribute value
-// (`<div title="a>b">`) cannot end the match early and shift the slice into the attribute.
-const xhtmlDivAttrsPattern = '(?:\\s+[^\\s=>]+\\s*=\\s*(?:"[^"]*"|\'[^\']*\'))*'
-const xhtmlSelfClosingDivRegex = new RegExp(
-  `^\\s*<(?:[a-zA-Z][\\w.-]*:)?div${xhtmlDivAttrsPattern}\\s*/>\\s*$`,
-)
-const xhtmlOpeningDivRegex = new RegExp(
-  `^\\s*<(?:([a-zA-Z][\\w.-]*):)?div${xhtmlDivAttrsPattern}\\s*>`,
-)
-// Classification only: a value opening with any div tag is markup, including shapes the
-// strict wrapper pattern rejects, such as an unquoted attribute value.
-const xhtmlDivStartRegex = /^\s*<(?:[a-zA-Z][\w.-]*:)?div[\s/>]/
-const divTagRegex = new RegExp(
-  `<(/?)(?:[a-zA-Z][\\w.-]*:)?div(?=[\\s/>])${xhtmlDivAttrsPattern}\\s*(/?)>`,
-  'g',
-)
-const commentRegex = /<!--[\s\S]*?-->/g
+const xhtmlDivStartRegex = /^\s*<(?:([a-zA-Z][\w.-]*):)?div[\s/>]/
 
-// A spec-violating construct can hold several sibling divs (`<div>a</div><div>b</div>`);
-// stripping the first opening and last closing tag there would leave unbalanced markup, so
-// the wrapper is only stripped when the remaining div tags close in order and end at depth
-// zero. Comments are dropped before counting because their text is literal, not markup;
-// CDATA is already escaped by the time this runs (see parseTypedText).
-const hasBalancedDivs = (inner: string): boolean => {
-  const scannable = inner.includes('<!--') ? inner.replace(commentRegex, '') : inner
-
-  divTagRegex.lastIndex = 0
-  let depth = 0
-  let match: RegExpExecArray | null = divTagRegex.exec(scannable)
-
-  while (match) {
-    if (match[1] === '/') {
-      depth--
-
-      if (depth < 0) {
-        return false
-      }
-    } else if (match[2] !== '/') {
-      depth++
-    }
-
-    match = divTagRegex.exec(scannable)
-  }
-
-  return depth === 0
-}
+// The wrapper is located by re-parsing the value with the div as a stop node, which hands
+// back its raw inner markup byte for byte while a real tag scan deals with a `>` inside a
+// quoted attribute, comments and nested divs. A spec-violating shape (sibling divs, text
+// or comments around the wrapper, a mismatched closing tag) surfaces as extra root
+// children or a parse error, and the value is then kept unchanged.
+//
+// The synthetic root exists because the parser silently drops text standing outside the
+// root element; inside `x-wrap`, that text stays visible to the shape check below.
+const xhtmlDivParser = new XMLParser({
+  preserveOrder: true,
+  stopNodes: ['x-wrap.div'],
+  processEntities: false,
+  ignoreAttributes: true,
+  removeNSPrefix: true,
+  trimValues: false,
+  commentPropName: '#comment',
+})
 
 export const unwrapXhtmlDiv = (value: Unreliable): Unreliable => {
   if (!isNonEmptyString(value)) {
     return value
   }
 
-  if (xhtmlSelfClosingDivRegex.test(value)) {
-    return
-  }
-
-  const match = value.match(xhtmlOpeningDivRegex)
+  const match = value.match(xhtmlDivStartRegex)
 
   if (!match) {
     return value
   }
 
-  // A prefix may contain dots, which are regex metacharacters when interpolated.
-  const prefix = match[1]?.replace(/\./g, '\\.')
-  const closingDivRegex = new RegExp(`</\\s*${prefix ? `${prefix}:` : ''}div\\s*>\\s*$`)
+  let children: Unreliable
 
-  if (!closingDivRegex.test(value)) {
+  try {
+    const parsed = xhtmlDivParser.parse(`<x-wrap>${value}</x-wrap>`)
+
+    if (parsed.length !== 1) {
+      return value
+    }
+
+    children = parsed[0]['x-wrap']
+  } catch {
     return value
   }
 
-  const inner = value.slice(match[0].length).replace(closingDivRegex, '')
-
-  if (!hasBalancedDivs(inner)) {
+  if (!Array.isArray(children)) {
     return value
   }
+
+  let inner: string | undefined
+
+  for (const child of children) {
+    if (Array.isArray(child.div)) {
+      if (inner !== undefined) {
+        return value
+      }
+
+      inner = child.div[0]?.['#text'] ?? ''
+      continue
+    }
+
+    if (typeof child['#text'] === 'string' && child['#text'].trim() === '') {
+      continue
+    }
+
+    return value
+  }
+
+  if (inner === undefined) {
+    return value
+  }
+
+  // A self-closing or empty wrapper is a construct with no content.
+  if (inner === '') {
+    return
+  }
+
+  const prefix = match[1]
 
   if (prefix) {
-    return inner.replace(new RegExp(`(</?)${prefix}:`, 'g'), '$1')
+    // A prefix may contain dots, which are regex metacharacters when interpolated.
+    const escapedPrefix = prefix.replace(/\./g, '\\.')
+
+    return inner.replace(new RegExp(`(</?)${escapedPrefix}:`, 'g'), '$1')
   }
 
   return inner
@@ -198,10 +205,8 @@ export const parseTypedText = (value: Unreliable, type: string | undefined): str
   }
 
   // A value that opens with a div is markup even when the wrapper cannot be stripped
-  // (sibling divs, an unterminated wrapper); only wrapper-less values keep the decoding
-  // path for feeds that label escaped HTML as xhtml. The looser test accepts shapes the
-  // strict wrapper regex rejects, such as an unquoted attribute value, so a value that is
-  // plainly markup never reaches the decoding path.
+  // (sibling divs, an unterminated wrapper, text around it); only wrapper-less values keep
+  // the decoding path for feeds that label escaped HTML as xhtml.
   if (isNonEmptyString(escaped) && xhtmlDivStartRegex.test(escaped)) {
     return parseVerbatimString(escaped)
   }

--- a/src/feeds/atom/parse/utils.ts
+++ b/src/feeds/atom/parse/utils.ts
@@ -110,7 +110,7 @@ export const unwrapXhtmlDiv = (value: Unreliable): Unreliable => {
   try {
     const parsed = xhtmlDivParser.parse(`<x-wrap>${value}</x-wrap>`)
 
-    if (parsed.length !== 1) {
+    if (parsed.length !== 1 || !Array.isArray(parsed[0]['x-wrap'])) {
       return value
     }
 
@@ -119,19 +119,11 @@ export const unwrapXhtmlDiv = (value: Unreliable): Unreliable => {
     return value
   }
 
-  if (!Array.isArray(children)) {
-    return value
-  }
-
-  let inner: string | undefined
+  const divTexts: Array<string> = []
 
   for (const child of children) {
     if (Array.isArray(child.div)) {
-      if (inner !== undefined) {
-        return value
-      }
-
-      inner = child.div[0]?.['#text'] ?? ''
+      divTexts.push(child.div[0]?.['#text'] ?? '')
       continue
     }
 
@@ -142,9 +134,11 @@ export const unwrapXhtmlDiv = (value: Unreliable): Unreliable => {
     return value
   }
 
-  if (inner === undefined) {
+  if (divTexts.length !== 1) {
     return value
   }
+
+  const inner = divTexts[0]
 
   // A self-closing or empty wrapper is a construct with no content.
   if (inner === '') {

--- a/src/feeds/atom/references/atom-03.json
+++ b/src/feeds/atom/references/atom-03.json
@@ -52,7 +52,7 @@
         }
       ],
       "content": {
-        "value": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Watch out for <span style=\"background-image: url(javascript:window.location='http://example.org/')\"> nasty tricks</span></div>",
+        "value": "Watch out for <span style=\"background-image: url(javascript:window.location='http://example.org/')\"> nasty tricks</span>",
         "type": "application/xhtml+xml",
         "xml": {
           "base": "http://example.org/entry/3",
@@ -123,7 +123,7 @@
         { "name": "Jane Smith", "uri": "http://example.org/jane/", "email": "jane@example.org" }
       ],
       "content": {
-        "value": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Watch out for <span style=\"background-image: url(javascript:window.location='http://example.org/')\"> nasty tricks</span></div>",
+        "value": "Watch out for <span style=\"background-image: url(javascript:window.location='http://example.org/')\"> nasty tricks</span>",
         "type": "application/xhtml+xml",
         "xml": {
           "base": "http://example.org/entry/3",

--- a/src/feeds/rdf/parse/index.test.ts
+++ b/src/feeds/rdf/parse/index.test.ts
@@ -189,6 +189,45 @@ describe('parse', () => {
     expect(parse(value)).toEqual(expected)
   })
 
+  it('should parse atom xhtml content in an RDF item with the div wrapper stripped', () => {
+    const value = `
+      <?xml version="1.0" encoding="UTF-8"?>
+      <rdf:RDF
+        xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+        xmlns="http://purl.org/rss/1.0/"
+        xmlns:atom="http://www.w3.org/2005/Atom"
+      >
+        <channel rdf:about="https://example.com">
+          <title>Test</title>
+          <link>https://example.com</link>
+        </channel>
+        <item rdf:about="https://example.com/item1">
+          <title>Item</title>
+          <atom:content type="xhtml"><div xmlns="http://www.w3.org/1999/xhtml"><p>a &lt; b</p></div></atom:content>
+        </item>
+      </rdf:RDF>
+    `
+    const expected = {
+      title: 'Test',
+      link: 'https://example.com',
+      rdf: { about: 'https://example.com' },
+      items: [
+        {
+          title: 'Item',
+          atom: {
+            content: {
+              value: '<p>a &lt; b</p>',
+              type: 'xhtml',
+            },
+          },
+          rdf: { about: 'https://example.com/item1' },
+        },
+      ],
+    }
+
+    expect(parse(value)).toEqual(expected)
+  })
+
   describe('namespace normalization integration', () => {
     it('should handle RDF 1.0 feeds with no additional namespaces', () => {
       const value = `

--- a/src/feeds/rss/generate/config.ts
+++ b/src/feeds/rss/generate/config.ts
@@ -2,9 +2,9 @@ import { XMLBuilder } from 'fast-xml-parser'
 import { builderConfig } from '../../../common/config.js'
 import { textConstructs } from '../../../namespaces/atom/common/config.js'
 
-// Atom text constructs embedded via the atom namespace hold raw xhtml markup when their
-// type is xhtml, exactly like in Atom feeds (see src/feeds/atom/generate/config.ts).
 export const builder = new XMLBuilder({
   ...builderConfig,
+  // Atom text constructs embedded via the atom namespace hold raw xhtml markup when their
+  // type is xhtml, exactly like in Atom feeds (see src/feeds/atom/generate/config.ts).
   stopNodes: textConstructs.map((element) => `..atom:${element}[type=xhtml]`),
 })

--- a/src/feeds/rss/generate/config.ts
+++ b/src/feeds/rss/generate/config.ts
@@ -1,6 +1,10 @@
 import { XMLBuilder } from 'fast-xml-parser'
 import { builderConfig } from '../../../common/config.js'
+import { textConstructs } from '../../../namespaces/atom/common/config.js'
 
+// Atom text constructs embedded via the atom namespace hold raw xhtml markup when their
+// type is xhtml, exactly like in Atom feeds (see src/feeds/atom/generate/config.ts).
 export const builder = new XMLBuilder({
   ...builderConfig,
+  stopNodes: textConstructs.map((element) => `..atom:${element}[type=xhtml]`),
 })

--- a/src/feeds/rss/generate/index.test.ts
+++ b/src/feeds/rss/generate/index.test.ts
@@ -89,7 +89,8 @@ describe('generate', () => {
     <item>
       <title>First item</title>
       <atom:content type="xhtml">
-<div xmlns="http://www.w3.org/1999/xhtml"><p>Rich <em>text</em></p></div>      </atom:content>
+<div xmlns="http://www.w3.org/1999/xhtml"><p>Rich <em>text</em></p></div>
+      </atom:content>
     </item>
   </channel>
 </rss>

--- a/src/feeds/rss/generate/index.test.ts
+++ b/src/feeds/rss/generate/index.test.ts
@@ -65,6 +65,39 @@ describe('generate', () => {
     expect(generate(value)).toEqual(expected)
   })
 
+  it('should generate atom xhtml content as markup inside a div wrapper', () => {
+    const value = {
+      title: 'Feed with Atom xhtml',
+      description: 'Test feed',
+      items: [
+        {
+          title: 'First item',
+          atom: {
+            content: {
+              value: '<p>Rich <em>text</em></p>',
+              type: 'xhtml',
+            },
+          },
+        },
+      ],
+    }
+    const expected = `<?xml version="1.0" encoding="utf-8"?>
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+  <channel>
+    <title>Feed with Atom xhtml</title>
+    <description>Test feed</description>
+    <item>
+      <title>First item</title>
+      <atom:content type="xhtml">
+<div xmlns="http://www.w3.org/1999/xhtml"><p>Rich <em>text</em></p></div>      </atom:content>
+    </item>
+  </channel>
+</rss>
+`
+
+    expect(generate(value)).toEqual(expected)
+  })
+
   it('should generate RSS with dc namespace', () => {
     const value = {
       title: 'Feed with dc namespace',

--- a/src/feeds/rss/parse/index.test.ts
+++ b/src/feeds/rss/parse/index.test.ts
@@ -1475,6 +1475,46 @@ describe('parse', () => {
         expect(parse(value)).toEqual(expected)
       })
 
+      it('should parse atom xhtml content in RSS item with the div wrapper stripped', () => {
+        const value = `
+          <?xml version="1.0" encoding="UTF-8"?>
+          <rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+            <channel>
+              <title>Test</title>
+              <link>https://example.com</link>
+              <description>Test</description>
+              <item>
+                <title>Item</title>
+                <atom:title type="xhtml"><div xmlns="http://www.w3.org/1999/xhtml"><p>a &lt; b</p></div></atom:title>
+                <atom:content type="xhtml"><div xmlns="http://www.w3.org/1999/xhtml"><p>Rich <em>text</em></p></div></atom:content>
+              </item>
+            </channel>
+          </rss>
+        `
+        const expected = {
+          title: 'Test',
+          link: 'https://example.com',
+          description: 'Test',
+          items: [
+            {
+              title: 'Item',
+              atom: {
+                title: {
+                  value: '<p>a &lt; b</p>',
+                  type: 'xhtml',
+                },
+                content: {
+                  value: '<p>Rich <em>text</em></p>',
+                  type: 'xhtml',
+                },
+              },
+            },
+          ],
+        }
+
+        expect(parse(value)).toEqual(expected)
+      })
+
       it('should parse atom:link in RSS feed (RW-L03)', () => {
         const value = `
           <?xml version="1.0" encoding="UTF-8"?>

--- a/src/namespaces/atom/common/config.ts
+++ b/src/namespaces/atom/common/config.ts
@@ -75,8 +75,6 @@ const prefixSegments = (path: string) => {
     .join('.')
 }
 
-// Embedded in other formats, every element spells the atom prefix below a host-dependent
-// mount point.
 export const stopNodes = [...new Set([...feedPaths, ...entryPaths])].map((path) => {
   return `*.${prefixSegments(path)}`
 })

--- a/src/namespaces/atom/common/config.ts
+++ b/src/namespaces/atom/common/config.ts
@@ -10,3 +10,73 @@ export const uris = [
 // The elements that can carry a type="xhtml" value with inline markup. Atom 0.3's tagline
 // is left out: generated feeds are normalized to 1.0, so its stop node would never match.
 export const textConstructs = ['title', 'subtitle', 'rights', 'summary', 'content']
+
+// Leaf paths the parser reads, relative to the feed and to the entry. Text constructs can
+// hold inline xhtml markup, which must reach parseText as raw text; containers (author,
+// contributor, source) appear only as segments so they parse into structure.
+const personPaths = (parent: string) => [
+  `${parent}.name`,
+  `${parent}.uri`,
+  `${parent}.url`, // Atom 0.3.
+  `${parent}.email`,
+]
+
+export const feedPaths = [
+  ...personPaths('author'),
+  'category',
+  ...personPaths('contributor'),
+  'generator',
+  'icon',
+  'id',
+  'link',
+  'logo',
+  'rights',
+  'subtitle',
+  'tagline', // Atom 0.3.
+  'title',
+  'updated',
+  'modified', // Atom 0.3.
+]
+
+export const entryPaths = [
+  ...personPaths('author'),
+  'category',
+  'content',
+  ...personPaths('contributor'),
+  'id',
+  'link',
+  'published',
+  'issued', // Atom 0.3.
+  'created', // Atom 0.3.
+  'rights',
+  ...personPaths('source.author'),
+  'source.category',
+  ...personPaths('source.contributor'),
+  'source.generator',
+  'source.icon',
+  'source.id',
+  'source.link',
+  'source.logo',
+  'source.rights',
+  'source.subtitle',
+  'source.title',
+  'source.updated',
+  'source.modified', // Atom 0.3.
+  'summary',
+  'title',
+  'updated',
+  'modified', // Atom 0.3.
+]
+
+const prefixSegments = (path: string) => {
+  return path
+    .split('.')
+    .map((segment) => `atom:${segment}`)
+    .join('.')
+}
+
+// Embedded in other formats, every element spells the atom prefix below a host-dependent
+// mount point.
+export const stopNodes = [...new Set([...feedPaths, ...entryPaths])].map((path) => {
+  return `*.${prefixSegments(path)}`
+})


### PR DESCRIPTION
Stacked on #332; base retargets as the stack merges.

Hardening against feed shapes found in a corpus audit, plus the conformance gaps the earlier PRs left open. A 1/256 sample (49,707 feeds, 185 carrying xhtml constructs, 3,478 constructs) sized each case, and all 185 feeds went through parse and generate before and after with zero regressions.

## Parse

- Sibling top-level divs no longer corrupt. `<div>a</div><div>b</div>` used to lose its first opening and last closing tag, leaving unbalanced markup. The wrapper is now located by re-parsing the value with the div as a stop node, which hands back its raw inner markup with entities intact; any shape other than a single enclosing div (sibling divs, text or comments around the wrapper, a mismatched closing tag) refuses the unwrap, and the value is kept verbatim, since a value opening with a div is markup however it violates the single-div rule. Zero in the sample; documented in the wild.
- Div-like text inside comments does not fool that scan, and CDATA is already escaped by then (#331), so neither makes a conformant construct keep its wrapper.
- A `>` inside a wrapper attribute no longer shifts the slice: the scan reads real tags, so `<div title="a>b">` ends at the real tag end, and an unquoted attribute value unwraps like any other wrapper.
- Prefixes containing dots (valid NCNames) match, and are escaped where interpolated into a regex.
- `type="application/xhtml+xml"`, Atom 0.3's spelling of the construct, unwraps too. All 3 sampled feeds using it wrap their markup in the same div; the type value is preserved on the parsed object.
- Atom text constructs inside RSS and RDF items work. `<atom:title type="xhtml">` in an item lost its value entirely: no stop node, so the div parsed into an element tree and no text remained. The atom namespace declares stop nodes for every leaf element the embedded parser reads, matching the other namespaces; the six text constructs carry the weight, containers with element children (`author`, `contributor`, `source`) stay unlisted so they parse into structure. Side effect: a construct whose closing tag does not match its opening tag is now a hard parse error, the same trade every existing stop node makes.

## Generate

- The escaped fallback emits `type="html"`. Escaped text under `type="xhtml"` is a construct without its div, which the RelaxNG makes invalid and the W3C validator flags as MissingXhtmlDiv. Escaped markup under `type="html"` says the same thing conformantly and round-trips identically.
- HTML-only entities take that fallback. `XMLValidator` accepts entity references it cannot resolve, so `&nbsp;` used to be embedded raw and broke strict parsers. 3 of 185 sampled feeds carry such values.
- A literal `\r` is emitted as `&#13;`, which survives the normalization XML §2.11 applies to the raw character.
- The RSS builder gains the `atom:`-prefixed xhtml stop nodes, so an embedded `atom:content` carries its div as markup instead of escaped soup.

## Not changed

- Case variants of the type value, comments or text before the wrapper, `xml:base` on the div: all zero in the sample, all already falling through conservatively.
- A wrapper-less `application/xhtml+xml` keeps the decode path, like wrapper-less `xhtml`; every sampled Atom 0.3 construct is wrapped.

