### PR TITLE
ci: Replace the local lint workflow with the shared one

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,34 +1,11 @@
 name: Lint
 
 on:
+  push:
+    branches: [main, alpha, beta, rc]
   pull_request:
-    types: [opened, synchronize, reopened]
 
 jobs:
   lint:
-    # Disable for dependabot PRs due https://github.com/dependabot/dependabot-core/issues/11705.
-    if: github.actor != 'dependabot[bot]'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
-
-      - uses: oven-sh/setup-bun@v2
-
-      - name: Install dependencies
-        run: bun install --frozen-lockfile
-
-      - name: Run Biome check
-        run: bunx @biomejs/biome check --write --no-errors-on-unmatched --files-ignore-unknown=true
-
-      - name: Run TypeScript check
-        run: bunx tsc --noEmit
-
-      - name: Validate PR commits
-        run: |
-          bunx commitlint \
-            --from ${{ github.event.pull_request.base.sha }} \
-            --to ${{ github.event.pull_request.head.sha }} \
-            --config ./commitlint.json \
-            --verbose
+    uses: macieklamberski/kvalita/.github/workflows/shared-lint.yml@main
+    secrets: inherit


### PR DESCRIPTION
The workflow this replaces ran `biome check --write`, which fixes what it finds in the runner's checkout, discards it and exits zero. Anything Biome can fix by itself has been passing CI regardless. The shared workflow drops `--write`, so those failures are now reported.

Dependabot also changes here. It previously skipped the whole job, which meant its pull requests changed a lockfile with no Biome or TypeScript check on it at all. Now only the commitlint step skips, for the reason the old comment gave: dependabot writes a lower-case subject and offers no option to change it.