### PR TITLE
refactor: Import trimObject and its types from trousse

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -11,7 +11,7 @@
       "devDependencies": {
         "@types/bun": "^1.3.14",
         "kvalita": "^1.16.0",
-        "trousse": "^1.1.1",
+        "trousse": "^1.5.0",
         "tsdown": "^0.22.7",
         "vitepress": "^2.0.0-alpha.18",
       },
@@ -908,7 +908,7 @@
 
     "trim-lines": ["trim-lines@3.0.1", "", {}, "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg=="],
 
-    "trousse": ["trousse@1.1.1", "", {}, "sha512-UEufemNgUNPIapW3WPVWwm0dS7GnXeXnOp/xUnSarQq97luECYmjXTXvRhw7tXqjiaqiifrnMFXXkj1XP1sv5Q=="],
+    "trousse": ["trousse@1.5.0", "", {}, "sha512-rvy/EyGp6Djxfe3fv13MCJwUie1cVUXbLaz6KVtETVq4ek4cD31OWoG3iotgInXt7RB4NW+vnxHTIIpcnPV4+Q=="],
 
     "tsdown": ["tsdown@0.22.7", "", { "dependencies": { "ansis": "^4.3.1", "cac": "^7.0.0", "defu": "^6.1.7", "empathic": "^2.0.1", "hookable": "^6.1.1", "import-without-cache": "^0.4.0", "obug": "^2.1.3", "picomatch": "^4.0.5", "rolldown": "~1.1.5", "rolldown-plugin-dts": "^0.27.8", "semver": "^7.8.5", "tinyexec": "^1.2.4", "tinyglobby": "^0.2.17", "tree-kill": "^1.2.2", "unconfig-core": "^7.5.0" }, "peerDependencies": { "@arethetypeswrong/core": "^0.18.1", "@tsdown/css": "0.22.7", "@tsdown/exe": "0.22.7", "@vitejs/devtools": "*", "publint": "^0.3.8", "tsx": "*", "typescript": "^5.0.0 || ^6.0.0 || ^7.0.0", "unplugin-unused": "^0.5.0", "unrun": "*" }, "optionalPeers": ["@arethetypeswrong/core", "@tsdown/css", "@tsdown/exe", "@vitejs/devtools", "publint", "tsx", "typescript", "unplugin-unused", "unrun"], "bin": { "tsdown": "./dist/run.mjs" } }, "sha512-4egbOzc9dxVv/QS+gDV75FIxDIjQQeOnXBlUuikyjmn0ozuc6FW11djJjEEo3vqkuJRygpnKHurnj+Iwftk4VA=="],
 

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
   "devDependencies": {
     "@types/bun": "^1.3.14",
     "kvalita": "^1.16.0",
-    "trousse": "^1.1.1",
+    "trousse": "^1.5.0",
     "tsdown": "^0.22.7",
     "vitepress": "^2.0.0-alpha.18"
   }

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -1,3 +1,5 @@
+export type { AnyOf, DeepOmit, IsPlainObject } from 'trousse'
+
 // TODO: Try to use: { [key: string]: Unreliable } | undefined for better type safety.
 // biome-ignore lint/suspicious/noExplicitAny: Temporary solution until the Unreliable type fixed.
 export type Unreliable = any
@@ -17,29 +19,6 @@ export type Strict<T, S extends boolean> = Simplify<
         [K in Optional<T> | Marked<T>]?: Unwrap<T[K]>
       }
 >
-
-export type AnyOf<T> = Partial<{ [P in keyof T]-?: NonNullable<T[P]> }> &
-  { [P in keyof T]-?: Pick<{ [Q in keyof T]-?: NonNullable<T[Q]> }, P> }[keyof T]
-
-export type IsPlainObject<T> =
-  T extends Array<unknown>
-    ? false
-    : T extends (...args: Array<unknown>) => unknown
-      ? false
-      : T extends Date
-        ? false
-        : T extends object
-          ? T extends null
-            ? false
-            : true
-          : false
-
-export type DeepOmit<T, K extends string> =
-  T extends Array<infer U>
-    ? Array<DeepOmit<U, K>>
-    : IsPlainObject<T> extends true
-      ? Pick<{ [P in keyof T]: DeepOmit<T[P], K> }, Exclude<keyof T, K>>
-      : T
 
 export type Requirable<T> = T | { __requirable: T }
 

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -1,5 +1,3 @@
-export type { AnyOf, DeepOmit, IsPlainObject } from 'trousse'
-
 // TODO: Try to use: { [key: string]: Unreliable } | undefined for better type safety.
 // biome-ignore lint/suspicious/noExplicitAny: Temporary solution until the Unreliable type fixed.
 export type Unreliable = any

--- a/src/common/utils.test.ts
+++ b/src/common/utils.test.ts
@@ -36,7 +36,6 @@ import {
   retrieveRdfResourceOrText,
   retrieveText,
   trimArray,
-  trimObject,
 } from './utils.js'
 
 describe('isNonEmptyStringOrNumber', () => {
@@ -424,73 +423,6 @@ describe('retrieveRdfResourceOrText', () => {
 
       expect(retrieveRdfResourceOrText(value, alwaysUndefined)).toBeUndefined()
     })
-  })
-})
-
-describe('trimObject', () => {
-  it('should remove nullish properties from objects', () => {
-    const value = { a: 1, b: undefined, c: 'string', d: undefined, e: null, f: false, g: 0, h: '' }
-    const expected = { a: 1, c: 'string', f: false, g: 0, h: '' }
-
-    expect(trimObject(value)).toEqual(expected)
-  })
-
-  it('should return the same object when no properties are nullish', () => {
-    const value = { a: 1, b: 'string', c: false, d: [], e: {} }
-
-    expect(trimObject(value)).toEqual(value)
-  })
-
-  it('should preserve falsy non-undefined values', () => {
-    const value = { a: 0, b: '', c: false, d: Number.NaN }
-
-    expect(trimObject(value)).toEqual(value)
-  })
-
-  it('should handle objects with symbol keys', () => {
-    const sym = Symbol('test')
-    const value = { a: 1, b: undefined, [sym]: 'symbol value' }
-    const expected = { a: 1 }
-
-    // Symbol keys are not enumerable with for..in, so they won't be included.
-    expect(trimObject(value)).toEqual(expected)
-  })
-
-  it('should handle complex nested objects', () => {
-    const value = {
-      a: { nested: 'value', undef: undefined },
-      b: undefined,
-      c: [1, undefined, 3],
-    }
-    const expected = {
-      a: { nested: 'value', undef: undefined },
-      c: [1, undefined, 3],
-    }
-
-    // The function only removes top-level undefined properties, not those in nested objects.
-    expect(trimObject(value)).toEqual(expected)
-  })
-
-  it('should handle object with getters', () => {
-    const value = {
-      get a() {
-        return 1
-      },
-      b: undefined,
-    }
-    const expected = { a: 1 }
-
-    expect(trimObject(value)).toEqual(expected)
-  })
-
-  it('should return undefined object when all properties are nullish', () => {
-    const value = { a: undefined, b: undefined, c: null }
-
-    expect(trimObject(value)).toBeUndefined()
-  })
-
-  it('should handle empty objects', () => {
-    expect(trimObject({})).toBeUndefined()
   })
 })
 

