### PR TITLE
chore: Add a one-day cooldown to Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,4 +4,6 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    cooldown:
+      default-days: 1
     target-branch: main


### PR DESCRIPTION
Adds `cooldown: default-days: 1` to every ecosystem block, so Dependabot will not propose a version published less than a day ago.

This matches the two other gates: npm's `min-release-age=1` in ~/.npmrc, and bun's `minimumReleaseAge = 86400` which now lives once in a global ~/.bunfig.toml. All three agree on one day, and this repo was one of eight where the Dependabot half was missing entirely.

A cool-off does not protect against a breaking major version, only against a compromised release being pulled within hours of publication.