### PR TITLE
chore: Update trousse to 2.0.0

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -11,7 +11,7 @@
       "devDependencies": {
         "@types/bun": "^1.3.14",
         "kvalita": "^1.21.0",
-        "trousse": "^1.5.0",
+        "trousse": "^2.0.0",
         "tsdown": "^0.22.14",
         "vitepress": "^2.0.0-alpha.19",
       },
@@ -930,7 +930,7 @@
 
     "trim-lines": ["trim-lines@3.0.1", "", {}, "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg=="],
 
-    "trousse": ["trousse@1.5.0", "", {}, "sha512-rvy/EyGp6Djxfe3fv13MCJwUie1cVUXbLaz6KVtETVq4ek4cD31OWoG3iotgInXt7RB4NW+vnxHTIIpcnPV4+Q=="],
+    "trousse": ["trousse@2.0.0", "", {}, "sha512-0usjimUtuKLzhaz+8XYgPPuoNWmPA0kHaqkWWb8wVMcHWCZ839yX6oTZRwfccp0HhrNncbRSeoMJ9YWy4ylK4w=="],
 
     "tsdown": ["tsdown@0.22.14", "", { "dependencies": { "ansis": "^4.3.1", "cac": "^7.0.0", "defu": "^6.1.7", "empathic": "^2.0.1", "hookable": "^6.1.1", "import-without-cache": "^0.4.0", "obug": "^2.1.4", "picomatch": "^4.0.5", "rolldown": "~1.2.0", "rolldown-plugin-dts": "^0.27.13", "tinyexec": "^1.2.4", "tinyglobby": "^0.2.17", "tree-kill": "^1.2.2", "unconfig-core": "^7.5.0", "verkit": "^0.3.0" }, "peerDependencies": { "@arethetypeswrong/core": "^0.18.1", "@tsdown/css": "0.22.14", "@tsdown/exe": "0.22.14", "@vitejs/devtools": "*", "publint": "^0.3.8", "tsx": "*", "typescript": "^5.0.0 || ^6.0.0 || ^7.0.0", "unplugin-unused": "^0.5.0", "unrun": "*" }, "optionalPeers": ["@arethetypeswrong/core", "@tsdown/css", "@tsdown/exe", "@vitejs/devtools", "publint", "tsx", "typescript", "unplugin-unused", "unrun"], "bin": { "tsdown": "./dist/run.mjs" } }, "sha512-ule7Y+fsAN2iZbLDoo7C4KYljFJNJJ+fLshyn+9gozeTspVersWHxwdGB+Dm2hzA38s6muFnUTl0jK3vJm9ifQ=="],
 

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
   "devDependencies": {
     "@types/bun": "^1.3.14",
     "kvalita": "^1.21.0",
-    "trousse": "^1.5.0",
+    "trousse": "^2.0.0",
     "tsdown": "^0.22.14",
     "vitepress": "^2.0.0-alpha.19"
   }


### PR DESCRIPTION
trousse 2.0.0 changes `omitEmpty` to return `undefined` instead of an empty array when nothing survives.

feedsmith never calls `omitEmpty`, so the bundled output is unchanged and this is a range bump only.