### PR TITLE
feat: Canonicalize namespace prefixes during parsing

### DIFF
--- a/src/common/utils.test.ts
+++ b/src/common/utils.test.ts
@@ -3,7 +3,7 @@ import { type XMLBuilder, XMLParser } from 'fast-xml-parser'
 import { namespacePrefixes, namespaceUris } from './config.js'
 import type { ParseUtilExact } from './types.js'
 import {
-  createNamespaceNormalizator,
+  createNamespaceResolver,
   detectNamespaces,
   generateBoolean,
   generateCdataString,
@@ -3260,942 +3260,155 @@ describe('generateRdfResource', () => {
   })
 })
 
-describe('createNamespaceNormalizator', () => {
-  describe('XML parsing integration tests', () => {
-    const parser = new XMLParser({
-      trimValues: true,
-      ignoreAttributes: false,
-      ignoreDeclaration: true,
-      attributeNamePrefix: '@',
-      transformTagName: (name: string) => name.toLowerCase(),
-      transformAttributeName: (name: string) => name.toLowerCase(),
+describe('createNamespaceResolver', () => {
+  const createParser = (primary?: Array<keyof typeof namespaceUris>, stopNodes?: Array<string>) => {
+    const createNamespaceOptions = createNamespaceResolver({
+      namespaceUris,
+      namespacePrefixes,
+      primaryNamespaces: primary,
     })
 
-    describe('default namespace handling', () => {
-      it('should handle default Atom namespace with primary namespace', () => {
-        const normalizeNamespaces = createNamespaceNormalizator(namespaceUris, namespacePrefixes, [
-          'atom',
-        ])
-        const value = parser.parse(`
-          <?xml version="1.0"?>
-          <feed xmlns="http://www.w3.org/2005/Atom">
-            <title>Test Feed</title>
-            <entry>
-              <title>Test Entry</title>
-            </entry>
-          </feed>
-        `)
-        const expected = {
-          feed: {
-            title: 'Test Feed',
-            entry: {
-              title: 'Test Entry',
-            },
-            '@xmlns': 'http://www.w3.org/2005/Atom',
-          },
-        }
+    return (value: string) =>
+      new XMLParser({
+        ignoreAttributes: false,
+        attributeNamePrefix: '@',
+        stopNodes,
+        ...createNamespaceOptions(),
+      }).parse(value)
+  }
 
-        expect(normalizeNamespaces(value)).toEqual(expected)
-      })
+  it('should canonicalize an alternate prefix declared on the root', () => {
+    const parse = createParser()
+    const value = parse(
+      '<rss xmlns:a10="http://www.w3.org/2005/Atom"><a10:title>Hello</a10:title></rss>',
+    )
+    const expected = { rss: { '@xmlns:a10': 'http://www.w3.org/2005/Atom', 'atom:title': 'Hello' } }
 
-      it('should handle default namespace without primary namespace', () => {
-        const normalizeNamespaces = createNamespaceNormalizator(namespaceUris, namespacePrefixes)
-        const value = parser.parse(`
-          <?xml version="1.0"?>
-          <feed xmlns="http://www.w3.org/2005/Atom">
-            <title>Test Feed</title>
-          </feed>
-        `)
-        const expected = {
-          'atom:feed': {
-            'atom:title': 'Test Feed',
-            '@xmlns': 'http://www.w3.org/2005/Atom',
-          },
-        }
-
-        expect(normalizeNamespaces(value)).toEqual(expected)
-      })
-    })
-
-    describe('prefixed namespace handling', () => {
-      it('should normalize custom prefixes to standard prefixes', () => {
-        const normalizeNamespaces = createNamespaceNormalizator(namespaceUris, namespacePrefixes)
-        const value = parser.parse(`
-          <?xml version="1.0"?>
-          <rss xmlns:custom="http://purl.org/dc/elements/1.1/">
-            <channel>
-              <title>RSS Feed</title>
-              <item>
-                <title>Item Title</title>
-                <custom:creator>John Doe</custom:creator>
-              </item>
-            </channel>
-          </rss>
-        `)
-        const expected = {
-          rss: {
-            channel: {
-              title: 'RSS Feed',
-              item: {
-                title: 'Item Title',
-                'dc:creator': 'John Doe',
-              },
-            },
-            '@xmlns:custom': 'http://purl.org/dc/elements/1.1/',
-          },
-        }
-
-        expect(normalizeNamespaces(value)).toEqual(expected)
-      })
-
-      it('should handle custom Atom prefix with primary namespace', () => {
-        const normalizeNamespaces = createNamespaceNormalizator(namespaceUris, namespacePrefixes, [
-          'atom',
-        ])
-        const value = parser.parse(`
-          <?xml version="1.0"?>
-          <a:feed xmlns:a="http://www.w3.org/2005/Atom">
-            <a:title>Test Feed</a:title>
-            <a:entry>
-              <a:title>Test Entry</a:title>
-            </a:entry>
-          </a:feed>
-        `)
-        const expected = {
-          feed: {
-            title: 'Test Feed',
-            entry: {
-              title: 'Test Entry',
-            },
-            '@xmlns:a': 'http://www.w3.org/2005/Atom',
-          },
-        }
-
-        expect(normalizeNamespaces(value)).toEqual(expected)
-      })
-    })
-
-    describe('nested namespace declarations', () => {
-      it('should handle namespace declarations in nested elements', () => {
-        const normalizeNamespaces = createNamespaceNormalizator(namespaceUris, namespacePrefixes)
-        const value = parser.parse(`
-          <?xml version="1.0"?>
-          <rss>
-            <channel>
-              <item xmlns:dc="http://purl.org/dc/elements/1.1/">
-                <title>Item Title</title>
-                <dc:creator>John Doe</dc:creator>
-                <dc:date>2023-01-01</dc:date>
-              </item>
-              <item>
-                <title>Item Without Namespace</title>
-              </item>
-            </channel>
-          </rss>
-        `)
-        const expected = {
-          rss: {
-            channel: {
-              item: [
-                {
-                  title: 'Item Title',
-                  'dc:creator': 'John Doe',
-                  'dc:date': '2023-01-01',
-                  '@xmlns:dc': 'http://purl.org/dc/elements/1.1/',
-                },
-                {
-                  title: 'Item Without Namespace',
-                },
-              ],
-            },
-          },
-        }
-
-        expect(normalizeNamespaces(value)).toEqual(expected)
-      })
-
-      it('should handle namespace redefinition in nested elements', () => {
-        const normalizeNamespaces = createNamespaceNormalizator(
-          {
-            v1: ['http://example.com/v1'],
-            v2: ['http://example.com/v2'],
-          },
-          {
-            'http://example.com/v1': 'v1',
-            'http://example.com/v2': 'v2',
-          },
-        )
-        const value = parser.parse(`
-          <?xml version="1.0"?>
-          <root xmlns:ns="http://example.com/v1">
-            <ns:element>Version 1</ns:element>
-            <child xmlns:ns="http://example.com/v2">
-              <ns:element>Version 2</ns:element>
-            </child>
-            <ns:element>Version 1 Again</ns:element>
-          </root>
-        `)
-        const expected = {
-          root: {
-            'v1:element': ['Version 1', 'Version 1 Again'],
-            child: {
-              'v2:element': 'Version 2',
-              '@xmlns:ns': 'http://example.com/v2',
-            },
-            '@xmlns:ns': 'http://example.com/v1',
-          },
-        }
-
-        expect(normalizeNamespaces(value)).toEqual(expected)
-      })
-    })
-
-    describe('mixed case handling', () => {
-      it('should normalize element names to lowercase while preserving namespace logic', () => {
-        const normalizeNamespaces = createNamespaceNormalizator(namespaceUris, namespacePrefixes)
-        const value = parser.parse(`
-          <?xml version="1.0"?>
-          <RSS xmlns:DC="http://purl.org/dc/elements/1.1/">
-            <Channel>
-              <TITLE>Feed Title</TITLE>
-              <Item>
-                <Title>Item Title</Title>
-                <DC:Creator>John Doe</DC:Creator>
-              </Item>
-            </Channel>
-          </RSS>
-        `)
-        const expected = {
-          rss: {
-            channel: {
-              title: 'Feed Title',
-              item: {
-                title: 'Item Title',
-                'dc:creator': 'John Doe',
-              },
-            },
-            '@xmlns:dc': 'http://purl.org/dc/elements/1.1/',
-          },
-        }
-
-        expect(normalizeNamespaces(value)).toEqual(expected)
-      })
-    })
-
-    describe('self-closing elements with namespaces', () => {
-      it('should handle self-closing elements with namespace declarations', () => {
-        const normalizeNamespaces = createNamespaceNormalizator(namespaceUris, namespacePrefixes)
-        const value = parser.parse(`
-          <?xml version="1.0"?>
-          <rss>
-            <channel>
-              <item>
-                <title>Item 1</title>
-                <media:thumbnail xmlns:media="http://search.yahoo.com/mrss/" url="http://example.com/thumb.jpg"/>
-              </item>
-              <item>
-                <title>Item 2</title>
-                <description>No media namespace here</description>
-              </item>
-            </channel>
-          </rss>
-        `)
-        const expected = {
-          rss: {
-            channel: {
-              item: [
-                {
-                  title: 'Item 1',
-                  'media:thumbnail': {
-                    '@url': 'http://example.com/thumb.jpg',
-                    '@xmlns:media': 'http://search.yahoo.com/mrss/',
-                  },
-                },
-                {
-                  title: 'Item 2',
-                  description: 'No media namespace here',
-                },
-              ],
-            },
-          },
-        }
-
-        expect(normalizeNamespaces(value)).toEqual(expected)
-      })
-    })
-
-    describe('multiple namespaces in same document', () => {
-      it('should handle multiple namespaces simultaneously', () => {
-        const normalizeNamespaces = createNamespaceNormalizator(namespaceUris, namespacePrefixes)
-        const value = parser.parse(`
-          <?xml version="1.0"?>
-          <rss
-            xmlns:dc="http://purl.org/dc/elements/1.1/"
-            xmlns:content="http://purl.org/rss/1.0/modules/content/"
-            xmlns:media="http://search.yahoo.com/mrss/"
-          >
-            <channel>
-              <item>
-                <title>Multi-namespace Item</title>
-                <dc:creator>John Doe</dc:creator>
-                <dc:date>2023-01-01</dc:date>
-                <content:encoded><![CDATA[Rich content]]></content:encoded>
-                <media:group>
-                  <media:content url="video.mp4" type="video/mp4"/>
-                  <media:description>Video description</media:description>
-                </media:group>
-              </item>
-            </channel>
-          </rss>
-        `)
-        const expected = {
-          rss: {
-            channel: {
-              item: {
-                title: 'Multi-namespace Item',
-                'dc:creator': 'John Doe',
-                'dc:date': '2023-01-01',
-                'content:encoded': 'Rich content',
-                'media:group': {
-                  'media:content': {
-                    '@url': 'video.mp4',
-                    '@type': 'video/mp4',
-                  },
-                  'media:description': 'Video description',
-                },
-              },
-            },
-            '@xmlns:dc': 'http://purl.org/dc/elements/1.1/',
-            '@xmlns:content': 'http://purl.org/rss/1.0/modules/content/',
-            '@xmlns:media': 'http://search.yahoo.com/mrss/',
-          },
-        }
-
-        expect(normalizeNamespaces(value)).toEqual(expected)
-      })
-    })
-
-    describe('edge cases', () => {
-      it('should handle empty namespace URIs', () => {
-        const normalizeNamespaces = createNamespaceNormalizator(namespaceUris, namespacePrefixes)
-        const value = parser.parse(`
-          <?xml version="1.0"?>
-          <root xmlns="">
-            <element>No namespace</element>
-          </root>
-        `)
-        const expected = {
-          root: {
-            element: 'No namespace',
-            '@xmlns': '',
-          },
-        }
-
-        expect(normalizeNamespaces(value)).toEqual(expected)
-      })
-
-      it('should handle unknown namespaces gracefully', () => {
-        const normalizeNamespaces = createNamespaceNormalizator(namespaceUris, namespacePrefixes)
-        const value = parser.parse(`
-          <?xml version="1.0"?>
-          <root xmlns:unknown="http://unknown.example.com/">
-            <unknown:element>Unknown namespace</unknown:element>
-          </root>
-        `)
-        const expected = {
-          root: {
-            'unknown:element': 'Unknown namespace',
-            '@xmlns:unknown': 'http://unknown.example.com/',
-          },
-        }
-
-        expect(normalizeNamespaces(value)).toEqual(expected)
-      })
-
-      it('should handle case-insensitive xmlns attributes', () => {
-        const normalizeNamespaces = createNamespaceNormalizator(namespaceUris, namespacePrefixes)
-        const value = parser.parse(`
-          <?xml version="1.0"?>
-          <root
-            XMLNS:DC="http://purl.org/dc/elements/1.1/"
-            xmlns:ATOM="http://www.w3.org/2005/Atom"
-          >
-            <DC:creator>Author Name</DC:creator>
-            <ATOM:title>Title</ATOM:title>
-          </root>
-        `)
-        const expected = {
-          root: {
-            'dc:creator': 'Author Name',
-            'atom:title': 'Title',
-            '@xmlns:dc': 'http://purl.org/dc/elements/1.1/',
-            '@xmlns:atom': 'http://www.w3.org/2005/Atom',
-          },
-        }
-
-        expect(normalizeNamespaces(value)).toEqual(expected)
-      })
-
-      it('should handle complex nesting with namespace inheritance', () => {
-        const normalizeNamespaces = createNamespaceNormalizator(namespaceUris, namespacePrefixes, [
-          'atom',
-        ])
-        const value = parser.parse(`
-          <?xml version="1.0"?>
-          <feed xmlns="http://www.w3.org/2005/Atom">
-            <entry xmlns:dc="http://purl.org/dc/elements/1.1/">
-              <title>Entry Title</title>
-              <dc:creator>Author</dc:creator>
-              <content xmlns:xhtml="http://www.w3.org/1999/xhtml">
-                <xhtml:div>
-                  <xhtml:p>Rich content</xhtml:p>
-                </xhtml:div>
-              </content>
-            </entry>
-          </feed>
-        `)
-        const expected = {
-          feed: {
-            entry: {
-              title: 'Entry Title',
-              'dc:creator': 'Author',
-              content: {
-                'xhtml:div': {
-                  'xhtml:p': 'Rich content',
-                },
-                '@xmlns:xhtml': 'http://www.w3.org/1999/xhtml',
-              },
-              '@xmlns:dc': 'http://purl.org/dc/elements/1.1/',
-            },
-            '@xmlns': 'http://www.w3.org/2005/Atom',
-          },
-        }
-
-        expect(normalizeNamespaces(value)).toEqual(expected)
-      })
-    })
-
-    describe('unhappy path scenarios', () => {
-      it('should handle non-object input gracefully', () => {
-        const normalizeNamespaces = createNamespaceNormalizator(namespaceUris, namespacePrefixes)
-
-        expect(normalizeNamespaces(null)).toBe(null)
-        expect(normalizeNamespaces(undefined)).toBe(undefined)
-        expect(normalizeNamespaces('string')).toBe('string')
-        expect(normalizeNamespaces(123)).toBe(123)
-        expect(normalizeNamespaces(true)).toBe(true)
-      })
-
-      it('should handle non-string xmlns values gracefully', () => {
-        const normalizeNamespaces = createNamespaceNormalizator(namespaceUris, namespacePrefixes)
-        const value = {
-          root: {
-            '@xmlns': 123,
-            '@xmlns:dc': null,
-            'dc:creator': 'Author',
-          },
-        }
-        const expected = {
-          root: {
-            '@xmlns': 123,
-            '@xmlns:dc': null,
-            'dc:creator': 'Author',
-          },
-        }
-
-        expect(normalizeNamespaces(value)).toEqual(expected)
-      })
-
-      it('should handle conflicting namespace declarations in siblings', () => {
-        const normalizeNamespaces = createNamespaceNormalizator(namespaceUris, namespacePrefixes)
-        const value = parser.parse(`
-          <?xml version="1.0"?>
-          <root>
-            <item1 xmlns:custom="http://purl.org/dc/elements/1.1/">
-              <custom:creator>Author 1</custom:creator>
-            </item1>
-            <item2 xmlns:custom="http://search.yahoo.com/mrss/">
-              <custom:title>Title 2</custom:title>
-            </item2>
-          </root>
-        `)
-        const expected = {
-          root: {
-            item1: {
-              'dc:creator': 'Author 1',
-              '@xmlns:custom': 'http://purl.org/dc/elements/1.1/',
-            },
-            item2: {
-              'media:title': 'Title 2',
-              '@xmlns:custom': 'http://search.yahoo.com/mrss/',
-            },
-          },
-        }
-
-        expect(normalizeNamespaces(value)).toEqual(expected)
-      })
-
-      it('should normalize when standard prefix used by unknown namespace', () => {
-        const normalizeNamespaces = createNamespaceNormalizator(namespaceUris, namespacePrefixes)
-        const value = parser.parse(`
-          <?xml version="1.0"?>
-          <root
-            xmlns:atom="http://example.com/unknown"
-            xmlns:feed="http://www.w3.org/2005/Atom"
-          >
-            <atom:unknown>ignored</atom:unknown>
-            <feed:title>Test Title</feed:title>
-          </root>
-        `)
-        const expected = {
-          root: {
-            'atom:unknown': 'ignored',
-            'atom:title': 'Test Title',
-            '@xmlns:atom': 'http://example.com/unknown',
-            '@xmlns:feed': 'http://www.w3.org/2005/Atom',
-          },
-        }
-
-        expect(normalizeNamespaces(value)).toEqual(expected)
-      })
-
-      it('should normalize multiple conflicts with same namespace URI', () => {
-        const normalizeNamespaces = createNamespaceNormalizator(namespaceUris, namespacePrefixes)
-        const value = parser.parse(`
-          <?xml version="1.0"?>
-          <root
-            xmlns:dc1="http://purl.org/dc/elements/1.1/"
-            xmlns:dc2="http://purl.org/dc/elements/1.1"
-          >
-            <dc1:creator>John Doe</dc1:creator>
-            <dc2:creator>Jane Smith</dc2:creator>
-          </root>
-        `)
-        const expected = {
-          root: {
-            'dc:creator': ['John Doe', 'Jane Smith'],
-            '@xmlns:dc1': 'http://purl.org/dc/elements/1.1/',
-            '@xmlns:dc2': 'http://purl.org/dc/elements/1.1',
-          },
-        }
-
-        expect(normalizeNamespaces(value)).toEqual(expected)
-      })
-
-      it('should handle namespace declarations without usage', () => {
-        const normalizeNamespaces = createNamespaceNormalizator(namespaceUris, namespacePrefixes)
-        const value = parser.parse(`
-          <?xml version="1.0"?>
-          <root
-            xmlns:dc="http://purl.org/dc/elements/1.1/"
-            xmlns:media="http://search.yahoo.com/mrss/"
-          >
-            <title>No namespaced elements</title>
-            <description>Just plain elements</description>
-          </root>
-        `)
-        const expected = {
-          root: {
-            title: 'No namespaced elements',
-            description: 'Just plain elements',
-            '@xmlns:dc': 'http://purl.org/dc/elements/1.1/',
-            '@xmlns:media': 'http://search.yahoo.com/mrss/',
-          },
-        }
-
-        expect(normalizeNamespaces(value)).toEqual(expected)
-      })
-
-      it('should handle mixed valid and invalid namespace values', () => {
-        const normalizeNamespaces = createNamespaceNormalizator(namespaceUris, namespacePrefixes)
-        const value = {
-          root: {
-            '@xmlns:dc': 'http://purl.org/dc/elements/1.1/',
-            '@xmlns:invalid1': '',
-            '@xmlns:invalid2': '   ',
-            '@xmlns:valid': 'http://example.com/',
-            'dc:creator': 'John Doe',
-            'invalid1:element': 'Value 1',
-            'invalid2:element': 'Value 2',
-            'valid:element': 'Value 3',
-          },
-        }
-        const expected = {
-          root: {
-            '@xmlns:dc': 'http://purl.org/dc/elements/1.1/',
-            '@xmlns:invalid1': '',
-            '@xmlns:invalid2': '   ',
-            '@xmlns:valid': 'http://example.com/',
-            'dc:creator': 'John Doe',
-            'invalid1:element': 'Value 1',
-            'invalid2:element': 'Value 2',
-            'valid:element': 'Value 3',
-          },
-        }
-
-        expect(normalizeNamespaces(value)).toEqual(expected)
-      })
-    })
-
-    describe('RDF primary namespace handling', () => {
-      it('should normalize RDF namespace elements and attributes including arrays', () => {
-        const normalizeNamespaces = createNamespaceNormalizator(namespaceUris, namespacePrefixes, [
-          'rdf',
-          'rss',
-        ])
-        const value = parser.parse(`
-          <?xml version="1.0" encoding="UTF-8"?>
-          <rdf:RDF
-            xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-            xmlns="http://purl.org/rss/1.0/"
-          >
-            <channel rdf:about="http://example.com">
-              <title>Test Feed</title>
-              <items>
-                <rdf:Seq>
-                  <rdf:li resource="http://example.com/item1"/>
-                  <rdf:li rdf:resource="http://example.com/item2"/>
-                </rdf:Seq>
-              </items>
-            </channel>
-            <item rdf:about="http://example.com/item1">
-              <title>Item 1</title>
-            </item>
-            <item rdf:about="http://example.com/item2">
-              <title>Item 2</title>
-            </item>
-          </rdf:RDF>
-        `)
-        const expected = {
-          rdf: {
-            '@xmlns:rdf': 'http://www.w3.org/1999/02/22-rdf-syntax-ns#',
-            '@xmlns': 'http://purl.org/rss/1.0/',
-            channel: {
-              title: 'Test Feed',
-              items: {
-                seq: {
-                  li: [
-                    { '@resource': 'http://example.com/item1' },
-                    { '@resource': 'http://example.com/item2' },
-                  ],
-                },
-              },
-              '@about': 'http://example.com',
-            },
-            item: [
-              { title: 'Item 1', '@about': 'http://example.com/item1' },
-              { title: 'Item 2', '@about': 'http://example.com/item2' },
-            ],
-          },
-        }
-
-        expect(normalizeNamespaces(value)).toEqual(expected)
-      })
-
-      it('should strip prefixes for multiple primary namespaces', () => {
-        const normalizeNamespaces = createNamespaceNormalizator(namespaceUris, namespacePrefixes, [
-          'rdf',
-          'rss',
-        ])
-        const value = parser.parse(`
-          <?xml version="1.0" encoding="UTF-8"?>
-          <rdf:RDF
-            xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-            xmlns:rss="http://purl.org/rss/1.0/"
-          >
-            <rss:channel>
-              <rss:title>Test Feed</rss:title>
-            </rss:channel>
-            <rss:item rdf:about="http://example.com/item1">
-              <rss:title>Item 1</rss:title>
-            </rss:item>
-          </rdf:RDF>
-        `)
-        const expected = {
-          rdf: {
-            '@xmlns:rdf': 'http://www.w3.org/1999/02/22-rdf-syntax-ns#',
-            '@xmlns:rss': 'http://purl.org/rss/1.0/',
-            channel: {
-              title: 'Test Feed',
-            },
-            item: {
-              title: 'Item 1',
-              '@about': 'http://example.com/item1',
-            },
-          },
-        }
-
-        expect(normalizeNamespaces(value)).toEqual(expected)
-      })
-    })
+    expect(value).toEqual(expected)
   })
 
-  describe('non-standard namespace URIs', () => {
-    it('should work with HTTPS variant and custom prefix', () => {
-      const normalizeNamespaces = createNamespaceNormalizator(namespaceUris, namespacePrefixes)
-      const value = {
-        item: {
-          '@xmlns:dublincore': 'https://purl.org/dc/elements/1.1/',
-          'dublincore:creator': 'John',
-        },
-      }
-      const expected = {
-        item: {
-          '@xmlns:dublincore': 'https://purl.org/dc/elements/1.1/',
-          'dc:creator': 'John',
-        },
-      }
+  it('should strip the prefix of a primary namespace', () => {
+    const parse = createParser(['atom'])
+    const value = parse(
+      '<atom:feed xmlns:atom="http://www.w3.org/2005/Atom"><atom:id>x</atom:id></atom:feed>',
+    )
+    const expected = { feed: { '@xmlns:atom': 'http://www.w3.org/2005/Atom', id: 'x' } }
 
-      expect(normalizeNamespaces(value)).toEqual(expected)
-    })
-
-    it('should work without trailing slash and custom prefix', () => {
-      const normalizeNamespaces = createNamespaceNormalizator(namespaceUris, namespacePrefixes)
-      const value = {
-        item: {
-          '@xmlns:dublincore': 'http://purl.org/dc/elements/1.1',
-          'dublincore:creator': 'John',
-        },
-      }
-      const expected = {
-        item: {
-          '@xmlns:dublincore': 'http://purl.org/dc/elements/1.1',
-          'dc:creator': 'John',
-        },
-      }
-
-      expect(normalizeNamespaces(value)).toEqual(expected)
-    })
-
-    it('should work with uppercase URI and custom prefix', () => {
-      const normalizeNamespaces = createNamespaceNormalizator(namespaceUris, namespacePrefixes)
-      const value = {
-        item: {
-          '@xmlns:dublincore': 'HTTP://PURL.ORG/DC/ELEMENTS/1.1/',
-          'dublincore:creator': 'John',
-        },
-      }
-      const expected = {
-        item: {
-          '@xmlns:dublincore': 'HTTP://PURL.ORG/DC/ELEMENTS/1.1/',
-          'dc:creator': 'John',
-        },
-      }
-
-      expect(normalizeNamespaces(value)).toEqual(expected)
-    })
-
-    it('should work with mixed case URI and custom prefix', () => {
-      const normalizeNamespaces = createNamespaceNormalizator(namespaceUris, namespacePrefixes)
-      const value = {
-        item: {
-          '@xmlns:dublincore': 'Http://Purl.Org/Dc/Elements/1.1/',
-          'dublincore:creator': 'John',
-        },
-      }
-      const expected = {
-        item: {
-          '@xmlns:dublincore': 'Http://Purl.Org/Dc/Elements/1.1/',
-          'dc:creator': 'John',
-        },
-      }
-
-      expect(normalizeNamespaces(value)).toEqual(expected)
-    })
-
-    it('should work with uppercase HTTPS URI and custom prefix', () => {
-      const normalizeNamespaces = createNamespaceNormalizator(namespaceUris, namespacePrefixes)
-      const value = {
-        item: {
-          '@xmlns:dublincore': 'HTTPS://PURL.ORG/DC/ELEMENTS/1.1/',
-          'dublincore:creator': 'John',
-        },
-      }
-      const expected = {
-        item: {
-          '@xmlns:dublincore': 'HTTPS://PURL.ORG/DC/ELEMENTS/1.1/',
-          'dc:creator': 'John',
-        },
-      }
-
-      expect(normalizeNamespaces(value)).toEqual(expected)
-    })
-
-    it('should work with URI containing whitespace around it', () => {
-      const normalizeNamespaces = createNamespaceNormalizator(namespaceUris, namespacePrefixes)
-      const value = {
-        item: {
-          '@xmlns:dublincore': '  http://purl.org/dc/elements/1.1/ ',
-          'dublincore:creator': 'John',
-        },
-      }
-      const expected = {
-        item: {
-          '@xmlns:dublincore': '  http://purl.org/dc/elements/1.1/ ',
-          'dc:creator': 'John',
-        },
-      }
-
-      expect(normalizeNamespaces(value)).toEqual(expected)
-    })
+    expect(value).toEqual(expected)
   })
 
-  describe('normalization skipping', () => {
-    it('should skip normalization when all prefixes match standard names', () => {
-      const normalizeNamespaces = createNamespaceNormalizator(namespaceUris, namespacePrefixes)
-      const value = {
-        rss: {
-          '@xmlns:dc': 'http://purl.org/dc/elements/1.1/',
-          '@xmlns:itunes': 'http://www.itunes.com/dtds/podcast-1.0.dtd',
-          '@version': '2.0',
-          channel: {
-            title: 'Test Feed',
-            'dc:creator': 'John',
-            'itunes:author': 'John',
-          },
+  it('should canonicalize an element that declares its own prefix', () => {
+    const parse = createParser()
+    const value = parse(
+      '<rss><myns:encoded xmlns:myns="http://purl.org/rss/1.0/modules/content/">Hi</myns:encoded></rss>',
+    )
+    const expected = {
+      rss: {
+        'content:encoded': {
+          '#text': 'Hi',
+          '@xmlns:myns': 'http://purl.org/rss/1.0/modules/content/',
         },
-      }
+      },
+    }
 
-      expect(normalizeNamespaces(value)).toBe(value)
-    })
+    expect(value).toEqual(expected)
+  })
 
-    it('should skip normalization when no xmlns declarations exist', () => {
-      const normalizeNamespaces = createNamespaceNormalizator(namespaceUris, namespacePrefixes)
-      const value = {
-        rss: {
-          '@version': '2.0',
-          channel: {
-            title: 'Test Feed',
-            '#text': 'Some text',
-          },
-        },
-      }
+  it('should prefix unprefixed elements under a recognized default namespace', () => {
+    const parse = createParser()
+    const value = parse('<box xmlns="http://search.yahoo.com/mrss/"><title>T</title></box>')
+    const expected = {
+      'media:box': { '@xmlns': 'http://search.yahoo.com/mrss/', 'media:title': 'T' },
+    }
 
-      expect(normalizeNamespaces(value)).toBe(value)
-    })
+    expect(value).toEqual(expected)
+  })
 
-    it('should skip normalization when default xmlns maps to primary namespace', () => {
-      const normalizeNamespaces = createNamespaceNormalizator(namespaceUris, namespacePrefixes, [
-        'atom',
-      ])
-      const value = {
-        feed: {
-          '@xmlns': 'http://www.w3.org/2005/Atom',
-          '@xmlns:dc': 'http://purl.org/dc/elements/1.1/',
-          title: 'Test Feed',
-          'dc:creator': 'John',
-        },
-      }
+  // A default namespace declared below the root scopes to its own subtree, which the
+  // parser gives no way to track; honoring it document wide would rename every later
+  // element and drop the entries that follow.
+  it('should ignore a default namespace declared below the root', () => {
+    const parse = createParser()
+    const value = parse(
+      '<rss><box xmlns="http://search.yahoo.com/mrss/"><title>T</title></box></rss>',
+    )
+    const expected = {
+      rss: { box: { '@xmlns': 'http://search.yahoo.com/mrss/', title: 'T' } },
+    }
 
-      expect(normalizeNamespaces(value)).toBe(value)
-    })
+    expect(value).toEqual(expected)
+  })
 
-    it('should skip normalization when xmlns URI is unknown', () => {
-      const normalizeNamespaces = createNamespaceNormalizator(namespaceUris, namespacePrefixes)
-      const value = {
-        root: {
-          '@xmlns:custom': 'http://example.com/unknown',
-          'custom:element': 'value',
-        },
-      }
+  it('should record a declaration whose attribute name is uppercased', () => {
+    const parse = createParser()
+    const value = parse(
+      '<rss XMLNS:CUSTOM="http://purl.org/dc/elements/1.1/"><CUSTOM:creator>A</CUSTOM:creator></rss>',
+    )
+    const expected = {
+      rss: { '@xmlns:custom': 'http://purl.org/dc/elements/1.1/', 'dc:creator': 'A' },
+    }
 
-      expect(normalizeNamespaces(value)).toBe(value)
-    })
+    expect(value).toEqual(expected)
+  })
 
-    it('should skip normalization with arrays containing standard prefixes', () => {
-      const normalizeNamespaces = createNamespaceNormalizator(namespaceUris, namespacePrefixes)
-      const value = {
-        rss: {
-          '@xmlns:dc': 'http://purl.org/dc/elements/1.1/',
-          channel: {
-            item: [
-              { title: 'Item 1', 'dc:creator': 'Alice' },
-              { title: 'Item 2', 'dc:creator': 'Bob' },
-            ],
-          },
-        },
-      }
+  it('should resolve namespace URI variants when canonicalizing', () => {
+    const parse = createParser()
+    const value = parse(
+      '<rss xmlns:a10="HTTPS://www.w3.org/2005/Atom/"><a10:title>Hello</a10:title></rss>',
+    )
+    const expected = {
+      rss: { '@xmlns:a10': 'HTTPS://www.w3.org/2005/Atom/', 'atom:title': 'Hello' },
+    }
 
-      expect(normalizeNamespaces(value)).toBe(value)
-    })
+    expect(value).toEqual(expected)
+  })
 
-    it('should not skip normalization when prefix differs from standard', () => {
-      const normalizeNamespaces = createNamespaceNormalizator(namespaceUris, namespacePrefixes)
-      const value = {
-        rss: {
-          '@xmlns:dublincore': 'http://purl.org/dc/elements/1.1/',
-          channel: {
-            'dublincore:creator': 'John',
-          },
-        },
-      }
+  it('should merge two prefixes bound to the same namespace onto one canonical key', () => {
+    const parse = createParser()
+    const value = parse(
+      '<rss xmlns:d1="http://purl.org/dc/elements/1.1/" xmlns:d2="https://purl.org/dc/elements/1.1/"><d1:creator>A</d1:creator><d2:creator>B</d2:creator></rss>',
+    )
+    const expected = {
+      rss: {
+        '@xmlns:d1': 'http://purl.org/dc/elements/1.1/',
+        '@xmlns:d2': 'https://purl.org/dc/elements/1.1/',
+        'dc:creator': ['A', 'B'],
+      },
+    }
 
-      expect(normalizeNamespaces(value)).not.toBe(value)
-    })
+    expect(value).toEqual(expected)
+  })
 
-    it('should not skip normalization when default xmlns maps to non-primary standard prefix', () => {
-      const normalizeNamespaces = createNamespaceNormalizator(namespaceUris, namespacePrefixes)
-      const value = {
-        root: {
-          '@xmlns': 'http://www.w3.org/2005/Atom',
-          title: 'Test',
-        },
-      }
+  it('should leave unknown prefixes untouched', () => {
+    const parse = createParser()
+    const value = parse('<rss xmlns:foo="urn:unknown"><foo:bar>x</foo:bar></rss>')
+    const expected = { rss: { '@xmlns:foo': 'urn:unknown', 'foo:bar': 'x' } }
 
-      expect(normalizeNamespaces(value)).not.toBe(value)
-    })
+    expect(value).toEqual(expected)
+  })
 
-    it('should not skip normalization when primary namespace has explicit prefix', () => {
-      const normalizeNamespaces = createNamespaceNormalizator(namespaceUris, namespacePrefixes, [
-        'rdf',
-        'rss',
-      ])
-      const value = {
-        'rdf:rdf': {
-          '@xmlns:rdf': 'http://www.w3.org/1999/02/22-rdf-syntax-ns#',
-          '@xmlns': 'http://purl.org/rss/1.0/',
-          'rdf:channel': {
-            title: 'Test',
-          },
-        },
-      }
+  it('should canonicalize namespaced attribute names', () => {
+    const parse = createParser()
+    const value = parse(
+      '<rss xmlns:rdf2="http://www.w3.org/1999/02/22-rdf-syntax-ns#"><item rdf2:about="u"/></rss>',
+    )
+    const expected = {
+      rss: {
+        '@xmlns:rdf2': 'http://www.w3.org/1999/02/22-rdf-syntax-ns#',
+        item: { '@rdf:about': 'u' },
+      },
+    }
 
-      expect(normalizeNamespaces(value)).not.toBe(value)
-    })
+    expect(value).toEqual(expected)
+  })
 
-    it('should not skip normalization when nested element has non-standard prefix', () => {
-      const normalizeNamespaces = createNamespaceNormalizator(namespaceUris, namespacePrefixes)
-      const value = {
-        rss: {
-          channel: {
-            item: {
-              '@xmlns:dublincore': 'http://purl.org/dc/elements/1.1/',
-              'dublincore:creator': 'John',
-            },
-          },
-        },
-      }
+  it('should not leak declarations between parses', () => {
+    const parse = createParser()
+    parse('<rss xmlns:a10="http://www.w3.org/2005/Atom"><a10:title>x</a10:title></rss>')
+    const value = parse('<rss><a10:title>y</a10:title></rss>')
+    const expected = { rss: { 'a10:title': 'y' } }
 
-      expect(normalizeNamespaces(value)).not.toBe(value)
-    })
-
-    it('should not skip normalization when array element has non-standard prefix', () => {
-      const normalizeNamespaces = createNamespaceNormalizator(namespaceUris, namespacePrefixes)
-      const value = {
-        rss: {
-          channel: {
-            item: [
-              {
-                '@xmlns:dublincore': 'http://purl.org/dc/elements/1.1/',
-                'dublincore:creator': 'Alice',
-              },
-            ],
-          },
-        },
-      }
-
-      expect(normalizeNamespaces(value)).not.toBe(value)
-    })
+    expect(value).toEqual(expected)
   })
 })
 

--- a/src/common/utils.ts
+++ b/src/common/utils.ts
@@ -613,259 +613,180 @@ export const generateNamespaceAttrs = (
   return namespaceAttrs
 }
 
-export const createNamespaceNormalizator = <T extends Record<string, Array<string>>>(
-  namespaceUris: T,
-  namespacePrefixes: Record<string, string>,
-  primaryNamespaces?: Array<keyof T>,
-) => {
-  const normalizedUriCache = new Map<string, string>()
+// Renames namespace prefixes to their canonical form while the document is being parsed,
+// so stop nodes can match `a10:title` as `atom:title`. Renaming after parsing would be
+// too late: stop nodes fire during it.
+//
+// Document order is what makes this work. By the time the parser hands over an element's
+// name, it has already read every ancestor's attributes, including their `xmlns:`
+// declarations, which attributeValueProcessor records into a map. transformTagName can
+// therefore rename the element right away. The one exception is an element that declares
+// its own prefix: its name arrives before its attributes, so updateTag renames it once
+// more after they are read.
+//
+// The map is flat and first-wins: real feeds declare namespaces once, on the root, and
+// re-binding a prefix deeper in a document has no observed usage. Add scope tracking if
+// such feeds ever appear.
+export const createNamespaceResolver = <T extends Record<string, Array<string>>>(options: {
+  namespaceUris: T
+  namespacePrefixes: Record<string, string>
+  primaryNamespaces?: Array<keyof T>
+}) => {
+  const { namespaceUris, namespacePrefixes, primaryNamespaces } = options
 
-  const normalizeNamespaceUri = (uri: string): string => {
-    if (typeof uri !== 'string') {
-      return uri
+  const primaryUris = new Set(
+    primaryNamespaces?.flatMap((key) => {
+      return namespaceUris[key]?.map((uri) => uri.toLowerCase()) ?? []
+    }),
+  )
+
+  // Canonical prefix for the URI, or an empty string when the URI is a primary namespace,
+  // whose elements go unprefixed. Undefined means the URI is not recognized.
+  const resolveUri = (uri: string): string | undefined => {
+    const normalized = uri.trim().toLowerCase()
+
+    if (primaryUris.has(normalized)) {
+      return ''
     }
 
-    let normalized = normalizedUriCache.get(uri)
-
-    if (normalized === undefined) {
-      normalized = uri.trim().toLowerCase()
-      normalizedUriCache.set(uri, normalized)
-    }
-
-    return normalized
+    return namespacePrefixes[normalized]
   }
 
-  const primaryNamespaceUris = primaryNamespaces?.length
-    ? primaryNamespaces.flatMap((key) => namespaceUris[key].map(normalizeNamespaceUri))
-    : undefined
+  // Every declaration a document makes lives in this call, so nothing survives the parse
+  // it belongs to and no state can leak into the next document.
+  return () => {
+    const prefixMap = new Map<string, string>()
+    let defaultCanonical: string | undefined
+    // Stays false while every declaration binds its conventional prefix, which keeps the
+    // per-tag work at a single boolean check for the overwhelming majority of feeds.
+    let hasRemapping = false
+    let tagsSeen = 0
 
-  const resolveNamespacePrefix = (uri: string, localName: string, fallback: string): string => {
-    const normalizedUri = normalizeNamespaceUri(uri)
+    const recordDeclaration = (rawAttrName: string, value: unknown) => {
+      // Anything not starting with "x" cannot be an xmlns declaration; bail before the
+      // string comparisons since this runs for every attribute in the document. The name
+      // arrives as written, so both cases are checked.
+      const firstCharCode = rawAttrName.charCodeAt(0)
 
-    if (primaryNamespaceUris?.includes(normalizedUri)) {
-      return localName
-    }
-
-    const standardPrefix = namespacePrefixes[normalizedUri]
-
-    if (standardPrefix) {
-      return `${standardPrefix}:${localName}`
-    }
-
-    return fallback
-  }
-
-  const extractNamespaceDeclarations = (element: Unreliable): Record<string, string> => {
-    const declarations: Record<string, string> = {}
-
-    if (isPlainObject(element)) {
-      // biome-ignore lint/suspicious/noForIn: Plain object; avoids per-call Object.keys allocation.
-      for (const key in element) {
-        if (key === '@xmlns') {
-          declarations[''] = normalizeNamespaceUri(element[key] as Unreliable)
-        } else if (key.indexOf('@xmlns:') === 0) {
-          const prefix = key.slice('@xmlns:'.length)
-          declarations[prefix] = normalizeNamespaceUri(element[key] as Unreliable)
-        }
-      }
-    }
-
-    return declarations
-  }
-
-  const normalizeWithContext = (
-    name: string,
-    context: Record<string, string>,
-    useDefault = false,
-  ): string => {
-    const colonIndex = name.indexOf(':')
-
-    if (colonIndex === -1) {
-      if (useDefault && context['']) {
-        return resolveNamespacePrefix(context[''], name, name)
+      if ((firstCharCode !== 120 && firstCharCode !== 88) || typeof value !== 'string') {
+        return
       }
 
-      return name
-    }
+      const attrName = rawAttrName.toLowerCase()
 
-    const prefix = name.slice(0, colonIndex)
-    const unprefixedName = name.slice(colonIndex + 1)
-    const uri = context[prefix]
+      if (attrName === 'xmlns') {
+        // Only the root's default namespace is honored. A default declared deeper scopes
+        // to its own subtree, which the parser gives no way to track, and applying it
+        // document wide would rename every later element: a feed carrying
+        // `<atom:link xmlns="...atom"/>` inside its channel would lose the items after it.
+        if (tagsSeen === 1 && defaultCanonical === undefined) {
+          defaultCanonical = resolveUri(value)
 
-    if (uri) {
-      return resolveNamespacePrefix(uri, unprefixedName, name)
-    }
-
-    return name
-  }
-
-  const normalizeKey = (key: string, context: Record<string, string>): string => {
-    if (key.charCodeAt(0) === 64) {
-      const attrName = key.slice(1)
-      const normalizedAttrName = normalizeWithContext(attrName, context, false)
-
-      return `@${normalizedAttrName}`
-    }
-
-    return normalizeWithContext(key, context, true)
-  }
-
-  const traverseAndNormalize = (
-    object: Unreliable,
-    parentContext: Record<string, string> = {},
-  ): Unreliable => {
-    // Check arrays first since isPlainObject() excludes arrays.
-    if (Array.isArray(object)) {
-      return object.map((item) => traverseAndNormalize(item, parentContext))
-    }
-
-    if (!isPlainObject(object)) {
-      return object
-    }
-
-    const declarations = extractNamespaceDeclarations(object)
-    // Avoid object spread if no new declarations (common case).
-    let hasDeclarations = false
-    // biome-ignore lint/suspicious/noForIn: Plain object; avoids per-call Object.keys allocation.
-    for (const _ in declarations) {
-      hasDeclarations = true
-      break
-    }
-    const currentContext = hasDeclarations ? { ...parentContext, ...declarations } : parentContext
-
-    const normalizedObject: Unreliable = {}
-
-    // biome-ignore lint/suspicious/noForIn: Plain object; avoids per-call Object.keys allocation.
-    for (const key in object) {
-      const value = object[key]
-
-      if (key.indexOf('@xmlns') === 0) {
-        normalizedObject[key] = value
-        continue
-      }
-
-      const normalizedKey = normalizeKey(key, currentContext)
-      const normalizedValue = traverseAndNormalize(value, currentContext)
-
-      // Handle key collisions inline (rare: different prefixes mapping to same namespace).
-      if (normalizedKey in normalizedObject) {
-        const existing = normalizedObject[normalizedKey]
-        if (Array.isArray(existing)) {
-          existing.push(normalizedValue)
-        } else {
-          normalizedObject[normalizedKey] = [existing, normalizedValue]
-        }
-      } else {
-        normalizedObject[normalizedKey] = normalizedValue
-      }
-    }
-
-    return normalizedObject
-  }
-
-  const needsNormalization = (object: Unreliable): boolean => {
-    const check = (value: Unreliable): boolean => {
-      if (Array.isArray(value)) {
-        for (const item of value) {
-          if (check(item)) {
-            return true
+          if (defaultCanonical) {
+            hasRemapping = true
           }
         }
 
-        return false
+        return
       }
 
-      if (!isPlainObject(value)) {
-        return false
-      }
+      if (attrName.startsWith('xmlns:')) {
+        const prefix = attrName.slice(6)
 
-      // biome-ignore lint/suspicious/noForIn: Plain object; avoids per-call Object.keys allocation.
-      for (const key in value) {
-        if (key[0] === '@') {
-          // Attribute key (@*) — only xmlns declarations matter.
-          if (key === '@xmlns') {
-            const normalizedUri = normalizeNamespaceUri(value[key] as Unreliable)
+        if (!prefixMap.has(prefix)) {
+          const canonical = resolveUri(value)
 
-            if (primaryNamespaceUris?.includes(normalizedUri)) {
-              // Default namespace maps to a primary namespace — unprefixed
-              // elements stay unprefixed, so no remapping is needed.
-              continue
-            }
+          if (canonical !== undefined) {
+            prefixMap.set(prefix, canonical)
 
-            if (namespacePrefixes[normalizedUri]) {
-              // Default namespace maps to a non-primary standard prefix —
-              // unprefixed elements need to be prefixed.
-              return true
-            }
-          } else if (key.startsWith('@xmlns:')) {
-            const prefix = key.slice(7)
-            const normalizedUri = normalizeNamespaceUri(value[key] as Unreliable)
-            const standardPrefix = namespacePrefixes[normalizedUri]
-
-            if (standardPrefix) {
-              if (primaryNamespaceUris?.includes(normalizedUri)) {
-                // Primary namespace with explicit prefix — normalization
-                // strips the prefix (e.g., rdf:channel → channel).
-                return true
-              }
-
-              if (standardPrefix !== prefix) {
-                return true
-              }
+            if (canonical !== prefix) {
+              hasRemapping = true
             }
           }
-
-          continue
-        }
-
-        // Skip text/cdata nodes (#text, #cdata) — never contain xmlns.
-        if (key[0] === '#') {
-          continue
-        }
-
-        // Recurse into child elements only.
-        if (check(value[key])) {
-          return true
         }
       }
-
-      return false
     }
 
-    return check(object)
+    const transformName = (name: string, useDefault: boolean): string => {
+      const lowered = name.toLowerCase()
+
+      if (!hasRemapping) {
+        return lowered
+      }
+
+      const colonIndex = lowered.indexOf(':')
+
+      if (colonIndex === -1) {
+        if (useDefault && defaultCanonical) {
+          return `${defaultCanonical}:${lowered}`
+        }
+
+        return lowered
+      }
+
+      const prefix = lowered.slice(0, colonIndex)
+
+      if (prefix === 'xmlns' || prefix === 'xml') {
+        return lowered
+      }
+
+      const canonical = prefixMap.get(prefix)
+
+      if (canonical === undefined) {
+        return lowered
+      }
+
+      const local = lowered.slice(colonIndex + 1)
+
+      return canonical === '' ? local : `${canonical}:${local}`
+    }
+
+    const transformTagName = (name: string) => {
+      tagsSeen++
+
+      return transformName(name, true)
+    }
+
+    // The parser hands attribute names in with the `@` marker already applied.
+    const transformAttributeName = (name: string) => `@${transformName(name.slice(1), false)}`
+
+    const attributeValueProcessor = (attrName: string, value: unknown) => {
+      recordDeclaration(attrName, value)
+
+      return value
+    }
+
+    // Re-canonicalize with the now-complete maps: a name transformed before its own
+    // element's declarations were read gets its final form here. The name arrives already
+    // lowercased and usually already canonical, so every unchanged path returns the same
+    // string without allocating.
+    const updateTag = (tagName: string) => {
+      if (!hasRemapping) {
+        return tagName
+      }
+
+      const colonIndex = tagName.indexOf(':')
+
+      if (colonIndex === -1) {
+        return defaultCanonical ? `${defaultCanonical}:${tagName}` : tagName
+      }
+
+      // The reserved xmlns/xml prefixes never appear as element names and are never
+      // recorded in the map, so the lookup alone leaves them unchanged.
+      const prefix = tagName.slice(0, colonIndex)
+      const canonical = prefixMap.get(prefix)
+
+      if (canonical === undefined || canonical === prefix) {
+        return tagName
+      }
+
+      const local = tagName.slice(colonIndex + 1)
+
+      return canonical === '' ? local : `${canonical}:${local}`
+    }
+
+    return { transformTagName, transformAttributeName, attributeValueProcessor, updateTag }
   }
-
-  // For the root level, we need to handle the special case where the root element
-  // itself has namespace declarations that apply to its own normalization.
-  const normalizeRoot = (object: Unreliable): Unreliable => {
-    if (!isPlainObject(object)) {
-      return object
-    }
-
-    if (!needsNormalization(object)) {
-      return object
-    }
-
-    const normalizedObject: Unreliable = {}
-
-    // biome-ignore lint/suspicious/noForIn: Plain object; avoids per-call Object.keys allocation.
-    for (const key in object) {
-      const value = object[key]
-
-      // Extract namespace declarations from the value to see if they apply to the key.
-      const declarations = extractNamespaceDeclarations(value)
-      // If this element has declarations, use them to normalize its own key.
-      const normalizedKey = Object.keys(declarations).length ? normalizeKey(key, declarations) : key
-      // Process the value with empty parent context since this is root.
-      const normalizedValue = traverseAndNormalize(value)
-
-      normalizedObject[normalizedKey] = normalizedValue
-    }
-
-    return normalizedObject
-  }
-
-  return normalizeRoot
 }
 
 export const parseJsonObject = (value: unknown): unknown => {

--- a/src/feeds/atom/parse/config.ts
+++ b/src/feeds/atom/parse/config.ts
@@ -1,11 +1,4 @@
-import { XMLParser } from 'fast-xml-parser'
-import {
-  namespacePrefixes,
-  namespaceStopNodes,
-  namespaceUris,
-  parserConfig,
-} from '../../../common/config.js'
-import { createNamespaceNormalizator } from '../../../common/utils.js'
+import { namespaceStopNodes } from '../../../common/config.js'
 import { entryPaths, feedPaths } from '../../../namespaces/atom/common/config.js'
 
 export const stopNodes = [
@@ -13,12 +6,3 @@ export const stopNodes = [
   ...feedPaths.map((path) => `feed.${path}`),
   ...entryPaths.map((path) => `feed.entry.${path}`),
 ]
-
-export const parser = new XMLParser({
-  ...parserConfig,
-  stopNodes,
-})
-
-export const normalizeNamespaces = createNamespaceNormalizator(namespaceUris, namespacePrefixes, [
-  'atom',
-])

--- a/src/feeds/atom/parse/index.test.ts
+++ b/src/feeds/atom/parse/index.test.ts
@@ -222,6 +222,27 @@ describe('parse', () => {
     expect(parse(value)).toEqual(expected)
   })
 
+  describe('known limitations', () => {
+    // The root element declares its own prefix, so its name reaches the stop-node matcher
+    // before the declaration is recorded and the path-anchored stop nodes miss; the xhtml
+    // title is parsed into an element tree and its value is lost. Seeding the declaration
+    // map from a pre-parse scan of the document would close this.
+    it('should lose an xhtml title in a fully prefixed Atom feed', () => {
+      const value = `
+        <?xml version="1.0" encoding="utf-8"?>
+        <atom:feed xmlns:atom="http://www.w3.org/2005/Atom">
+          <atom:id>example-feed</atom:id>
+          <atom:title type="xhtml"><div xmlns="http://www.w3.org/1999/xhtml"><p>a &lt; b</p></div></atom:title>
+        </atom:feed>
+      `
+      const expected = {
+        id: 'example-feed',
+      }
+
+      expect(parse(value)).toEqual(expected)
+    })
+  })
+
   it('should throw error for invalid input', () => {
     const throwing = () => parse('not a feed')
 

--- a/src/feeds/atom/parse/index.ts
+++ b/src/feeds/atom/parse/index.ts
@@ -1,10 +1,31 @@
-import { locales } from '../../../common/config.js'
+import { XMLParser } from 'fast-xml-parser'
+import { locales, namespacePrefixes, namespaceUris, parserConfig } from '../../../common/config.js'
 import { DetectError, MalformedError, ParseError } from '../../../common/errors.js'
 import type { ParseMainOptions, Unreliable } from '../../../common/types.js'
+import { createNamespaceResolver } from '../../../common/utils.js'
 import { detectAtomFeed } from '../../../index.js'
 import type { AtomFeed } from '../common/types.js'
-import { normalizeNamespaces, parser } from './config.js'
+import { stopNodes } from './config.js'
 import { retrieveFeed } from './utils.js'
+
+const createNamespaceOptions = createNamespaceResolver({
+  namespaceUris,
+  namespacePrefixes,
+  primaryNamespaces: ['atom'],
+})
+
+// Replaced per document, so the hooks below always read the declarations of the feed
+// being parsed and nothing survives into the next one.
+let namespaceOptions = createNamespaceOptions()
+
+const parser = new XMLParser({
+  ...parserConfig,
+  stopNodes,
+  transformTagName: (name) => namespaceOptions.transformTagName(name),
+  transformAttributeName: (name) => namespaceOptions.transformAttributeName(name),
+  attributeValueProcessor: (name, value) => namespaceOptions.attributeValueProcessor(name, value),
+  updateTag: (name) => namespaceOptions.updateTag(name),
+})
 
 export const parse = <TDate = string>(
   value: unknown,
@@ -17,8 +38,8 @@ export const parse = <TDate = string>(
   let normalized: Unreliable
 
   try {
-    const object = parser.parse(value)
-    normalized = normalizeNamespaces(object)
+    namespaceOptions = createNamespaceOptions()
+    normalized = parser.parse(value)
   } catch (error) {
     throw new MalformedError(locales.invalidFeedFormat, { cause: error })
   }

--- a/src/feeds/rdf/parse/config.ts
+++ b/src/feeds/rdf/parse/config.ts
@@ -1,11 +1,4 @@
-import { XMLParser } from 'fast-xml-parser'
-import {
-  namespacePrefixes,
-  namespaceStopNodes,
-  namespaceUris,
-  parserConfig,
-} from '../../../common/config.js'
-import { createNamespaceNormalizator } from '../../../common/utils.js'
+import { namespaceStopNodes } from '../../../common/config.js'
 
 export const stopNodes = [
   ...namespaceStopNodes,
@@ -23,13 +16,3 @@ export const stopNodes = [
   'rdf:rdf.textinput.name',
   'rdf:rdf.textinput.link',
 ]
-
-export const parser = new XMLParser({
-  ...parserConfig,
-  stopNodes,
-})
-
-export const normalizeNamespaces = createNamespaceNormalizator(namespaceUris, namespacePrefixes, [
-  'rdf',
-  'rss',
-])

--- a/src/feeds/rdf/parse/index.ts
+++ b/src/feeds/rdf/parse/index.ts
@@ -1,10 +1,31 @@
-import { locales } from '../../../common/config.js'
+import { XMLParser } from 'fast-xml-parser'
+import { locales, namespacePrefixes, namespaceUris, parserConfig } from '../../../common/config.js'
 import { DetectError, MalformedError, ParseError } from '../../../common/errors.js'
 import type { ParseMainOptions, Unreliable } from '../../../common/types.js'
+import { createNamespaceResolver } from '../../../common/utils.js'
 import { detectRdfFeed } from '../../../index.js'
 import type { RdfFeed } from '../common/types.js'
-import { normalizeNamespaces, parser } from './config.js'
+import { stopNodes } from './config.js'
 import { retrieveFeed } from './utils.js'
+
+const createNamespaceOptions = createNamespaceResolver({
+  namespaceUris,
+  namespacePrefixes,
+  primaryNamespaces: ['rdf', 'rss'],
+})
+
+// Replaced per document, so the hooks below always read the declarations of the feed
+// being parsed and nothing survives into the next one.
+let namespaceOptions = createNamespaceOptions()
+
+const parser = new XMLParser({
+  ...parserConfig,
+  stopNodes,
+  transformTagName: (name) => namespaceOptions.transformTagName(name),
+  transformAttributeName: (name) => namespaceOptions.transformAttributeName(name),
+  attributeValueProcessor: (name, value) => namespaceOptions.attributeValueProcessor(name, value),
+  updateTag: (name) => namespaceOptions.updateTag(name),
+})
 
 export const parse = <TDate = string>(
   value: unknown,
@@ -17,8 +38,8 @@ export const parse = <TDate = string>(
   let normalized: Unreliable
 
   try {
-    const object = parser.parse(value)
-    normalized = normalizeNamespaces(object)
+    namespaceOptions = createNamespaceOptions()
+    normalized = parser.parse(value)
   } catch (error) {
     throw new MalformedError(locales.invalidFeedFormat, { cause: error })
   }

--- a/src/feeds/rss/parse/config.ts
+++ b/src/feeds/rss/parse/config.ts
@@ -1,11 +1,4 @@
-import { XMLParser } from 'fast-xml-parser'
-import {
-  namespacePrefixes,
-  namespaceStopNodes,
-  namespaceUris,
-  parserConfig,
-} from '../../../common/config.js'
-import { createNamespaceNormalizator } from '../../../common/utils.js'
+import { namespaceStopNodes } from '../../../common/config.js'
 
 // These elements can appear both inside <channel> and as direct children of
 // <rss> in malformed feeds, so stop nodes are generated for both paths.
@@ -56,10 +49,3 @@ export const stopNodes = [
   ...sharedStopNodes.map((node) => `rss.channel.${node}`),
   ...sharedStopNodes.map((node) => `rss.${node}`),
 ]
-
-export const parser = new XMLParser({
-  ...parserConfig,
-  stopNodes,
-})
-
-export const normalizeNamespaces = createNamespaceNormalizator(namespaceUris, namespacePrefixes)

--- a/src/feeds/rss/parse/index.test.ts
+++ b/src/feeds/rss/parse/index.test.ts
@@ -1475,6 +1475,47 @@ describe('parse', () => {
         expect(parse(value)).toEqual(expected)
       })
 
+      // A hosting platform emits this shape: a default namespace declared on an element
+      // inside the channel. Honoring it beyond that element renamed every later element
+      // and left the feed with no items.
+      it('should keep items when a nested element declares a default namespace', () => {
+        const value = `
+          <?xml version="1.0" encoding="UTF-8"?>
+          <rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+            <channel>
+              <atom:link href="https://example.com/feed" rel="self"/>
+              <atom:link href="https://hub.example.com" rel="hub" xmlns="http://www.w3.org/2005/Atom"/>
+              <title>Podcast</title>
+              <description>Desc</description>
+              <item>
+                <title>Ep 1</title>
+                <guid>1</guid>
+              </item>
+              <item>
+                <title>Ep 2</title>
+                <guid>2</guid>
+              </item>
+            </channel>
+          </rss>
+        `
+        const expected = {
+          title: 'Podcast',
+          description: 'Desc',
+          atom: {
+            links: [
+              { href: 'https://example.com/feed', rel: 'self' },
+              { href: 'https://hub.example.com', rel: 'hub' },
+            ],
+          },
+          items: [
+            { title: 'Ep 1', guid: { value: '1' } },
+            { title: 'Ep 2', guid: { value: '2' } },
+          ],
+        }
+
+        expect(parse(value)).toEqual(expected)
+      })
+
       it('should parse atom xhtml content in RSS item with the div wrapper stripped', () => {
         const value = `
           <?xml version="1.0" encoding="UTF-8"?>
@@ -1505,6 +1546,71 @@ describe('parse', () => {
                 },
                 content: {
                   value: '<p>Rich <em>text</em></p>',
+                  type: 'xhtml',
+                },
+              },
+            },
+          ],
+        }
+
+        expect(parse(value)).toEqual(expected)
+      })
+
+      it('should parse a namespaced element that declares its own prefix', () => {
+        const value = `
+          <?xml version="1.0" encoding="UTF-8"?>
+          <rss version="2.0">
+            <channel>
+              <title>Test</title>
+              <link>https://example.com</link>
+              <description>Test</description>
+              <item>
+                <title>Item</title>
+                <myns:encoded xmlns:myns="http://purl.org/rss/1.0/modules/content/"><![CDATA[<p>Hello</p>]]></myns:encoded>
+              </item>
+            </channel>
+          </rss>
+        `
+        const expected = {
+          title: 'Test',
+          link: 'https://example.com',
+          description: 'Test',
+          items: [
+            {
+              title: 'Item',
+              content: { encoded: '<p>Hello</p>' },
+            },
+          ],
+        }
+
+        expect(parse(value)).toEqual(expected)
+      })
+
+      it('should parse xhtml content under the a10 prefix', () => {
+        const value = `
+          <?xml version="1.0" encoding="UTF-8"?>
+          <rss version="2.0" xmlns:a10="http://www.w3.org/2005/Atom">
+            <channel>
+              <title>Test</title>
+              <link>https://example.com</link>
+              <description>Test</description>
+              <item>
+                <title>Item</title>
+                <a10:content type="xhtml"><div xmlns="http://www.w3.org/1999/xhtml"><p>a &lt; b</p></div></a10:content>
+              </item>
+            </channel>
+          </rss>
+        `
+        const expected = {
+          title: 'Test',
+          link: 'https://example.com',
+          description: 'Test',
+          items: [
+            {
+              title: 'Item',
+              atom: {
+                content: {
+                  value: '<p>a &lt; b</p>',
                   type: 'xhtml',
                 },
               },
@@ -4623,6 +4729,45 @@ describe('parse', () => {
         },
       }
       expect(parse(value, { parseDateFn: (raw) => new Date(raw) })).toEqual(expected)
+    })
+  })
+
+  describe('known limitations', () => {
+    // An element that declares its own namespace prefix reaches the stop-node matcher
+    // before the declaration is recorded, so its inline markup is parsed into an element
+    // tree and the value is lost; the key itself still canonicalizes. The parser offers no
+    // hook between reading the attributes and the stop-node check; seeding the declaration
+    // map from a pre-parse scan of the document would close this.
+    it('should lose the xhtml value of a construct that declares its own prefix', () => {
+      const value = `
+        <?xml version="1.0" encoding="UTF-8"?>
+        <rss version="2.0">
+          <channel>
+            <title>Test</title>
+            <link>https://example.com</link>
+            <description>Test</description>
+            <item>
+              <title>Item</title>
+              <myatom:content xmlns:myatom="http://www.w3.org/2005/Atom" type="xhtml"><div xmlns="http://www.w3.org/1999/xhtml"><p>Text</p></div></myatom:content>
+            </item>
+          </channel>
+        </rss>
+      `
+      const expected = {
+        title: 'Test',
+        link: 'https://example.com',
+        description: 'Test',
+        items: [
+          {
+            title: 'Item',
+            atom: {
+              content: { type: 'xhtml' },
+            },
+          },
+        ],
+      }
+
+      expect(parse(value)).toEqual(expected)
     })
   })
 })

--- a/src/feeds/rss/parse/index.ts
+++ b/src/feeds/rss/parse/index.ts
@@ -1,10 +1,27 @@
-import { locales } from '../../../common/config.js'
+import { XMLParser } from 'fast-xml-parser'
+import { locales, namespacePrefixes, namespaceUris, parserConfig } from '../../../common/config.js'
 import { DetectError, MalformedError, ParseError } from '../../../common/errors.js'
 import type { ParseMainOptions, Unreliable } from '../../../common/types.js'
+import { createNamespaceResolver } from '../../../common/utils.js'
 import { detectRssFeed } from '../../../index.js'
 import type { RssFeed } from '../common/types.js'
-import { normalizeNamespaces, parser } from './config.js'
+import { stopNodes } from './config.js'
 import { retrieveFeed } from './utils.js'
+
+const createNamespaceOptions = createNamespaceResolver({ namespaceUris, namespacePrefixes })
+
+// Replaced per document, so the hooks below always read the declarations of the feed
+// being parsed and nothing survives into the next one.
+let namespaceOptions = createNamespaceOptions()
+
+const parser = new XMLParser({
+  ...parserConfig,
+  stopNodes,
+  transformTagName: (name) => namespaceOptions.transformTagName(name),
+  transformAttributeName: (name) => namespaceOptions.transformAttributeName(name),
+  attributeValueProcessor: (name, value) => namespaceOptions.attributeValueProcessor(name, value),
+  updateTag: (name) => namespaceOptions.updateTag(name),
+})
 
 export const parse = <TDate = string>(
   value: unknown,
@@ -17,8 +34,8 @@ export const parse = <TDate = string>(
   let normalized: Unreliable
 
   try {
-    const object = parser.parse(value)
-    normalized = normalizeNamespaces(object)
+    namespaceOptions = createNamespaceOptions()
+    normalized = parser.parse(value)
   } catch (error) {
     throw new MalformedError(locales.invalidFeedFormat, { cause: error })
   }

--- a/src/namespaces/atom/common/config.ts
+++ b/src/namespaces/atom/common/config.ts
@@ -75,6 +75,8 @@ const prefixSegments = (path: string) => {
     .join('.')
 }
 
+// Prefixes are canonicalized to `atom:` during parsing (createNamespaceHooks), so
+// alternates like `a10:` match these entries too.
 export const stopNodes = [...new Set([...feedPaths, ...entryPaths])].map((path) => {
   return `*.${prefixSegments(path)}`
 })


### PR DESCRIPTION
Stacked on #334; base retargets as the stack merges.

Namespace canonicalization moves from a post-parse tree walk into the parser, through three fast-xml-parser hooks sharing a per-document declaration map. Document order does the work: every ancestor's attributes stream past before a descendant's tag name is transformed, so by the time `<a10:title>` reaches `transformTagName` the root's `xmlns:a10` is recorded and the tag becomes `atom:title` before stop-node matching. `createNamespaceNormalizator` and its walk are deleted, net −900 lines.

What the walk could not do:

- Stop nodes match any prefix a feed uses. They fire during parsing on literal tag names, so a post-parse rename was always too late and only the conventional prefix ever worked. `a10:` (127 of 49,707 sampled feeds, the only alternate Atom prefix in the corpus) needs no dedicated entries.
- An element declaring its own prefix parses at all. `<myns:encoded xmlns:myns="…/content/">` in an RSS item kept its unrecognized key and lost its value, because the walk applied an element's declarations to its children only. `updateTag` re-canonicalizes the name after the attributes are read.

Deferred to #336: such an element still reaches the stop-node matcher before its declaration is recorded, so its xhtml value is lost even though the key canonicalizes. There is no hook between reading attributes and the stop-node check, so the fix is seeding the map from a pre-parse scan. Two `known limitations` tests pin the behaviour until then.

Scoping rules, both narrower than the walk's:

- Only the root's default `xmlns` is honoured. A default declared deeper scopes to its subtree, which the hooks cannot track, and applying it document-wide renames every later element: a feed carrying `<atom:link xmlns="…atom"/>` inside its channel lost every item that followed. Simplecast emits exactly that, and 5 feeds in `benchmarks/files` were affected.
- Prefix bindings are flat and first-wins. Re-binding a prefix deeper in a document has no observed usage in the sample.

`hasRemapping` keeps the per-tag cost at one boolean check for feeds whose declarations all use conventional prefixes, which is nearly all of them.

## Performance

`benchmarks/javascript`, hyperfine, this branch against its parent:

| Scenario | Post-parse walk | Parse-time hooks |
|---|---|---|
| rss-small (100 files) | 470.9 ± 6.0 ms | 469.0 ± 2.0 ms |
| atom-small (100 files) | 2.485 ± 0.021 s | 2.484 ± 0.010 s |
| rdf (97 files) | 276.8 ± 3.3 ms | 278.4 ± 2.4 ms |

Parity. The walk was already near-free for conventional feeds thanks to its skip check, and the flag preserves that; the win is capability and code size. The whole stack against `3.0.0-rc.2` lands within ±2% on every scenario.

Parsing all 479 feeds in `benchmarks/files` gives byte-identical output to `rc`.