--- a/src/common/utils.ts
+++ b/src/common/utils.ts
@@ -54,8 +54,6 @@ export const retrieveRdfResourceOrText = <T>(
   return parse(retrieveText(value))
 }
 
-export { trimObject }
-
 export const trimArray = <T, R = T>(
   value: Array<T> | undefined,
   parse?: ParseUtilExact<R>,

--- a/src/common/utils.ts
+++ b/src/common/utils.ts
@@ -9,9 +9,9 @@ import {
   isNumber,
   isPlainObject,
   isPresent,
+  trimObject,
 } from 'trousse'
 import type {
-  AnyOf,
   DateAny,
   DateLike,
   GenerateUtil,
@@ -54,44 +54,7 @@ export const retrieveRdfResourceOrText = <T>(
   return parse(retrieveText(value))
 }
 
-export const trimObject = <T extends Record<string, unknown>>(object: T): AnyOf<T> | undefined => {
-  let hasPresent = false
-  let hasAbsent = false
-
-  // biome-ignore lint/suspicious/noForIn: Plain object; avoids per-call Object.keys allocation.
-  for (const key in object) {
-    if (isPresent(object[key])) {
-      hasPresent = true
-    } else {
-      hasAbsent = true
-    }
-
-    if (hasPresent && hasAbsent) {
-      break
-    }
-  }
-
-  if (!hasPresent) {
-    return
-  }
-
-  if (!hasAbsent) {
-    return object as AnyOf<T>
-  }
-
-  const result: Partial<T> = {}
-
-  // biome-ignore lint/suspicious/noForIn: Plain object; avoids per-call Object.keys allocation.
-  for (const key in object) {
-    const value = object[key]
-
-    if (isPresent(value)) {
-      result[key] = value
-    }
-  }
-
-  return result as AnyOf<T>
-}
+export { trimObject }
 
 export const trimArray = <T, R = T>(
   value: Array<T> | undefined,

--- a/src/feeds/atom/generate/utils.ts
+++ b/src/feeds/atom/generate/utils.ts
@@ -1,5 +1,5 @@
 import { XMLValidator } from 'fast-xml-parser'
-import { escapeHtml, isNonEmptyString, isPlainObject } from 'trousse'
+import { escapeHtml, isNonEmptyString, isPlainObject, trimObject } from 'trousse'
 import { namespaceUris } from '../../../common/config.js'
 import type { DateLike } from '../../../common/types.js'
 import {
@@ -11,7 +11,6 @@ import {
   generateTextOrCdataString,
   isXmlAttributeKey,
   trimArray,
-  trimObject,
 } from '../../../common/utils.js'
 import { generateFeed as generateAdminFeed } from '../../../namespaces/admin/generate/utils.js'
 import { generateEntry as generateAppEntry } from '../../../namespaces/app/generate/utils.js'

--- a/src/feeds/atom/parse/utils.ts
+++ b/src/feeds/atom/parse/utils.ts
@@ -1,5 +1,5 @@
 import { XMLParser } from 'fast-xml-parser'
-import { isNonEmptyString, isPlainObject, parseUrl } from 'trousse'
+import { isNonEmptyString, isPlainObject, parseUrl, trimObject } from 'trousse'
 import type { DateAny, Unreliable } from '../../../common/types.js'
 import {
   detectNamespaces,
@@ -10,7 +10,6 @@ import {
   parseString,
   parseVerbatimString,
   retrieveText,
-  trimObject,
 } from '../../../common/utils.js'
 import { retrieveFeed as retrieveAdminFeed } from '../../../namespaces/admin/parse/utils.js'
 import { retrieveEntry as retrieveAppEntry } from '../../../namespaces/app/parse/utils.js'

--- a/src/feeds/json/generate/utils.ts
+++ b/src/feeds/json/generate/utils.ts
@@ -1,6 +1,6 @@
-import { isPlainObject } from 'trousse'
+import { isPlainObject, trimObject } from 'trousse'
 import type { DateLike } from '../../../common/types.js'
-import { generateRfc3339Date, trimArray, trimObject } from '../../../common/utils.js'
+import { generateRfc3339Date, trimArray } from '../../../common/utils.js'
 import type { GenerateUtil, JsonFeed } from '../common/types.js'
 
 export const generateItem: GenerateUtil<JsonFeed.Item<DateLike>> = (item) => {

--- a/src/feeds/json/parse/utils.ts
+++ b/src/feeds/json/parse/utils.ts
@@ -1,4 +1,4 @@
-import { isPlainObject } from 'trousse'
+import { isPlainObject, trimObject } from 'trousse'
 import type { DateAny } from '../../../common/types.js'
 import {
   isNonEmptyStringOrNumber,
@@ -8,7 +8,6 @@ import {
   parseNumber,
   parseSingularOf,
   parseVerbatimString,
-  trimObject,
 } from '../../../common/utils.js'
 import type { JsonFeed, ParseUtilPartial } from '../common/types.js'
 

--- a/src/feeds/rdf/parse/utils.ts
+++ b/src/feeds/rdf/parse/utils.ts
@@ -1,4 +1,4 @@
-import { isPlainObject } from 'trousse'
+import { isPlainObject, trimObject } from 'trousse'
 import type { DateAny, Unreliable } from '../../../common/types.js'
 import {
   detectNamespaces,
@@ -8,7 +8,6 @@ import {
   parseString,
   retrieveText,
   trimArray,
-  trimObject,
 } from '../../../common/utils.js'
 import { retrieveFeed as retrieveAdminFeed } from '../../../namespaces/admin/parse/utils.js'
 import {

--- a/src/feeds/rss/generate/utils.ts
+++ b/src/feeds/rss/generate/utils.ts
@@ -1,4 +1,4 @@
-import { isPlainObject } from 'trousse'
+import { isPlainObject, trimObject } from 'trousse'
 import { namespaceUris } from '../../../common/config.js'
 import type { DateLike } from '../../../common/types.js'
 import {
@@ -10,7 +10,6 @@ import {
   generateRfc822Date,
   generateTextOrCdataString,
   trimArray,
-  trimObject,
 } from '../../../common/utils.js'
 import {
   generateFeed as generateAcastFeed,

--- a/src/feeds/rss/parse/utils.ts
+++ b/src/feeds/rss/parse/utils.ts
@@ -1,4 +1,4 @@
-import { isPlainObject } from 'trousse'
+import { isPlainObject, trimObject } from 'trousse'
 import type { DateAny } from '../../../common/types.js'
 import {
   detectNamespaces,
@@ -11,7 +11,6 @@ import {
   parseString,
   retrieveText,
   trimArray,
-  trimObject,
 } from '../../../common/utils.js'
 import {
   retrieveFeed as retrieveAcastFeed,

--- a/src/namespaces/acast/generate/utils.ts
+++ b/src/namespaces/acast/generate/utils.ts
@@ -1,10 +1,9 @@
-import { isPlainObject } from 'trousse'
+import { isPlainObject, trimObject } from 'trousse'
 import type { GenerateUtil } from '../../../common/types.js'
 import {
   generateCdataString,
   generatePlainString,
   generateTextOrCdataString,
-  trimObject,
 } from '../../../common/utils.js'
 import type { AcastNs } from '../common/types.js'
 

--- a/src/namespaces/acast/parse/utils.ts
+++ b/src/namespaces/acast/parse/utils.ts
@@ -1,6 +1,6 @@
-import { isPlainObject } from 'trousse'
+import { isPlainObject, trimObject } from 'trousse'
 import type { ParseUtilPartial } from '../../../common/types.js'
-import { parseSingularOf, parseString, retrieveText, trimObject } from '../../../common/utils.js'
+import { parseSingularOf, parseString, retrieveText } from '../../../common/utils.js'
 import type { AcastNs } from '../common/types.js'
 
 export const parseSignature: ParseUtilPartial<AcastNs.Signature> = (value) => {

--- a/src/namespaces/admin/generate/utils.ts
+++ b/src/namespaces/admin/generate/utils.ts
@@ -1,6 +1,6 @@
-import { isPlainObject } from 'trousse'
+import { isPlainObject, trimObject } from 'trousse'
 import type { GenerateUtil } from '../../../common/types.js'
-import { generatePlainString, generateRdfResource, trimObject } from '../../../common/utils.js'
+import { generatePlainString, generateRdfResource } from '../../../common/utils.js'
 import type { AdminNs } from '../common/types.js'
 
 export const generateFeed: GenerateUtil<AdminNs.Feed> = (feed) => {

--- a/src/namespaces/admin/parse/utils.ts
+++ b/src/namespaces/admin/parse/utils.ts
@@ -1,11 +1,6 @@
-import { isPlainObject } from 'trousse'
+import { isPlainObject, trimObject } from 'trousse'
 import type { ParseUtilPartial } from '../../../common/types.js'
-import {
-  parseSingularOf,
-  parseString,
-  retrieveRdfResourceOrText,
-  trimObject,
-} from '../../../common/utils.js'
+import { parseSingularOf, parseString, retrieveRdfResourceOrText } from '../../../common/utils.js'
 import type { AdminNs } from '../common/types.js'
 
 export const retrieveFeed: ParseUtilPartial<AdminNs.Feed> = (value) => {

--- a/src/namespaces/app/generate/utils.ts
+++ b/src/namespaces/app/generate/utils.ts
@@ -1,6 +1,6 @@
-import { isPlainObject } from 'trousse'
+import { isPlainObject, trimObject } from 'trousse'
 import type { DateLike, GenerateUtil } from '../../../common/types.js'
-import { generateRfc3339Date, generateYesNoBoolean, trimObject } from '../../../common/utils.js'
+import { generateRfc3339Date, generateYesNoBoolean } from '../../../common/utils.js'
 import type { AppNs } from '../common/types.js'
 
 export const generateControl: GenerateUtil<AppNs.Control> = (control) => {

--- a/src/namespaces/app/parse/utils.ts
+++ b/src/namespaces/app/parse/utils.ts
@@ -1,11 +1,10 @@
-import { isPlainObject } from 'trousse'
+import { isPlainObject, trimObject } from 'trousse'
 import type { DateAny, ParseMainOptions, ParseUtilPartial } from '../../../common/types.js'
 import {
   parseDate,
   parseSingularOf,
   parseYesNoBoolean,
   retrieveText,
-  trimObject,
 } from '../../../common/utils.js'
 import type { AppNs } from '../common/types.js'
 

--- a/src/namespaces/arxiv/generate/utils.ts
+++ b/src/namespaces/arxiv/generate/utils.ts
@@ -1,6 +1,6 @@
-import { isPlainObject } from 'trousse'
+import { isPlainObject, trimObject } from 'trousse'
 import type { GenerateUtil } from '../../../common/types.js'
-import { generateCdataString, generatePlainString, trimObject } from '../../../common/utils.js'
+import { generateCdataString, generatePlainString } from '../../../common/utils.js'
 import type { ArxivNs } from '../common/types.js'
 
 export const generatePrimaryCategory: GenerateUtil<ArxivNs.PrimaryCategory> = (primaryCategory) => {

--- a/src/namespaces/arxiv/parse/utils.ts
+++ b/src/namespaces/arxiv/parse/utils.ts
@@ -1,6 +1,6 @@
-import { isPlainObject } from 'trousse'
+import { isPlainObject, trimObject } from 'trousse'
 import type { ParseUtilPartial } from '../../../common/types.js'
-import { parseSingularOf, parseString, retrieveText, trimObject } from '../../../common/utils.js'
+import { parseSingularOf, parseString, retrieveText } from '../../../common/utils.js'
 import type { ArxivNs } from '../common/types.js'
 
 export const parsePrimaryCategory: ParseUtilPartial<ArxivNs.PrimaryCategory> = (value) => {

--- a/src/namespaces/atom/common/types.ts
+++ b/src/namespaces/atom/common/types.ts
@@ -1,4 +1,4 @@
-import type { DeepOmit } from '../../../common/types.js'
+import type { DeepOmit } from 'trousse'
 import type { AtomFeed } from '../../../feeds/atom/common/types.js'
 
 // Namespace properties to exclude when Atom is used as a namespace (not as a feed format).

--- a/src/namespaces/blogchannel/generate/utils.ts
+++ b/src/namespaces/blogchannel/generate/utils.ts
@@ -1,6 +1,6 @@
-import { isPlainObject } from 'trousse'
+import { isPlainObject, trimObject } from 'trousse'
 import type { GenerateUtil } from '../../../common/types.js'
-import { generateCdataString, trimObject } from '../../../common/utils.js'
+import { generateCdataString } from '../../../common/utils.js'
 import type { BlogChannelNs } from '../common/types.js'
 
 export const generateFeed: GenerateUtil<BlogChannelNs.Feed> = (feed) => {

--- a/src/namespaces/blogchannel/parse/utils.ts
+++ b/src/namespaces/blogchannel/parse/utils.ts
@@ -1,6 +1,6 @@
-import { isPlainObject } from 'trousse'
+import { isPlainObject, trimObject } from 'trousse'
 import type { ParseUtilPartial } from '../../../common/types.js'
-import { parseSingularOf, parseString, retrieveText, trimObject } from '../../../common/utils.js'
+import { parseSingularOf, parseString, retrieveText } from '../../../common/utils.js'
 import type { BlogChannelNs } from '../common/types.js'
 
 export const retrieveFeed: ParseUtilPartial<BlogChannelNs.Feed> = (value) => {

--- a/src/namespaces/cc/generate/utils.ts
+++ b/src/namespaces/cc/generate/utils.ts
@@ -1,6 +1,6 @@
-import { isPlainObject } from 'trousse'
+import { isPlainObject, trimObject } from 'trousse'
 import type { GenerateUtil } from '../../../common/types.js'
-import { generateCdataString, trimObject } from '../../../common/utils.js'
+import { generateCdataString } from '../../../common/utils.js'
 import type { CcNs } from '../common/types.js'
 
 export const generateItemOrFeed: GenerateUtil<CcNs.ItemOrFeed> = (data) => {

--- a/src/namespaces/cc/parse/utils.ts
+++ b/src/namespaces/cc/parse/utils.ts
@@ -1,11 +1,6 @@
-import { isPlainObject } from 'trousse'
+import { isPlainObject, trimObject } from 'trousse'
 import type { ParseUtilPartial } from '../../../common/types.js'
-import {
-  parseSingularOf,
-  parseString,
-  retrieveRdfResourceOrText,
-  trimObject,
-} from '../../../common/utils.js'
+import { parseSingularOf, parseString, retrieveRdfResourceOrText } from '../../../common/utils.js'
 import type { CcNs } from '../common/types.js'
 
 export const retrieveItemOrFeed: ParseUtilPartial<CcNs.ItemOrFeed> = (value) => {

--- a/src/namespaces/content/generate/utils.ts
+++ b/src/namespaces/content/generate/utils.ts
@@ -1,6 +1,6 @@
-import { isPlainObject } from 'trousse'
+import { isPlainObject, trimObject } from 'trousse'
 import type { GenerateUtil } from '../../../common/types.js'
-import { generateCdataString, trimObject } from '../../../common/utils.js'
+import { generateCdataString } from '../../../common/utils.js'
 import type { ContentNs } from '../common/types.js'
 
 export const generateItem: GenerateUtil<ContentNs.Item> = (item) => {

--- a/src/namespaces/content/parse/utils.ts
+++ b/src/namespaces/content/parse/utils.ts
@@ -1,6 +1,6 @@
-import { isPlainObject } from 'trousse'
+import { isPlainObject, trimObject } from 'trousse'
 import type { ParseUtilPartial } from '../../../common/types.js'
-import { parseSingularOf, parseString, retrieveText, trimObject } from '../../../common/utils.js'
+import { parseSingularOf, parseString, retrieveText } from '../../../common/utils.js'
 import type { ContentNs } from '../common/types.js'
 
 export const retrieveItem: ParseUtilPartial<ContentNs.Item> = (value) => {

--- a/src/namespaces/creativecommons/generate/utils.ts
+++ b/src/namespaces/creativecommons/generate/utils.ts
@@ -1,6 +1,6 @@
-import { isPlainObject } from 'trousse'
+import { isPlainObject, trimObject } from 'trousse'
 import type { GenerateUtil } from '../../../common/types.js'
-import { generateCdataString, trimArray, trimObject } from '../../../common/utils.js'
+import { generateCdataString, trimArray } from '../../../common/utils.js'
 import type { CreativeCommonsNs } from '../common/types.js'
 
 export const generateItemOrFeed: GenerateUtil<CreativeCommonsNs.ItemOrFeed> = (itemOrFeed) => {

--- a/src/namespaces/creativecommons/parse/utils.ts
+++ b/src/namespaces/creativecommons/parse/utils.ts
@@ -1,6 +1,6 @@
-import { isPlainObject } from 'trousse'
+import { isPlainObject, trimObject } from 'trousse'
 import type { ParseUtilPartial } from '../../../common/types.js'
-import { parseArrayOf, parseString, retrieveText, trimObject } from '../../../common/utils.js'
+import { parseArrayOf, parseString, retrieveText } from '../../../common/utils.js'
 import type { CreativeCommonsNs } from '../common/types.js'
 
 export const retrieveItemOrFeed: ParseUtilPartial<CreativeCommonsNs.ItemOrFeed> = (value) => {

--- a/src/namespaces/dc/generate/utils.ts
+++ b/src/namespaces/dc/generate/utils.ts
@@ -1,11 +1,6 @@
-import { isPlainObject } from 'trousse'
+import { isPlainObject, trimObject } from 'trousse'
 import type { DateLike, GenerateUtil } from '../../../common/types.js'
-import {
-  generateCdataString,
-  generateRfc3339Date,
-  trimArray,
-  trimObject,
-} from '../../../common/utils.js'
+import { generateCdataString, generateRfc3339Date, trimArray } from '../../../common/utils.js'
 import type { DcNs } from '../common/types.js'
 
 export const generateItemOrFeed: GenerateUtil<DcNs.ItemOrFeed<DateLike>> = (itemOrFeed) => {

--- a/src/namespaces/dc/parse/utils.ts
+++ b/src/namespaces/dc/parse/utils.ts
@@ -1,12 +1,6 @@
-import { isPlainObject } from 'trousse'
+import { isPlainObject, trimObject } from 'trousse'
 import type { DateAny, ParseMainOptions, ParseUtilPartial } from '../../../common/types.js'
-import {
-  parseArrayOf,
-  parseDate,
-  parseString,
-  retrieveText,
-  trimObject,
-} from '../../../common/utils.js'
+import { parseArrayOf, parseDate, parseString, retrieveText } from '../../../common/utils.js'
 import type { DcNs } from '../common/types.js'
 
 export const retrieveItemOrFeed: ParseUtilPartial<

--- a/src/namespaces/dcterms/generate/utils.ts
+++ b/src/namespaces/dcterms/generate/utils.ts
@@ -1,11 +1,6 @@
-import { isPlainObject } from 'trousse'
+import { isPlainObject, trimObject } from 'trousse'
 import type { DateLike, GenerateUtil } from '../../../common/types.js'
-import {
-  generateCdataString,
-  generateRfc3339Date,
-  trimArray,
-  trimObject,
-} from '../../../common/utils.js'
+import { generateCdataString, generateRfc3339Date, trimArray } from '../../../common/utils.js'
 import type { DcTermsNs } from '../common/types.js'
 
 export const generateItemOrFeed: GenerateUtil<DcTermsNs.ItemOrFeed<DateLike>> = (itemOrFeed) => {

--- a/src/namespaces/dcterms/parse/utils.ts
+++ b/src/namespaces/dcterms/parse/utils.ts
@@ -1,12 +1,6 @@
-import { isPlainObject } from 'trousse'
+import { isPlainObject, trimObject } from 'trousse'
 import type { DateAny, ParseMainOptions, ParseUtilPartial } from '../../../common/types.js'
-import {
-  parseArrayOf,
-  parseDate,
-  parseString,
-  retrieveText,
-  trimObject,
-} from '../../../common/utils.js'
+import { parseArrayOf, parseDate, parseString, retrieveText } from '../../../common/utils.js'
 import type { DcTermsNs } from '../common/types.js'
 
 export const retrieveItemOrFeed: ParseUtilPartial<

--- a/src/namespaces/feedpress/generate/utils.ts
+++ b/src/namespaces/feedpress/generate/utils.ts
@@ -1,6 +1,6 @@
-import { isPlainObject } from 'trousse'
+import { isPlainObject, trimObject } from 'trousse'
 import type { GenerateUtil } from '../../../common/types.js'
-import { generateCdataString, trimObject } from '../../../common/utils.js'
+import { generateCdataString } from '../../../common/utils.js'
 import type { FeedPressNs } from '../common/types.js'
 
 export const generateFeed: GenerateUtil<FeedPressNs.Feed> = (feed) => {

--- a/src/namespaces/feedpress/parse/utils.ts
+++ b/src/namespaces/feedpress/parse/utils.ts
@@ -1,6 +1,6 @@
-import { isPlainObject } from 'trousse'
+import { isPlainObject, trimObject } from 'trousse'
 import type { ParseUtilPartial } from '../../../common/types.js'
-import { parseSingularOf, parseString, retrieveText, trimObject } from '../../../common/utils.js'
+import { parseSingularOf, parseString, retrieveText } from '../../../common/utils.js'
 import type { FeedPressNs } from '../common/types.js'
 
 export const retrieveFeed: ParseUtilPartial<FeedPressNs.Feed> = (value) => {

--- a/src/namespaces/geo/generate/utils.ts
+++ b/src/namespaces/geo/generate/utils.ts
@@ -1,6 +1,6 @@
-import { isPlainObject } from 'trousse'
+import { isPlainObject, trimObject } from 'trousse'
 import type { GenerateUtil } from '../../../common/types.js'
-import { generateNumber, trimObject } from '../../../common/utils.js'
+import { generateNumber } from '../../../common/utils.js'
 import type { GeoNs } from '../common/types.js'
 
 export const generateItemOrFeed: GenerateUtil<GeoNs.ItemOrFeed> = (geo) => {

--- a/src/namespaces/geo/parse/utils.ts
+++ b/src/namespaces/geo/parse/utils.ts
@@ -1,6 +1,6 @@
-import { isPlainObject } from 'trousse'
+import { isPlainObject, trimObject } from 'trousse'
 import type { ParseUtilPartial } from '../../../common/types.js'
-import { parseNumber, parseSingularOf, retrieveText, trimObject } from '../../../common/utils.js'
+import { parseNumber, parseSingularOf, retrieveText } from '../../../common/utils.js'
 import type { GeoNs } from '../common/types.js'
 
 export const retrieveItemOrFeed: ParseUtilPartial<GeoNs.ItemOrFeed> = (value) => {

--- a/src/namespaces/georss/generate/utils.ts
+++ b/src/namespaces/georss/generate/utils.ts
@@ -1,6 +1,6 @@
-import { isPlainObject } from 'trousse'
+import { isPlainObject, trimObject } from 'trousse'
 import type { GenerateUtil } from '../../../common/types.js'
-import { generateCdataString, generateNumber, trimObject } from '../../../common/utils.js'
+import { generateCdataString, generateNumber } from '../../../common/utils.js'
 import type { GeoRssNs } from '../common/types.js'
 
 export const generateLatLngPairs = (

--- a/src/namespaces/georss/parse/utils.ts
+++ b/src/namespaces/georss/parse/utils.ts
@@ -1,4 +1,4 @@
-import { isNonEmptyString, isPlainObject, isPresent } from 'trousse'
+import { isNonEmptyString, isPlainObject, isPresent, trimObject } from 'trousse'
 import type { ParseUtilExact, ParseUtilPartial, Unreliable } from '../../../common/types.js'
 import {
   parseArrayOf,
@@ -6,7 +6,6 @@ import {
   parseSingularOf,
   parseString,
   retrieveText,
-  trimObject,
 } from '../../../common/utils.js'
 import type { GeoRssNs } from '../common/types.js'
 

--- a/src/namespaces/googleplay/generate/utils.ts
+++ b/src/namespaces/googleplay/generate/utils.ts
@@ -1,11 +1,10 @@
-import { isPlainObject } from 'trousse'
+import { isPlainObject, trimObject } from 'trousse'
 import type { GenerateUtil } from '../../../common/types.js'
 import {
   generateCdataString,
   generatePlainString,
   generateYesNoBoolean,
   trimArray,
-  trimObject,
 } from '../../../common/utils.js'
 import type { GooglePlayNs } from '../common/types.js'
 

--- a/src/namespaces/googleplay/parse/utils.ts
+++ b/src/namespaces/googleplay/parse/utils.ts
@@ -1,4 +1,4 @@
-import { isPlainObject } from 'trousse'
+import { isPlainObject, trimObject } from 'trousse'
 import type { ParseUtilPartial } from '../../../common/types.js'
 import {
   parseArrayOf,
@@ -6,7 +6,6 @@ import {
   parseString,
   parseYesNoBoolean,
   retrieveText,
-  trimObject,
 } from '../../../common/utils.js'
 import type { GooglePlayNs } from '../common/types.js'
 

--- a/src/namespaces/itunes/generate/utils.ts
+++ b/src/namespaces/itunes/generate/utils.ts
@@ -1,4 +1,4 @@
-import { isNonEmptyString, isPlainObject } from 'trousse'
+import { isNonEmptyString, isPlainObject, trimObject } from 'trousse'
 import type { GenerateUtil } from '../../../common/types.js'
 import {
   generateCdataString,
@@ -7,7 +7,6 @@ import {
   generatePlainString,
   generateYesNoBoolean,
   trimArray,
-  trimObject,
 } from '../../../common/utils.js'
 import type { ItunesNs } from '../common/types.js'
 

--- a/src/namespaces/itunes/parse/utils.ts
+++ b/src/namespaces/itunes/parse/utils.ts
@@ -1,4 +1,4 @@
-import { isPlainObject } from 'trousse'
+import { isPlainObject, trimObject } from 'trousse'
 import type { ParseUtilPartial } from '../../../common/types.js'
 import {
   isNonEmptyStringOrNumber,
@@ -10,7 +10,6 @@ import {
   parseString,
   parseYesNoBoolean,
   retrieveText,
-  trimObject,
 } from '../../../common/utils.js'
 import type { ItunesNs } from '../common/types.js'
 

--- a/src/namespaces/media/generate/utils.ts
+++ b/src/namespaces/media/generate/utils.ts
@@ -1,4 +1,4 @@
-import { isPlainObject } from 'trousse'
+import { isPlainObject, trimObject } from 'trousse'
 import type { GenerateUtil } from '../../../common/types.js'
 import {
   generateCdataString,
@@ -8,7 +8,6 @@ import {
   generateTextOrCdataString,
   generateYesNoBoolean,
   trimArray,
-  trimObject,
 } from '../../../common/utils.js'
 import type { MediaNs } from '../common/types.js'
 

--- a/src/namespaces/media/parse/utils.ts
+++ b/src/namespaces/media/parse/utils.ts
@@ -1,4 +1,4 @@
-import { isPlainObject } from 'trousse'
+import { isPlainObject, trimObject } from 'trousse'
 import type { ParseUtilPartial } from '../../../common/types.js'
 import {
   isNonEmptyStringOrNumber,
@@ -9,7 +9,6 @@ import {
   parseSingularOf,
   parseString,
   retrieveText,
-  trimObject,
 } from '../../../common/utils.js'
 import type { MediaNs } from '../common/types.js'
 

--- a/src/namespaces/opensearch/generate/utils.ts
+++ b/src/namespaces/opensearch/generate/utils.ts
@@ -1,11 +1,6 @@
-import { isPlainObject } from 'trousse'
+import { isPlainObject, trimObject } from 'trousse'
 import type { GenerateUtil } from '../../../common/types.js'
-import {
-  generateNumber,
-  generatePlainString,
-  trimArray,
-  trimObject,
-} from '../../../common/utils.js'
+import { generateNumber, generatePlainString, trimArray } from '../../../common/utils.js'
 import type { OpenSearchNs } from '../common/types.js'
 
 export const generateQuery: GenerateUtil<OpenSearchNs.Query> = (query) => {

--- a/src/namespaces/opensearch/parse/utils.ts
+++ b/src/namespaces/opensearch/parse/utils.ts
@@ -1,4 +1,4 @@
-import { isPlainObject } from 'trousse'
+import { isPlainObject, trimObject } from 'trousse'
 import type { ParseUtilPartial } from '../../../common/types.js'
 import {
   parseArrayOf,
@@ -6,7 +6,6 @@ import {
   parseSingularOf,
   parseString,
   retrieveText,
-  trimObject,
 } from '../../../common/utils.js'
 import type { OpenSearchNs } from '../common/types.js'
 

--- a/src/namespaces/pingback/generate/utils.ts
+++ b/src/namespaces/pingback/generate/utils.ts
@@ -1,6 +1,6 @@
-import { isPlainObject } from 'trousse'
+import { isPlainObject, trimObject } from 'trousse'
 import type { GenerateUtil } from '../../../common/types.js'
-import { generateCdataString, trimObject } from '../../../common/utils.js'
+import { generateCdataString } from '../../../common/utils.js'
 import type { PingbackNs } from '../common/types.js'
 
 export const generateItem: GenerateUtil<PingbackNs.Item> = (item) => {

--- a/src/namespaces/pingback/parse/utils.ts
+++ b/src/namespaces/pingback/parse/utils.ts
@@ -1,11 +1,6 @@
-import { isPlainObject } from 'trousse'
+import { isPlainObject, trimObject } from 'trousse'
 import type { ParseUtilPartial } from '../../../common/types.js'
-import {
-  parseSingularOf,
-  parseString,
-  retrieveRdfResourceOrText,
-  trimObject,
-} from '../../../common/utils.js'
+import { parseSingularOf, parseString, retrieveRdfResourceOrText } from '../../../common/utils.js'
 import type { PingbackNs } from '../common/types.js'
 
 export const retrieveItem: ParseUtilPartial<PingbackNs.Item> = (value) => {

--- a/src/namespaces/podcast/generate/utils.ts
+++ b/src/namespaces/podcast/generate/utils.ts
@@ -1,4 +1,4 @@
-import { isPlainObject } from 'trousse'
+import { isPlainObject, trimObject } from 'trousse'
 import type { DateLike, GenerateUtil } from '../../../common/types.js'
 import {
   generateBoolean,
@@ -10,7 +10,6 @@ import {
   generateTextOrCdataString,
   generateYesNoBoolean,
   trimArray,
-  trimObject,
 } from '../../../common/utils.js'
 import type { PodcastNs } from '../common/types.js'
 

--- a/src/namespaces/podcast/parse/utils.ts
+++ b/src/namespaces/podcast/parse/utils.ts
@@ -1,4 +1,4 @@
-import { isPlainObject } from 'trousse'
+import { isPlainObject, trimObject } from 'trousse'
 import type { DateAny, ParseMainOptions, ParseUtilPartial } from '../../../common/types.js'
 import {
   parseArrayOf,
@@ -10,7 +10,6 @@ import {
   parseYesNoBoolean,
   retrieveText,
   trimArray,
-  trimObject,
 } from '../../../common/utils.js'
 import type { PodcastNs } from '../common/types.js'
 

--- a/src/namespaces/prism/generate/utils.ts
+++ b/src/namespaces/prism/generate/utils.ts
@@ -1,11 +1,10 @@
-import { isPlainObject } from 'trousse'
+import { isPlainObject, trimObject } from 'trousse'
 import type { DateLike, GenerateUtil } from '../../../common/types.js'
 import {
   generateCdataString,
   generateNumber,
   generateRfc3339Date,
   trimArray,
-  trimObject,
 } from '../../../common/utils.js'
 import type { PrismNs } from '../common/types.js'
 

--- a/src/namespaces/prism/parse/utils.ts
+++ b/src/namespaces/prism/parse/utils.ts
@@ -1,4 +1,4 @@
-import { isPlainObject } from 'trousse'
+import { isPlainObject, trimObject } from 'trousse'
 import type { DateAny, ParseMainOptions, ParseUtilPartial } from '../../../common/types.js'
 import {
   parseArrayOf,
@@ -7,7 +7,6 @@ import {
   parseSingularOf,
   parseString,
   retrieveText,
-  trimObject,
 } from '../../../common/utils.js'
 import type { PrismNs } from '../common/types.js'
 

--- a/src/namespaces/psc/generate/utils.ts
+++ b/src/namespaces/psc/generate/utils.ts
@@ -1,6 +1,6 @@
-import { isPlainObject } from 'trousse'
+import { isPlainObject, trimObject } from 'trousse'
 import type { GenerateUtil } from '../../../common/types.js'
-import { generatePlainString, trimArray, trimObject } from '../../../common/utils.js'
+import { generatePlainString, trimArray } from '../../../common/utils.js'
 import type { PscNs } from '../common/types.js'
 
 export const generateChapter: GenerateUtil<PscNs.Chapter> = (chapter) => {

--- a/src/namespaces/psc/parse/utils.ts
+++ b/src/namespaces/psc/parse/utils.ts
@@ -1,6 +1,6 @@
-import { isPlainObject } from 'trousse'
+import { isPlainObject, trimObject } from 'trousse'
 import type { ParseUtilPartial } from '../../../common/types.js'
-import { parseArrayOf, parseSingularOf, parseString, trimObject } from '../../../common/utils.js'
+import { parseArrayOf, parseSingularOf, parseString } from '../../../common/utils.js'
 import type { PscNs } from '../common/types.js'
 
 export const parseChapter: ParseUtilPartial<PscNs.Chapter> = (value) => {

--- a/src/namespaces/rawvoice/generate/utils.ts
+++ b/src/namespaces/rawvoice/generate/utils.ts
@@ -1,4 +1,4 @@
-import { isPlainObject } from 'trousse'
+import { isPlainObject, trimObject } from 'trousse'
 import type { DateLike, GenerateUtil } from '../../../common/types.js'
 import {
   generateCdataString,
@@ -8,7 +8,6 @@ import {
   generateTextOrCdataString,
   generateYesNoBoolean,
   trimArray,
-  trimObject,
 } from '../../../common/utils.js'
 import type { RawVoiceNs } from '../common/types.js'
 

--- a/src/namespaces/rawvoice/parse/utils.ts
+++ b/src/namespaces/rawvoice/parse/utils.ts
@@ -1,4 +1,4 @@
-import { isPlainObject } from 'trousse'
+import { isPlainObject, trimObject } from 'trousse'
 import type { DateAny, ParseMainOptions, ParseUtilPartial } from '../../../common/types.js'
 import {
   isXmlAttributeKey,
@@ -9,7 +9,6 @@ import {
   parseString,
   parseYesNoBoolean,
   retrieveText,
-  trimObject,
 } from '../../../common/utils.js'
 import type { RawVoiceNs } from '../common/types.js'
 

--- a/src/namespaces/rdf/generate/utils.ts
+++ b/src/namespaces/rdf/generate/utils.ts
@@ -1,6 +1,6 @@
-import { isPlainObject } from 'trousse'
+import { isPlainObject, trimObject } from 'trousse'
 import type { GenerateUtil } from '../../../common/types.js'
-import { generatePlainString, trimArray, trimObject } from '../../../common/utils.js'
+import { generatePlainString, trimArray } from '../../../common/utils.js'
 import type { RdfNs } from '../common/types.js'
 
 export const generateAbout: GenerateUtil<RdfNs.About> = (about) => {

--- a/src/namespaces/rdf/parse/utils.ts
+++ b/src/namespaces/rdf/parse/utils.ts
@@ -1,4 +1,4 @@
-import { isPlainObject } from 'trousse'
+import { isPlainObject, trimObject } from 'trousse'
 import type { ParseUtilPartial } from '../../../common/types.js'
 import {
   parseArrayOf,
@@ -6,7 +6,6 @@ import {
   parseString,
   retrieveRdfResourceOrText,
   retrieveText,
-  trimObject,
 } from '../../../common/utils.js'
 import type { RdfNs } from '../common/types.js'
 

--- a/src/namespaces/slash/generate/utils.ts
+++ b/src/namespaces/slash/generate/utils.ts
@@ -1,11 +1,6 @@
-import { isPlainObject } from 'trousse'
+import { isPlainObject, trimObject } from 'trousse'
 import type { GenerateUtil } from '../../../common/types.js'
-import {
-  generateCdataString,
-  generateCsvOf,
-  generateNumber,
-  trimObject,
-} from '../../../common/utils.js'
+import { generateCdataString, generateCsvOf, generateNumber } from '../../../common/utils.js'
 import type { SlashNs } from '../common/types.js'
 
 export const generateItem: GenerateUtil<SlashNs.Item> = (item) => {

--- a/src/namespaces/slash/parse/utils.ts
+++ b/src/namespaces/slash/parse/utils.ts
@@ -1,4 +1,4 @@
-import { isPlainObject } from 'trousse'
+import { isPlainObject, trimObject } from 'trousse'
 import type { ParseUtilPartial } from '../../../common/types.js'
 import {
   parseCsvOf,
@@ -6,7 +6,6 @@ import {
   parseSingularOf,
   parseString,
   retrieveText,
-  trimObject,
 } from '../../../common/utils.js'
 import type { SlashNs } from '../common/types.js'
 

--- a/src/namespaces/source/generate/utils.ts
+++ b/src/namespaces/source/generate/utils.ts
@@ -1,11 +1,10 @@
-import { isNonEmptyString, isPlainObject } from 'trousse'
+import { isNonEmptyString, isPlainObject, trimObject } from 'trousse'
 import type { GenerateUtil } from '../../../common/types.js'
 import {
   generateBoolean,
   generateCdataString,
   generateTextOrCdataString,
   trimArray,
-  trimObject,
 } from '../../../common/utils.js'
 import type { SourceNs } from '../common/types.js'
 

--- a/src/namespaces/source/parse/utils.ts
+++ b/src/namespaces/source/parse/utils.ts
@@ -1,4 +1,4 @@
-import { isPlainObject } from 'trousse'
+import { isPlainObject, trimObject } from 'trousse'
 import type { ParseUtilPartial } from '../../../common/types.js'
 import {
   parseArrayOf,
@@ -6,7 +6,6 @@ import {
   parseSingularOf,
   parseString,
   retrieveText,
-  trimObject,
 } from '../../../common/utils.js'
 import type { SourceNs } from '../common/types.js'
 

--- a/src/namespaces/spotify/generate/utils.ts
+++ b/src/namespaces/spotify/generate/utils.ts
@@ -1,11 +1,6 @@
-import { isPlainObject } from 'trousse'
+import { isPlainObject, trimObject } from 'trousse'
 import type { GenerateUtil } from '../../../common/types.js'
-import {
-  generateCdataString,
-  generateNumber,
-  generatePlainString,
-  trimObject,
-} from '../../../common/utils.js'
+import { generateCdataString, generateNumber, generatePlainString } from '../../../common/utils.js'
 import type { SpotifyNs } from '../common/types.js'
 
 export const generateLimit: GenerateUtil<SpotifyNs.Limit> = (limit) => {

--- a/src/namespaces/spotify/parse/utils.ts
+++ b/src/namespaces/spotify/parse/utils.ts
@@ -1,4 +1,4 @@
-import { isPlainObject } from 'trousse'
+import { isPlainObject, trimObject } from 'trousse'
 import type { ParseUtilPartial } from '../../../common/types.js'
 import {
   parseBoolean,
@@ -6,7 +6,6 @@ import {
   parseSingularOf,
   parseString,
   retrieveText,
-  trimObject,
 } from '../../../common/utils.js'
 import type { SpotifyNs } from '../common/types.js'
 

--- a/src/namespaces/sy/generate/utils.ts
+++ b/src/namespaces/sy/generate/utils.ts
@@ -1,11 +1,6 @@
-import { isPlainObject } from 'trousse'
+import { isPlainObject, trimObject } from 'trousse'
 import type { DateLike, GenerateUtil } from '../../../common/types.js'
-import {
-  generateCdataString,
-  generateNumber,
-  generateRfc3339Date,
-  trimObject,
-} from '../../../common/utils.js'
+import { generateCdataString, generateNumber, generateRfc3339Date } from '../../../common/utils.js'
 import type { SyNs } from '../common/types.js'
 
 export const generateFeed: GenerateUtil<SyNs.Feed<DateLike>> = (feed) => {

--- a/src/namespaces/sy/parse/utils.ts
+++ b/src/namespaces/sy/parse/utils.ts
@@ -1,4 +1,4 @@
-import { isPlainObject } from 'trousse'
+import { isPlainObject, trimObject } from 'trousse'
 import type { DateAny, ParseMainOptions, ParseUtilPartial } from '../../../common/types.js'
 import {
   parseDate,
@@ -6,7 +6,6 @@ import {
   parseSingularOf,
   parseString,
   retrieveText,
-  trimObject,
 } from '../../../common/utils.js'
 import type { SyNs } from '../common/types.js'
 

--- a/src/namespaces/thr/generate/utils.ts
+++ b/src/namespaces/thr/generate/utils.ts
@@ -1,11 +1,10 @@
-import { isPlainObject } from 'trousse'
+import { isPlainObject, trimObject } from 'trousse'
 import type { DateLike, GenerateUtil } from '../../../common/types.js'
 import {
   generateNumber,
   generatePlainString,
   generateRfc3339Date,
   trimArray,
-  trimObject,
 } from '../../../common/utils.js'
 import type { ThrNs } from '../common/types.js'
 

--- a/src/namespaces/thr/parse/utils.ts
+++ b/src/namespaces/thr/parse/utils.ts
@@ -1,4 +1,4 @@
-import { isPlainObject } from 'trousse'
+import { isPlainObject, trimObject } from 'trousse'
 import type { DateAny, ParseMainOptions, ParseUtilPartial } from '../../../common/types.js'
 import {
   parseArrayOf,
@@ -7,7 +7,6 @@ import {
   parseSingularOf,
   parseString,
   retrieveText,
-  trimObject,
 } from '../../../common/utils.js'
 import type { ThrNs } from '../common/types.js'
 

--- a/src/namespaces/trackback/generate/utils.ts
+++ b/src/namespaces/trackback/generate/utils.ts
@@ -1,6 +1,6 @@
-import { isPlainObject } from 'trousse'
+import { isPlainObject, trimObject } from 'trousse'
 import type { GenerateUtil } from '../../../common/types.js'
-import { generateCdataString, trimArray, trimObject } from '../../../common/utils.js'
+import { generateCdataString, trimArray } from '../../../common/utils.js'
 import type { TrackbackNs } from '../common/types.js'
 
 export const generateItem: GenerateUtil<TrackbackNs.Item> = (item) => {

--- a/src/namespaces/trackback/parse/utils.ts
+++ b/src/namespaces/trackback/parse/utils.ts
@@ -1,11 +1,10 @@
-import { isPlainObject } from 'trousse'
+import { isPlainObject, trimObject } from 'trousse'
 import type { ParseUtilPartial } from '../../../common/types.js'
 import {
   parseArrayOf,
   parseSingularOf,
   parseString,
   retrieveRdfResourceOrText,
-  trimObject,
 } from '../../../common/utils.js'
 import type { TrackbackNs } from '../common/types.js'
 

--- a/src/namespaces/wfw/generate/utils.ts
+++ b/src/namespaces/wfw/generate/utils.ts
@@ -1,6 +1,6 @@
-import { isPlainObject } from 'trousse'
+import { isPlainObject, trimObject } from 'trousse'
 import type { GenerateUtil } from '../../../common/types.js'
-import { generateCdataString, trimObject } from '../../../common/utils.js'
+import { generateCdataString } from '../../../common/utils.js'
 import type { WfwNs } from '../common/types.js'
 
 export const generateItem: GenerateUtil<WfwNs.Item> = (item) => {

--- a/src/namespaces/wfw/parse/utils.ts
+++ b/src/namespaces/wfw/parse/utils.ts
@@ -1,6 +1,6 @@
-import { isPlainObject } from 'trousse'
+import { isPlainObject, trimObject } from 'trousse'
 import type { ParseUtilPartial } from '../../../common/types.js'
-import { parseSingularOf, parseString, retrieveText, trimObject } from '../../../common/utils.js'
+import { parseSingularOf, parseString, retrieveText } from '../../../common/utils.js'
 import type { WfwNs } from '../common/types.js'
 
 export const retrieveItem: ParseUtilPartial<WfwNs.Item> = (value) => {

--- a/src/namespaces/xml/generate/utils.ts
+++ b/src/namespaces/xml/generate/utils.ts
@@ -1,6 +1,6 @@
-import { isPlainObject } from 'trousse'
+import { isPlainObject, trimObject } from 'trousse'
 import type { GenerateUtil } from '../../../common/types.js'
-import { generatePlainString, trimObject } from '../../../common/utils.js'
+import { generatePlainString } from '../../../common/utils.js'
 import type { XmlNs } from '../common/types.js'
 
 export const generateItemOrFeed: GenerateUtil<XmlNs.ItemOrFeed> = (itemOrFeed) => {

--- a/src/namespaces/xml/parse/utils.ts
+++ b/src/namespaces/xml/parse/utils.ts
@@ -1,6 +1,6 @@
-import { isPlainObject } from 'trousse'
+import { isPlainObject, trimObject } from 'trousse'
 import type { ParseUtilPartial } from '../../../common/types.js'
-import { parseString, trimObject } from '../../../common/utils.js'
+import { parseString } from '../../../common/utils.js'
 import type { XmlNs } from '../common/types.js'
 
 export const retrieveItemOrFeed: ParseUtilPartial<XmlNs.ItemOrFeed> = (value) => {

--- a/src/namespaces/yt/generate/utils.ts
+++ b/src/namespaces/yt/generate/utils.ts
@@ -1,6 +1,6 @@
-import { isPlainObject } from 'trousse'
+import { isPlainObject, trimObject } from 'trousse'
 import type { GenerateUtil } from '../../../common/types.js'
-import { generateCdataString, trimObject } from '../../../common/utils.js'
+import { generateCdataString } from '../../../common/utils.js'
 import type { YtNs } from '../common/types.js'
 
 export const generateItem: GenerateUtil<YtNs.Item> = (item) => {

--- a/src/namespaces/yt/parse/utils.ts
+++ b/src/namespaces/yt/parse/utils.ts
@@ -1,6 +1,6 @@
-import { isPlainObject } from 'trousse'
+import { isPlainObject, trimObject } from 'trousse'
 import type { ParseUtilPartial } from '../../../common/types.js'
-import { parseSingularOf, parseString, retrieveText, trimObject } from '../../../common/utils.js'
+import { parseSingularOf, parseString, retrieveText } from '../../../common/utils.js'
 import type { YtNs } from '../common/types.js'
 
 export const retrieveItem: ParseUtilPartial<YtNs.Item> = (value) => {

--- a/src/opml/generate/utils.ts
+++ b/src/opml/generate/utils.ts
@@ -1,4 +1,4 @@
-import { isPlainObject, isPresent } from 'trousse'
+import { isPlainObject, isPresent, trimObject } from 'trousse'
 import type { DateLike } from '../../common/types.js'
 import {
   generateBoolean,
@@ -8,7 +8,6 @@ import {
   generatePlainString,
   generateRfc822Date,
   trimArray,
-  trimObject,
 } from '../../common/utils.js'
 import type { GenerateUtil, Opml } from '../common/types.js'
 

--- a/src/opml/parse/utils.ts
+++ b/src/opml/parse/utils.ts
@@ -1,4 +1,4 @@
-import { isPlainObject, isPresent } from 'trousse'
+import { isPlainObject, isPresent, trimObject } from 'trousse'
 import type { DateAny } from '../../common/types.js'
 import {
   parseArrayOf,
@@ -9,7 +9,6 @@ import {
   parseSingularOf,
   parseString,
   retrieveText,
-  trimObject,
 } from '../../common/utils.js'
 import type { Opml, ParseUtilPartial } from '../common/types.js'
 


### PR DESCRIPTION
This PR replaces the local copies of `trimObject` and the `AnyOf`, `DeepOmit` and `IsPlainObject` types with imports from trousse 1.5.0, which now exports them. The change is internal only: none of the four names is exported from the index, and every existing import through `common/utils.js` and `common/types.js` keeps resolving, so no call sites change. Behavior is identical, since trousse carries the same implementation and it runs here with the default predicate. The local `trimObject` tests moved upstream with the function, so the suite drops by 8 tests. Like the other trousse helpers, the implementation is inlined into dist at build time, so trousse stays a dev dependency.

`refactor:` cuts no release, so this rides with the next rc release.