### PR TITLE
docs: Add v3.0 release announcement to homepage

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -55,8 +55,8 @@ export default defineConfig({
       { text: 'Parsing', link: '/parsing' },
       { text: 'Generating', link: '/generating' },
       {
-        text: 'v3.0 (Next)',
-        items: [{ text: 'v2.0', link: 'https://feedsmith.dev' }],
+        text: 'v3.x',
+        items: [{ text: 'v2.x', link: 'https://v2.feedsmith.dev' }],
       },
     ],
     sidebar: [

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,6 +8,10 @@ Fast, all‑in‑one JavaScript feed parser and generator for RSS, Atom, RDF, an
 
 Feedsmith offers universal and format‑specific parsers that maintain the original feed structure in a clean, object-oriented format while intelligently normalizing legacy elements. Access all feed data without compromising simplicity.
 
+::: tip ANNOUNCEMENT
+**Feedsmith 3.0 is out! 🎉** It comes with a range of improvements and some breaking changes. Check out the [migration guide](/migration/v2-to-v3) to see what's new and how to upgrade from 2.x.
+:::
+
 ## Features
 
 ### Core


### PR DESCRIPTION
Adds a tip callout to the docs homepage announcing the 3.0 release, linking the v2-to-v3 migration guide. Mirrors the banner main's homepage shows about the next version.