### PR TITLE
feat: Surface wrapper div xml:base and xml:lang on xhtml constructs

### DIFF
--- a/docs/migration/v2-to-v3.md
+++ b/docs/migration/v2-to-v3.md
@@ -261,6 +261,7 @@ const xml = generateAtomFeed({
 Parsing of `type="xhtml"` text constructs and content now conforms to [RFC 4287 §3.1.1.3](https://www.rfc-editor.org/rfc/rfc4287#section-3.1.1.3), and the parsed value is the plain HTML the spec describes. The same applies to `type="application/xhtml+xml"` (the Atom 0.3 spelling) and to Atom text constructs embedded in RSS items. Three things changed:
 
 - The wrapper `<div>` is stripped: the spec excludes it from the content
+- `xml:base` and `xml:lang` declared on the stripped wrapper fold into the construct's `xml` object, where the element's own declarations already live. The wrapper is the inner scope, so its `lang` replaces the element's, and its `base` resolves against the element's when relative. The `base` is surfaced as declared, not resolved against feed or entry level declarations, which stay on their own levels
 - The `xhtml:` prefix is removed from every tag when the feed binds the XHTML namespace to a prefix
 - Escaped characters are no longer decoded: inside an xhtml construct `&lt;` stands for the literal character, so an email address like `From: Sean &lt;sean@intel.com&gt;` survives instead of becoming a tag that HTML parsers swallow. A CDATA section also means literal text, so `<![CDATA[a < b]]>` comes out as `a &lt; b`
 

--- a/src/feeds/atom/parse/utils.test.ts
+++ b/src/feeds/atom/parse/utils.test.ts
@@ -504,6 +504,126 @@ describe('parseText', () => {
 
     expect(parseText(value)).toBeUndefined()
   })
+
+  describe('wrapper div xml declarations', () => {
+    it('should surface xml:base declared on the stripped wrapper div', () => {
+      const value = {
+        '#text':
+          '<div xmlns="http://www.w3.org/1999/xhtml" xml:base="https://example.com/posts/"><p>Text</p></div>',
+        '@type': 'xhtml',
+      }
+      const expected = {
+        value: '<p>Text</p>',
+        type: 'xhtml',
+        xml: { base: 'https://example.com/posts/' },
+      }
+
+      expect(parseText(value)).toEqual(expected)
+    })
+
+    it('should surface xml:lang declared on the stripped wrapper div', () => {
+      const value = {
+        '#text': '<div xmlns="http://www.w3.org/1999/xhtml" xml:lang="de"><p>Text</p></div>',
+        '@type': 'xhtml',
+      }
+      const expected = {
+        value: '<p>Text</p>',
+        type: 'xhtml',
+        xml: { lang: 'de' },
+      }
+
+      expect(parseText(value)).toEqual(expected)
+    })
+
+    it('should let the wrapper div lang replace the element lang', () => {
+      const value = {
+        '#text': '<div xmlns="http://www.w3.org/1999/xhtml" xml:lang="de"><p>Text</p></div>',
+        '@type': 'xhtml',
+        '@xml:lang': 'en',
+      }
+      const expected = {
+        value: '<p>Text</p>',
+        type: 'xhtml',
+        xml: { lang: 'de' },
+      }
+
+      expect(parseText(value)).toEqual(expected)
+    })
+
+    it('should let an absolute wrapper div base replace the element base', () => {
+      const value = {
+        '#text':
+          '<div xmlns="http://www.w3.org/1999/xhtml" xml:base="https://inner.example.com/"><p>Text</p></div>',
+        '@type': 'xhtml',
+        '@xml:base': 'https://outer.example.com/',
+      }
+      const expected = {
+        value: '<p>Text</p>',
+        type: 'xhtml',
+        xml: { base: 'https://inner.example.com/' },
+      }
+
+      expect(parseText(value)).toEqual(expected)
+    })
+
+    it('should resolve a relative wrapper div base against the element base', () => {
+      const value = {
+        '#text': '<div xmlns="http://www.w3.org/1999/xhtml" xml:base="images/"><p>Text</p></div>',
+        '@type': 'xhtml',
+        '@xml:base': 'https://example.com/posts/',
+      }
+      const expected = {
+        value: '<p>Text</p>',
+        type: 'xhtml',
+        xml: { base: 'https://example.com/posts/images/' },
+      }
+
+      expect(parseText(value)).toEqual(expected)
+    })
+
+    it('should keep the wrapper div base as declared when the pair does not resolve', () => {
+      const value = {
+        '#text': '<div xmlns="http://www.w3.org/1999/xhtml" xml:base="images/"><p>Text</p></div>',
+        '@type': 'xhtml',
+        '@xml:base': 'not a url',
+      }
+      const expected = {
+        value: '<p>Text</p>',
+        type: 'xhtml',
+        xml: { base: 'images/' },
+      }
+
+      expect(parseText(value)).toEqual(expected)
+    })
+
+    it('should attach nothing from a wrapper div that was not stripped', () => {
+      const value = {
+        '#text': '<div xml:base="https://example.com/"><p>1</p></div><div><p>2</p></div>',
+        '@type': 'xhtml',
+      }
+      const expected = {
+        value: '<div xml:base="https://example.com/"><p>1</p></div><div><p>2</p></div>',
+        type: 'xhtml',
+      }
+
+      expect(parseText(value)).toEqual(expected)
+    })
+
+    it('should decode entities in a wrapper div base', () => {
+      const value = {
+        '#text':
+          '<div xmlns="http://www.w3.org/1999/xhtml" xml:base="https://example.com/?a=1&amp;b=2"><p>Text</p></div>',
+        '@type': 'xhtml',
+      }
+      const expected = {
+        value: '<p>Text</p>',
+        type: 'xhtml',
+        xml: { base: 'https://example.com/?a=1&b=2' },
+      }
+
+      expect(parseText(value)).toEqual(expected)
+    })
+  })
 })
 
 describe('parseContent', () => {

--- a/src/feeds/atom/parse/utils.ts
+++ b/src/feeds/atom/parse/utils.ts
@@ -1,5 +1,5 @@
 import { XMLParser } from 'fast-xml-parser'
-import { isNonEmptyString, isPlainObject } from 'trousse'
+import { isNonEmptyString, isPlainObject, parseUrl } from 'trousse'
 import type { DateAny, Unreliable } from '../../../common/types.js'
 import {
   detectNamespaces,
@@ -47,6 +47,7 @@ import {
 } from '../../../namespaces/thr/parse/utils.js'
 import { retrieveItem as retrieveTrackbackItem } from '../../../namespaces/trackback/parse/utils.js'
 import { retrieveItem as retrieveWfwItem } from '../../../namespaces/wfw/parse/utils.js'
+import type { XmlNs } from '../../../namespaces/xml/common/types.js'
 import { retrieveItemOrFeed as retrieveXmlItemOrFeed } from '../../../namespaces/xml/parse/utils.js'
 import {
   retrieveFeed as retrieveYtFeed,
@@ -88,7 +89,8 @@ const xhtmlDivParser = new XMLParser({
   preserveOrder: true,
   stopNodes: ['x-wrap.div'],
   processEntities: false,
-  ignoreAttributes: true,
+  ignoreAttributes: false,
+  attributeNamePrefix: '@',
   removeNSPrefix: true,
   trimValues: false,
   commentPropName: '#comment',
@@ -157,6 +159,72 @@ export const unwrapXhtmlDiv = (value: Unreliable): Unreliable => {
   return inner
 }
 
+// The wrapper div is excluded from the content (RFC 4287 §3.1.1.3), so xml:base and
+// xml:lang declared on it would vanish with it. They are read here through the same
+// mini-parse that located the wrapper, only when it was actually stripped: a value kept
+// verbatim still carries its div, declarations included.
+// Atom 0.3 spelled the construct type as `application/xhtml+xml`.
+const isXhtmlType = (type: string | undefined): boolean => {
+  return type === 'xhtml' || type === 'application/xhtml+xml'
+}
+
+export const retrieveXhtmlDivXml = (
+  value: Unreliable,
+  type: string | undefined,
+): XmlNs.ItemOrFeed | undefined => {
+  if (!isXhtmlType(type)) {
+    return
+  }
+
+  const escaped = escapeCdataSections(retrieveText(value))
+
+  if (!isNonEmptyString(escaped) || unwrapXhtmlDiv(escaped) === escaped) {
+    return
+  }
+
+  // The wrapper was stripped, so this identical parse is known to succeed and to hold
+  // exactly one div child; no guards are needed on the way to it.
+  const children = xhtmlDivParser.parse(`<x-wrap>${escaped}</x-wrap>`)[0]['x-wrap']
+
+  for (const child of children) {
+    if (Array.isArray(child.div)) {
+      const attributes = child[':@']
+      const xml = {
+        base: parseString(attributes?.['@base']),
+        lang: parseString(attributes?.['@lang']),
+      }
+
+      return trimObject(xml)
+    }
+  }
+}
+
+// The div is the inner scope, so its lang replaces the element's, and its base resolves
+// against the element's when relative (XML Base §4.3); a pair the URL parser rejects keeps
+// the div's value as declared.
+export const mergeXhtmlDivXml = (
+  elementXml: XmlNs.ItemOrFeed | undefined,
+  divXml: XmlNs.ItemOrFeed | undefined,
+): XmlNs.ItemOrFeed | undefined => {
+  if (!divXml) {
+    return elementXml
+  }
+
+  let base = divXml.base ?? elementXml?.base
+
+  if (divXml.base && elementXml?.base) {
+    base = parseUrl(divXml.base, elementXml.base)?.href ?? base
+  }
+
+  const merged = {
+    ...elementXml,
+    lang: divXml.lang ?? elementXml?.lang,
+    base,
+  }
+
+  return trimObject(merged)
+}
+
 // A CDATA section is XML's other spelling for literal text, so its content becomes entities
 // in the verbatim value: dropping only the markers would hand a literal `<` to an HTML
 // parser as markup, the same corruption the verbatim path exists to avoid. A section
@@ -185,7 +253,7 @@ export const escapeCdataSections = (value: Unreliable): Unreliable => {
 export const parseTypedText = (value: Unreliable, type: string | undefined): string | undefined => {
   const text = retrieveText(value)
 
-  if (type !== 'xhtml' && type !== 'application/xhtml+xml') {
+  if (!isXhtmlType(type)) {
     return parseString(text)
   }
 
@@ -229,7 +297,7 @@ export const parseText: ParseUtilPartial<AtomFeed.Text> = (value) => {
   const text = {
     value: parsedValue,
     type,
-    xml: retrieveXmlItemOrFeed(value),
+    xml: mergeXhtmlDivXml(retrieveXmlItemOrFeed(value), retrieveXhtmlDivXml(value, type)),
   }
 
   return trimObject(text) as AtomFeed.Text
@@ -252,7 +320,7 @@ export const parseContent: ParseUtilPartial<AtomFeed.Content> = (value) => {
     value: parseTypedText(value, type),
     type,
     src: parseString(value['@src']),
-    xml: retrieveXmlItemOrFeed(value),
+    xml: mergeXhtmlDivXml(retrieveXmlItemOrFeed(value), retrieveXhtmlDivXml(value, type)),
   }
 
   return trimObject(content)

--- a/src/feeds/rss/parse/index.test.ts
+++ b/src/feeds/rss/parse/index.test.ts
@@ -1516,6 +1516,45 @@ describe('parse', () => {
         expect(parse(value)).toEqual(expected)
       })
 
+      it('should surface wrapper div xml declarations on embedded atom content', () => {
+        const value = `
+          <?xml version="1.0" encoding="UTF-8"?>
+          <rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+            <channel>
+              <title>Test</title>
+              <link>https://example.com</link>
+              <description>Test</description>
+              <item>
+                <title>Item</title>
+                <atom:content type="xhtml"><div xmlns="http://www.w3.org/1999/xhtml" xml:base="https://example.com/posts/" xml:lang="de"><p>Text</p></div></atom:content>
+              </item>
+            </channel>
+          </rss>
+        `
+        const expected = {
+          title: 'Test',
+          link: 'https://example.com',
+          description: 'Test',
+          items: [
+            {
+              title: 'Item',
+              atom: {
+                content: {
+                  value: '<p>Text</p>',
+                  type: 'xhtml',
+                  xml: {
+                    base: 'https://example.com/posts/',
+                    lang: 'de',
+                  },
+                },
+              },
+            },
+          ],
+        }
+
+        expect(parse(value)).toEqual(expected)
+      })
+
       it('should parse atom xhtml content in RSS item with the div wrapper stripped', () => {
         const value = `
           <?xml version="1.0" encoding="UTF-8"?>


### PR DESCRIPTION
An Atom `type="xhtml"` construct can carry `xml:base` and `xml:lang` on its wrapper div. The parser strips that div (RFC 4287 §3.1.1.3 excludes it from the content), so declarations sitting on it were lost with it. They were the only declarations in a feed with nowhere to go: the construct element's own `xml:base`/`xml:lang` already surface in the `xml` object, and feed and entry elements keep theirs at their own levels.

The wrapper's two declarations now fold into that same `xml` object, read off the opening tag only when the wrapper was actually stripped: a value kept verbatim still carries its div, declarations included. The wrapper is the inner scope, so its `lang` replaces the element's, and its `base` resolves against the element's when relative (`new URL(divBase, elementBase)`); a pair the URL parser rejects keeps the div's value as declared. The `base` is surfaced as declared, not resolved against feed or entry declarations. Embedded Atom constructs in RSS items inherit the behavior through the shared parser.

Generation needs no change: `text.xml` already emits on the construct element, which is the one spelling observed in the wild.

Prevalence, 1/256 unbiased corpus sample (49,707 feeds, 185 carrying xhtml constructs, 3,346 wrapped): wrapper attributes are `xmlns` (3,260), `xmlns:xhtml` (73), `class` (1); `xml:base` and `xml:lang` on the wrapper occur zero times. The one sampled feed relying on `xml:base` declares it on the construct element, which already worked. This closes a spec shape with no observed usage, cheaply, so declarations can no longer be silently dropped at any level.
