### PR TITLE
fix: Resolve an unknown namespace uri to undefined, not an inherited member

### DIFF
--- a/src/common/config.ts
+++ b/src/common/config.ts
@@ -177,7 +177,7 @@ export const namespacePrefixes = Object.entries(namespaceUris).reduce(
 
     return prefixes
   },
-  {} as Record<string, string>,
+  Object.create(null) as Record<string, string>,
 )
 
 export const namespaceStopNodes = [

--- a/src/common/utils.test.ts
+++ b/src/common/utils.test.ts
@@ -3409,12 +3409,12 @@ describe('createNamespaceResolver', () => {
   // A default namespace is an attribute value, which fast-xml-parser does not sanitize, so
   // `constructor` and `__proto__` reach the prefix table as keys. Answering with an inherited
   // member renames every element after the uri and the document stops being a feed.
-  it.each([
-    'constructor',
-    '__proto__',
-  ])('should not resolve a %s namespace uri to an inherited member', (uri) => {
-    const createNamespaceOptions = createNamespaceResolver({ namespaceUris, namespacePrefixes })
-    const options = createNamespaceOptions(`<rss xmlns="${uri}">`)
+  const inheritedMemberUris = ['constructor', '__proto__']
+
+  it.each(inheritedMemberUris)('should not resolve %s to an inherited member', (uri) => {
+    const options = createNamespaceResolver({ namespaceUris, namespacePrefixes })(
+      `<rss xmlns="${uri}">`,
+    )
     const parser = new XMLParser({ ignoreAttributes: false, attributeNamePrefix: '@', ...options })
     const expected = { rss: { '@xmlns': uri, title: 'T' } }
 

--- a/src/common/utils.test.ts
+++ b/src/common/utils.test.ts
@@ -3406,6 +3406,21 @@ describe('createNamespaceResolver', () => {
     expect(parser.parse('<rss><a:title>T</a:title></rss>')).toEqual(expected)
   })
 
+  // A default namespace is an attribute value, which fast-xml-parser does not sanitize, so
+  // `constructor` and `__proto__` reach the prefix table as keys. Answering with an inherited
+  // member renames every element after the uri and the document stops being a feed.
+  it.each([
+    'constructor',
+    '__proto__',
+  ])('should not resolve a %s namespace uri to an inherited member', (uri) => {
+    const createNamespaceOptions = createNamespaceResolver({ namespaceUris, namespacePrefixes })
+    const options = createNamespaceOptions(`<rss xmlns="${uri}">`)
+    const parser = new XMLParser({ ignoreAttributes: false, attributeNamePrefix: '@', ...options })
+    const expected = { rss: { '@xmlns': uri, title: 'T' } }
+
+    expect(parser.parse(`<rss xmlns="${uri}"><title>T</title></rss>`)).toEqual(expected)
+  })
+
   it('should fall back to a whole-document scan when a comment never closes', () => {
     const createNamespaceOptions = createNamespaceResolver({ namespaceUris, namespacePrefixes })
     // The comment never closes, so no root can be found and the scan falls back to the


### PR DESCRIPTION
This PR seeds the namespace prefix table with `Object.create(null)`, so an unknown namespace uri answers `undefined` instead of an inherited member.

`xmlns` is an attribute value, and fast-xml-parser sanitizes names but not values. So `<rss xmlns="constructor">` gets the `Object` function back from the table, every element is renamed to `function Object() { [native code] }:rss`, and `parseFeed` throws `Invalid feed format`. RDF and Atom go the same way.

- Only `constructor` and `__proto__` get that far, since the resolver lowercases the uri first and `toString` and `hasOwnProperty` stop matching.
- Nothing is written to a prototype. This is a read.
- The table is read in one place, the uri resolver, so the seed is the only thing that changes.
- I picked this over a `Map` because the `Map` is a wider diff for the same outcome, and the only variant measurably slower on JSC at +5.5 ns a lookup. Neither shows up at parse scale.

