### PR TITLE
feat: Seed namespace declarations from a pre-parse document scan

### DIFF
--- a/src/common/utils.test.ts
+++ b/src/common/utils.test.ts
@@ -3273,7 +3273,7 @@ describe('createNamespaceResolver', () => {
         ignoreAttributes: false,
         attributeNamePrefix: '@',
         stopNodes,
-        ...createNamespaceOptions(),
+        ...createNamespaceOptions(value),
       }).parse(value)
   }
 
@@ -3400,6 +3400,140 @@ describe('createNamespaceResolver', () => {
     }
 
     expect(value).toEqual(expected)
+  })
+
+  it('should seed a self-declared prefix so its stop node captures raw content', () => {
+    const parse = createParser(undefined, ['*.content:encoded'])
+    const value = `
+      <rss>
+        <myns:encoded xmlns:myns="http://purl.org/rss/1.0/modules/content/"><b>Hi</b></myns:encoded>
+      </rss>
+    `
+    const expected = {
+      rss: {
+        'content:encoded': {
+          '#text': '<b>Hi</b>',
+          '@xmlns:myns': 'http://purl.org/rss/1.0/modules/content/',
+        },
+      },
+    }
+
+    expect(parse(value)).toEqual(expected)
+  })
+
+  it('should seed declarations spelled with single quotes and spacing', () => {
+    const parse = createParser(undefined, ['*.content:encoded'])
+    const value = `
+      <rss>
+        <myns:encoded xmlns:myns = 'http://purl.org/rss/1.0/modules/content/'><b>Hi</b></myns:encoded>
+      </rss>
+    `
+    const expected = {
+      rss: {
+        'content:encoded': {
+          '#text': '<b>Hi</b>',
+          '@xmlns:myns': 'http://purl.org/rss/1.0/modules/content/',
+        },
+      },
+    }
+
+    expect(parse(value)).toEqual(expected)
+  })
+
+  it('should not seed a declaration past the scan cap', () => {
+    const parse = createParser(undefined, ['*.content:encoded'])
+    // The comment pushes the declaration past the 64KB seed window. The element still
+    // renames, since its own declaration arrives with its attributes, but the stop node
+    // missed it, so the content parses as structure instead of raw text.
+    const value = `
+      <rss>
+        <!-- ${'x'.repeat(70000)} -->
+        <myns:encoded xmlns:myns="http://purl.org/rss/1.0/modules/content/"><b>Hi</b></myns:encoded>
+      </rss>
+    `
+    const expected = {
+      rss: {
+        'content:encoded': {
+          b: 'Hi',
+          '@xmlns:myns': 'http://purl.org/rss/1.0/modules/content/',
+        },
+      },
+    }
+
+    expect(parse(value)).toEqual(expected)
+  })
+
+  it('should fall back to a whole-document scan when no root element is found', () => {
+    const createNamespaceOptions = createNamespaceResolver({ namespaceUris, namespacePrefixes })
+    // Markup, but no element to anchor on, so the scan covers the whole string. Such a
+    // document is not a feed and never reaches the parser in practice.
+    const options = createNamespaceOptions('<!-- xmlns:a="http://purl.org/dc/elements/1.1/" -->')
+    const parser = new XMLParser({ ignoreAttributes: false, attributeNamePrefix: '@', ...options })
+    const expected = { rss: { 'dc:title': 'T' } }
+
+    expect(parser.parse('<rss><a:title>T</a:title></rss>')).toEqual(expected)
+  })
+
+  it('should fall back to a whole-document scan when a comment never closes', () => {
+    const createNamespaceOptions = createNamespaceResolver({ namespaceUris, namespacePrefixes })
+    // The comment never closes, so no root can be found and the scan falls back to the
+    // whole string.
+    const options = createNamespaceOptions('<!-- xmlns:a="http://purl.org/dc/elements/1.1/"')
+    const parser = new XMLParser({ ignoreAttributes: false, attributeNamePrefix: '@', ...options })
+    const expected = { rss: { 'dc:title': 'T' } }
+
+    expect(parser.parse('<rss><a:title>T</a:title></rss>')).toEqual(expected)
+  })
+
+  // The scan matches `xmlns:` case-sensitively, so an uppercased declaration is only seen
+  // by the streaming recorder, after the element's own name was transformed; updateTag is
+  // what repairs the name afterwards.
+  it('should canonicalize a self-declared prefix the scan cannot see', () => {
+    const parse = createParser()
+    const value =
+      '<rss><FOO:creator XMLNS:FOO="http://purl.org/dc/elements/1.1/">A</FOO:creator></rss>'
+    const expected = {
+      rss: {
+        'dc:creator': { '#text': 'A', '@xmlns:foo': 'http://purl.org/dc/elements/1.1/' },
+      },
+    }
+
+    expect(parse(value)).toEqual(expected)
+  })
+
+  it('should let a real declaration replace a seeded guess', () => {
+    const parse = createParser()
+    const value = `
+      <rss xmlns:custom="http://search.yahoo.com/mrss/">
+        <item>
+          <note><![CDATA[ xmlns:custom="http://purl.org/dc/elements/1.1/" ]]></note>
+          <custom:title>T</custom:title>
+        </item>
+      </rss>
+    `
+    const expected = {
+      rss: {
+        '@xmlns:custom': 'http://search.yahoo.com/mrss/',
+        item: {
+          note: ' xmlns:custom="http://purl.org/dc/elements/1.1/" ',
+          'media:title': 'T',
+        },
+      },
+    }
+
+    expect(parse(value)).toEqual(expected)
+  })
+
+  it('should ignore a declaration-shaped string before the root element', () => {
+    const parse = createParser(['rdf'])
+    const value = `
+      <!-- xmlns:rdf="http://purl.org/dc/elements/1.1/" -->
+      <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+        <channel>T</channel>
+      </rdf:RDF>
+    `
+
+    expect(Object.keys(parse(value) as Record<string, unknown>)).toContain('rdf')
   })
 
   it('should not leak declarations between parses', () => {

--- a/src/common/utils.ts
+++ b/src/common/utils.ts
@@ -652,15 +652,98 @@ export const createNamespaceResolver = <T extends Record<string, Array<string>>>
     return namespacePrefixes[normalized]
   }
 
+  // Far above the deepest alternate-prefix declaration observed in real feeds.
+  const seedScanLimit = 65536
+
+  // Everything before the root element is a comment, a processing instruction or a
+  // doctype, none of which can carry a declaration. A document with no root is not a feed
+  // and never reaches the parser; the scan then simply starts at the beginning.
+  const findRootIndex = (document: string): number => {
+    let index = document.indexOf('<')
+
+    while (index !== -1) {
+      const marker = document.charCodeAt(index + 1)
+
+      // A letter or underscore starts a tag name, so this is the root.
+      if (marker !== 63 && marker !== 33) {
+        return index
+      }
+
+      const end = document.startsWith('<!--', index)
+        ? document.indexOf('-->', index)
+        : document.indexOf('>', index)
+
+      if (end === -1) {
+        return -1
+      }
+
+      index = document.indexOf('<', end)
+    }
+
+    return -1
+  }
+
   // Every declaration a document makes lives in this call, so nothing survives the parse
   // it belongs to and no state can leak into the next document.
-  return () => {
+  return (document?: string) => {
     const prefixMap = new Map<string, string>()
+    const seededPrefixes = new Set<string>()
     let defaultCanonical: string | undefined
     // Stays false while every declaration binds its conventional prefix, which keeps the
     // per-tag work at a single boolean check for the overwhelming majority of feeds.
     let hasRemapping = false
     let tagsSeen = 0
+
+    const recordPrefix = (prefix: string, uri: string) => {
+      if (!prefixMap.has(prefix)) {
+        const canonical = resolveUri(uri)
+
+        if (canonical !== undefined) {
+          prefixMap.set(prefix, canonical)
+
+          if (canonical !== prefix) {
+            hasRemapping = true
+          }
+        }
+      }
+    }
+
+    // The parser matches stop nodes against an element's name before reading its own
+    // attributes, so an element that declares its own prefix would miss them. Seeding the
+    // map from the raw document first closes that gap. Only prefixed declarations are
+    // seeded: a default `xmlns` cannot be scoped without parsing. The scan starts at the
+    // root element because junk before it is the one case a later real declaration cannot
+    // repair, the root's own name being resolved before its attributes are read.
+    if (document) {
+      // Only the head of the document is scanned, which keeps the cost flat on
+      // multi-megabyte feeds. Alternate prefixes, the reason the seed exists, are declared
+      // at the top of real documents; declarations found deeper either already spell the
+      // canonical prefix or resolve to no known namespace, so seeding them would change
+      // nothing. An alternate past the cap falls back to in-order discovery, the behavior
+      // every element had before seeding existed.
+      const head = document.length > seedScanLimit ? document.slice(0, seedScanLimit) : document
+
+      // indexOf jumps from one `xmlns:` occurrence to the next, and the sticky regex then
+      // reads just the `prefix="uri"` pair at that spot, so no regex ever scans the
+      // document itself.
+      const declarationTailRegex = /([\w.-]+)\s*=\s*(?:"([^"]*)"|'([^']*)')/y
+
+      let index = head.indexOf('xmlns:', findRootIndex(head))
+
+      while (index !== -1) {
+        declarationTailRegex.lastIndex = index + 6
+        const match = declarationTailRegex.exec(head)
+
+        if (match) {
+          const prefix = match[1].toLowerCase()
+
+          recordPrefix(prefix, match[2] ?? match[3])
+          seededPrefixes.add(prefix)
+        }
+
+        index = head.indexOf('xmlns:', match ? declarationTailRegex.lastIndex : index + 6)
+      }
+    }
 
     const recordDeclaration = (rawAttrName: string, value: unknown) => {
       // Anything not starting with "x" cannot be an xmlns declaration; bail before the
@@ -693,17 +776,13 @@ export const createNamespaceResolver = <T extends Record<string, Array<string>>>
       if (attrName.startsWith('xmlns:')) {
         const prefix = attrName.slice(6)
 
-        if (!prefixMap.has(prefix)) {
-          const canonical = resolveUri(value)
-
-          if (canonical !== undefined) {
-            prefixMap.set(prefix, canonical)
-
-            if (canonical !== prefix) {
-              hasRemapping = true
-            }
-          }
+        // A seeded entry is a guess read out of the raw text; the parser reporting the
+        // declaration is the document itself, so it replaces the guess.
+        if (seededPrefixes.delete(prefix)) {
+          prefixMap.delete(prefix)
         }
+
+        recordPrefix(prefix, value)
       }
     }
 

--- a/src/feeds/atom/parse/index.test.ts
+++ b/src/feeds/atom/parse/index.test.ts
@@ -222,25 +222,23 @@ describe('parse', () => {
     expect(parse(value)).toEqual(expected)
   })
 
-  describe('known limitations', () => {
-    // The root element declares its own prefix, so its name reaches the stop-node matcher
-    // before the declaration is recorded and the path-anchored stop nodes miss; the xhtml
-    // title is parsed into an element tree and its value is lost. Seeding the declaration
-    // map from a pre-parse scan of the document would close this.
-    it('should lose an xhtml title in a fully prefixed Atom feed', () => {
-      const value = `
-        <?xml version="1.0" encoding="utf-8"?>
-        <atom:feed xmlns:atom="http://www.w3.org/2005/Atom">
-          <atom:id>example-feed</atom:id>
-          <atom:title type="xhtml"><div xmlns="http://www.w3.org/1999/xhtml"><p>a &lt; b</p></div></atom:title>
-        </atom:feed>
-      `
-      const expected = {
-        id: 'example-feed',
-      }
+  it('should parse an xhtml title in a fully prefixed Atom feed', () => {
+    const value = `
+      <?xml version="1.0" encoding="utf-8"?>
+      <atom:feed xmlns:atom="http://www.w3.org/2005/Atom">
+        <atom:id>example-feed</atom:id>
+        <atom:title type="xhtml"><div xmlns="http://www.w3.org/1999/xhtml"><p>a &lt; b</p></div></atom:title>
+      </atom:feed>
+    `
+    const expected = {
+      id: 'example-feed',
+      title: {
+        value: '<p>a &lt; b</p>',
+        type: 'xhtml',
+      },
+    }
 
-      expect(parse(value)).toEqual(expected)
-    })
+    expect(parse(value)).toEqual(expected)
   })
 
   it('should throw error for invalid input', () => {

--- a/src/feeds/atom/parse/index.ts
+++ b/src/feeds/atom/parse/index.ts
@@ -38,7 +38,7 @@ export const parse = <TDate = string>(
   let normalized: Unreliable
 
   try {
-    namespaceOptions = createNamespaceOptions()
+    namespaceOptions = createNamespaceOptions(value)
     normalized = parser.parse(value)
   } catch (error) {
     throw new MalformedError(locales.invalidFeedFormat, { cause: error })

--- a/src/feeds/rdf/parse/config.ts
+++ b/src/feeds/rdf/parse/config.ts
@@ -1,18 +1,21 @@
 import { namespaceStopNodes } from '../../../common/config.js'
 
+// The pre-parse seed canonicalizes the root's primary prefix before matching, so the root
+// spells as `rdf`. A document that never declares the prefix keeps `rdf:rdf` as its key
+// and fails retrieval regardless, so only the canonical form is matched.
 export const stopNodes = [
   ...namespaceStopNodes,
-  'rdf:rdf.channel.title',
-  'rdf:rdf.channel.link',
-  'rdf:rdf.channel.description',
-  'rdf:rdf.image.title',
-  'rdf:rdf.image.link',
-  'rdf:rdf.image.url',
-  'rdf:rdf.item.title',
-  'rdf:rdf.item.link',
-  'rdf:rdf.item.description',
-  'rdf:rdf.textinput.title',
-  'rdf:rdf.textinput.description',
-  'rdf:rdf.textinput.name',
-  'rdf:rdf.textinput.link',
+  'rdf.channel.title',
+  'rdf.channel.link',
+  'rdf.channel.description',
+  'rdf.image.title',
+  'rdf.image.link',
+  'rdf.image.url',
+  'rdf.item.title',
+  'rdf.item.link',
+  'rdf.item.description',
+  'rdf.textinput.title',
+  'rdf.textinput.description',
+  'rdf.textinput.name',
+  'rdf.textinput.link',
 ]

--- a/src/feeds/rdf/parse/index.test.ts
+++ b/src/feeds/rdf/parse/index.test.ts
@@ -668,6 +668,60 @@ describe('parse', () => {
       expect(parse(value)).toEqual(expected)
     })
 
+    it('should parse a bare root element under the RDF default namespace', () => {
+      const value = `
+        <?xml version="1.0" encoding="UTF-8"?>
+        <RDF xmlns="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+          <channel xmlns="http://purl.org/rss/1.0/">
+            <title>Bare Root</title>
+            <link>https://example.com</link>
+          </channel>
+        </RDF>
+      `
+      const expected = {
+        title: 'Bare Root',
+        link: 'https://example.com',
+      }
+
+      expect(parse(value)).toEqual(expected)
+    })
+
+    // The channel stop nodes are spelled `rdf.*`, so this pins that they still fire after
+    // the root's prefix canonicalizes away: entities inside CDATA stay raw, which only a
+    // captured stop node preserves.
+    it('should capture stop-node content under a prefixed root', () => {
+      const value = `
+        <?xml version="1.0" encoding="UTF-8"?>
+        <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns="http://purl.org/rss/1.0/">
+          <channel rdf:about="https://example.com">
+            <title><![CDATA[Ampersands &amp; <b>markup</b>]]></title>
+            <link>https://example.com</link>
+          </channel>
+        </rdf:RDF>
+      `
+      const expected = {
+        title: 'Ampersands &amp; <b>markup</b>',
+        link: 'https://example.com',
+        rdf: { about: 'https://example.com' },
+      }
+
+      expect(parse(value)).toEqual(expected)
+    })
+
+    it('should throw when the root prefix is never declared', () => {
+      const value = `
+        <?xml version="1.0" encoding="UTF-8"?>
+        <rdf:RDF>
+          <channel>
+            <title>Undeclared</title>
+          </channel>
+        </rdf:RDF>
+      `
+      const throwing = () => parse(value)
+
+      expect(throwing).toThrowError(ParseError)
+    })
+
     it('should handle missing required RDF elements', () => {
       const value = `
         <?xml version="1.0" encoding="UTF-8"?>

--- a/src/feeds/rdf/parse/index.ts
+++ b/src/feeds/rdf/parse/index.ts
@@ -38,7 +38,7 @@ export const parse = <TDate = string>(
   let normalized: Unreliable
 
   try {
-    namespaceOptions = createNamespaceOptions()
+    namespaceOptions = createNamespaceOptions(value)
     normalized = parser.parse(value)
   } catch (error) {
     throw new MalformedError(locales.invalidFeedFormat, { cause: error })

--- a/src/feeds/rss/parse/index.test.ts
+++ b/src/feeds/rss/parse/index.test.ts
@@ -1556,6 +1556,41 @@ describe('parse', () => {
         expect(parse(value)).toEqual(expected)
       })
 
+      it('should parse the xhtml value of a construct that declares its own prefix', () => {
+        const value = `
+          <?xml version="1.0" encoding="UTF-8"?>
+          <rss version="2.0">
+            <channel>
+              <title>Test</title>
+              <link>https://example.com</link>
+              <description>Test</description>
+              <item>
+                <title>Item</title>
+                <myatom:content xmlns:myatom="http://www.w3.org/2005/Atom" type="xhtml"><div xmlns="http://www.w3.org/1999/xhtml"><p>Text</p></div></myatom:content>
+              </item>
+            </channel>
+          </rss>
+        `
+        const expected = {
+          title: 'Test',
+          link: 'https://example.com',
+          description: 'Test',
+          items: [
+            {
+              title: 'Item',
+              atom: {
+                content: {
+                  value: '<p>Text</p>',
+                  type: 'xhtml',
+                },
+              },
+            },
+          ],
+        }
+
+        expect(parse(value)).toEqual(expected)
+      })
+
       it('should parse a namespaced element that declares its own prefix', () => {
         const value = `
           <?xml version="1.0" encoding="UTF-8"?>
@@ -4729,45 +4764,6 @@ describe('parse', () => {
         },
       }
       expect(parse(value, { parseDateFn: (raw) => new Date(raw) })).toEqual(expected)
-    })
-  })
-
-  describe('known limitations', () => {
-    // An element that declares its own namespace prefix reaches the stop-node matcher
-    // before the declaration is recorded, so its inline markup is parsed into an element
-    // tree and the value is lost; the key itself still canonicalizes. The parser offers no
-    // hook between reading the attributes and the stop-node check; seeding the declaration
-    // map from a pre-parse scan of the document would close this.
-    it('should lose the xhtml value of a construct that declares its own prefix', () => {
-      const value = `
-        <?xml version="1.0" encoding="UTF-8"?>
-        <rss version="2.0">
-          <channel>
-            <title>Test</title>
-            <link>https://example.com</link>
-            <description>Test</description>
-            <item>
-              <title>Item</title>
-              <myatom:content xmlns:myatom="http://www.w3.org/2005/Atom" type="xhtml"><div xmlns="http://www.w3.org/1999/xhtml"><p>Text</p></div></myatom:content>
-            </item>
-          </channel>
-        </rss>
-      `
-      const expected = {
-        title: 'Test',
-        link: 'https://example.com',
-        description: 'Test',
-        items: [
-          {
-            title: 'Item',
-            atom: {
-              content: { type: 'xhtml' },
-            },
-          },
-        ],
-      }
-
-      expect(parse(value)).toEqual(expected)
     })
   })
 })

--- a/src/feeds/rss/parse/index.ts
+++ b/src/feeds/rss/parse/index.ts
@@ -34,7 +34,7 @@ export const parse = <TDate = string>(
   let normalized: Unreliable
 
   try {
-    namespaceOptions = createNamespaceOptions()
+    namespaceOptions = createNamespaceOptions(value)
     normalized = parser.parse(value)
   } catch (error) {
     throw new MalformedError(locales.invalidFeedFormat, { cause: error })


### PR DESCRIPTION
Stacked on #335; base retargets as the stack merges.

Closes the limitation #335 documented: an element declaring its own namespace prefix reached the stop-node matcher before the declaration was recorded, so its xhtml value parsed into an element tree and was lost. That covered a self-declaring construct in an RSS item and the root of a fully prefixed `<atom:feed>` document. No hook exists between reading an element's attributes and the stop-node check, so the map is seeded before parsing: each format's `parse()` hands the raw document to the per-document options factory, where an `indexOf` traversal plus a sticky regex collects the `xmlns:` declarations in the first 64KB. The two `known limitations` tests become positive tests of the recovered values.

Only prefixed declarations seed. A default `xmlns` cannot be scoped without parsing, so it keeps in-order discovery through the streaming recorder (see #335 for why only the root's is honoured).

The scan reads whatever looks like a declaration, so a declaration-shaped string in a comment, in CDATA, or inside another attribute's value can seed a junk entry. Two rules keep that harmless:

- Seeded entries are provisional. The first real declaration the parser reports for a prefix replaces the guess, so a document's own markup always outranks the scan.
- The scan starts at the root element. Junk before it is the one case a later real declaration cannot repair, since the root's own name resolves against the map before its attributes are read.

Seeding also changes what the RDF stop nodes see: the primary `rdf:` prefix on the root canonicalizes before matching, so the root spells `rdf` and the paths move to that spelling. A document that never declares the prefix keeps `rdf:rdf` as its key and fails retrieval regardless, so no fallback spelling is kept.

## Cost

An uncapped scan reads each document to the end even when it finds nothing, since proving there are no further `xmlns:` occurrences means traversing the rest. Measured, that cost 4–5% of parse time on the large-document scenarios, outside run-to-run variance. The scan is therefore capped at the first 64KB, sized from a 49,707-feed corpus sample (1/256): the deepest first declaration of an alternate prefix, the only kind seeding does anything for, sits at 4.1KB (`atom10`), and every declaration first appearing deeper, down to 8.9MB, either already spells the canonical prefix or resolves to no known namespace, so its seed would be a no-op. A declaration past the cap falls back to in-order discovery, the behavior every element had before seeding existed.

Sequential hyperfine runs against the parent branch with the cap in place, same session:

| Scenario | Before | After |
|---|---|---|
| rss-big (10 × 5–50MB) | 827.6 ± 26.4 ms | 841.9 ± 14.2 ms |
| rdf (97 files) | 278.9 ± 4.6 ms | 284.6 ± 4.8 ms |
| atom-small (100 files) | 2.591 ± 0.081 s | 2.603 ± 0.046 s |

rss-big and atom-small sit inside run-to-run variance; rdf shows ~2% at the edge of its interval, unchanged from the uncapped measurement, so it is the per-document seeding setup rather than the traversal.


