### PR TITLE
perf: Skip JSON detection faster for non-JSON documents

### DIFF
--- a/src/common/utils.ts
+++ b/src/common/utils.ts
@@ -4,6 +4,7 @@ import {
   coerceBoolean,
   coerceNumber,
   coerceSingular,
+  isJsonLike,
   isNonEmptyString,
   isNumber,
   isPlainObject,
@@ -862,26 +863,20 @@ export const createNamespaceNormalizator = <T extends Record<string, Array<strin
   return normalizeRoot
 }
 
-const startsWithBraceRegex = /^\s*\{/
-const endsWithBraceRegex = /\}\s*$/
-
 export const parseJsonObject = (value: unknown): unknown => {
   if (isPlainObject(value)) {
     return value
   }
 
-  if (!isNonEmptyString(value) || value.length < 2) {
-    return
-  }
-
-  const startsWithBrace = value.charAt(0) === '{' || startsWithBraceRegex.test(value)
-  const endsWithBrace = value.charAt(value.length - 1) === '}' || endsWithBraceRegex.test(value)
-
-  if (!startsWithBrace || !endsWithBrace) {
+  if (!isNonEmptyString(value) || !isJsonLike(value)) {
     return
   }
 
   try {
-    return JSON.parse(value)
+    const parsed = JSON.parse(value)
+
+    if (isPlainObject(parsed)) {
+      return parsed
+    }
   } catch {}
 }


### PR DESCRIPTION
`parseJsonObject` guards the JSON branch of the generic `parseFeed()` detection, so every document passes through it, XML included. It computed both brace checks before testing either, so a document that visibly wasn't JSON from its first character still ran `/\}\s*$/` over its entire body: on a 5 MB XML feed that scan costs ~3.3 ms per parse, all of it wasted.

The check is now trousse's `isJsonLike`, which walks whitespace inward from both ends with `charCodeAt` and compares two characters — no full-body scan exists in it structurally. `isJsonLike` also accepts `[...]` arrays, so the parse result is additionally checked with `isPlainObject`; only an object is a candidate feed document, and behavior stays identical on every probed input.

| Input | Before | After |
|---|---|---|
| XML 5 MB (reject) | 3310 µs | 0.4 µs |
| XML 500 KB, leading whitespace (reject) | 159 µs | 0.2 µs |
| `{` + 1 MB garbage (reject) | 40 µs | 0.04 µs |
| JSON Feed ~50 KB (accept) | 31.9 µs | 30.8 µs |

The accept path is unchanged within noise, since `JSON.parse` dominates it.
