### PR TITLE
Call the shared test and release workflows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,9 +4,9 @@ on:
   workflow_dispatch:
     inputs:
       branch:
-        description: 'Branch to release'
+        description: Branch to release
         required: true
-        default: 'main'
+        default: main
         type: choice
         options:
           - main
@@ -16,7 +16,8 @@ on:
 
 jobs:
   test:
-    uses: ./.github/workflows/test.yml
+    uses: macieklamberski/kvalita/.github/workflows/shared-test.yml@main
+    secrets: inherit
 
   compatibility:
     uses: ./.github/workflows/compatibility.yml
@@ -28,29 +29,8 @@ jobs:
       issues: write
       pull-requests: write
       id-token: write
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-        with:
-          ref: ${{ inputs.branch }}
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version: 24
-          registry-url: https://registry.npmjs.org
-
-      - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
-
-      - name: Install dependencies
-        run: bun install --frozen-lockfile
-
-      - name: Build package
-        run: bun run build
-
-      - name: Release and publish package
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: bunx semantic-release --extends kvalita/semantic-release
+    uses: macieklamberski/kvalita/.github/workflows/shared-release.yml@main
+    with:
+      branch: ${{ inputs.branch }}
+      build: true
+    secrets: inherit

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,27 +4,8 @@ on:
   push:
     branches: [main, alpha, beta, rc]
   pull_request:
-  workflow_call:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-
-      - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
-
-      - name: Install dependencies
-        run: bun install --frozen-lockfile --ignore-scripts
-
-      - name: Run tests with coverage
-        run: bun test --coverage --coverage-reporter=lcov
-
-      - name: Upload coverage to Codecov
-        if: github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref == 'refs/heads/main')
-        uses: codecov/codecov-action@v5
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          files: ./coverage/lcov.info
+    uses: macieklamberski/kvalita/.github/workflows/shared-test.yml@main
+    secrets: inherit


### PR DESCRIPTION
Both workflows were maintained by hand here and are byte-identical in seven repos. They now call the shared definitions in kvalita, so the job lives in one place and cannot drift.

The trigger blocks and the release dispatch inputs stay, since GitHub gives a reusable workflow no way to contribute those to its caller.