### PR TITLE
style: Reformat comments in src

### DIFF
--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -22,11 +22,10 @@ export type Requirable<T> = T | { __requirable: T }
 
 export type DateLike = Date | string
 
-// Date-aware parse utils need to return different date types depending on the
-// parseDateFn option, but TypeScript can't express generic functions through
-// type aliases like ParseUtilPartial. Using `any` here lets all parse utils
-// share the same ParseUtilPartial pattern while the public parse() entry points
-// enforce the correct TDate type via generics.
+// Date-aware parse utils need to return different date types depending on the parseDateFn option,
+// but TypeScript can't express generic functions through type aliases like ParseUtilPartial. Using
+// `any` here lets all parse utils share the same ParseUtilPartial pattern while the public parse()
+// entry points enforce the correct TDate type via generics.
 // biome-ignore lint/suspicious/noExplicitAny: See above reasoning.
 export type DateAny = any
 

--- a/src/common/utils.ts
+++ b/src/common/utils.ts
@@ -78,8 +78,8 @@ export const trimArray = <T, R = T>(
     }
   }
 
-  // Pre-allocation in case of Array is more performant than doing the lazy-allocation
-  // similar to the one used in trimObject.
+  // Pre-allocation in case of Array is more performant than doing the lazy-allocation similar to
+  // the one used in trimObject.
   const result: Array<R> = []
 
   for (const element of value) {
@@ -131,8 +131,8 @@ const stripComments = (text: string): string => {
 }
 
 const decodeWithCdata = (text: string): string => {
-  // Per XML spec, CDATA content should be passed through verbatim without entity decoding.
-  // Text outside CDATA should have entities decoded normally.
+  // Per XML spec, CDATA content should be passed through verbatim without entity decoding. Text
+  // outside CDATA should have entities decoded normally.
 
   let currentIndex = text.indexOf(cdataStartTag)
 
@@ -185,10 +185,10 @@ export const parseString: ParseUtilExact<string> = (value) => {
   }
 }
 
-// Variant of parseString for values that are already final markup: skips XML entity
-// decoding and HTML comment stripping. Used where a `&lt;` / `<!--` belongs to the payload
-// rather than encoding it — JSON Feed's `content_html`, whose string comes straight out of
-// JSON.parse, and Atom's xhtml constructs, whose entities stand for literal characters.
+// Variant of parseString for values that are already final markup: skips XML entity decoding and
+// HTML comment stripping. Used where a `&lt;` / `<!--` belongs to the payload rather than encoding
+// it: JSON Feed's `content_html`, whose string comes straight out of JSON.parse, and Atom's xhtml
+// constructs, whose entities stand for literal characters.
 export const parseVerbatimString: ParseUtilExact<string> = (value) => {
   if (typeof value === 'string') {
     if (value === '') {
@@ -412,10 +412,10 @@ export const generateRfc822Date: GenerateUtil<DateLike> = (value) => {
 }
 
 export const generateRfc3339Date: GenerateUtil<DateLike> = (value) => {
-  // This function generates RFC 3339 format dates which is also compatible with W3C-DTF.
-  // The only difference between ISO 8601 (produced by toISOString) and RFC 3339 is that
-  // RFC 3339 allows a space between date and time parts instead of 'T', but the 'T' format
-  // is actually valid in RFC 3339 as well, so we can just return the ISO string.
+  // This function generates RFC 3339 format dates which is also compatible with W3C-DTF. The only
+  // difference between ISO 8601 (produced by toISOString) and RFC 3339 is that RFC 3339 allows a
+  // space between date and time parts instead of 'T', but the 'T' format is actually valid in RFC
+  // 3339 as well, so we can just return the ISO string.
 
   if (!isPresent(value)) {
     return
@@ -574,20 +574,18 @@ export const generateNamespaceAttrs = (
   return namespaceAttrs
 }
 
-// Renames namespace prefixes to their canonical form while the document is being parsed,
-// so stop nodes can match `a10:title` as `atom:title`. Renaming after parsing would be
-// too late: stop nodes fire during it.
+// Renames namespace prefixes to their canonical form while the document is being parsed, so stop
+// nodes can match `a10:title` as `atom:title`. Renaming after parsing would be too late: stop nodes
+// fire during it.
 //
-// Document order is what makes this work. By the time the parser hands over an element's
-// name, it has already read every ancestor's attributes, including their `xmlns:`
-// declarations, which attributeValueProcessor records into a map. transformTagName can
-// therefore rename the element right away. The one exception is an element that declares
-// its own prefix: its name arrives before its attributes, so updateTag renames it once
-// more after they are read.
+// Document order is what makes this work. By the time the parser hands over an element's name, it
+// has already read every ancestor's attributes, including their `xmlns:` declarations, which
+// attributeValueProcessor records into a map. transformTagName can therefore rename the element
+// right away. The one exception is an element that declares its own prefix: its name arrives before
+// its attributes, so updateTag renames it once more after they are read.
 //
-// The map is flat and first-wins: real feeds declare namespaces once, on the root, and
-// re-binding a prefix deeper in a document has no observed usage. Add scope tracking if
-// such feeds ever appear.
+// The map is flat and first-wins: real feeds declare namespaces once, on the root, and re-binding a
+// prefix deeper in a document has no observed usage. Add scope tracking if such feeds ever appear.
 export const createNamespaceResolver = <T extends Record<string, Array<string>>>(options: {
   namespaceUris: T
   namespacePrefixes: Record<string, string>
@@ -601,8 +599,8 @@ export const createNamespaceResolver = <T extends Record<string, Array<string>>>
     }),
   )
 
-  // Canonical prefix for the URI, or an empty string when the URI is a primary namespace,
-  // whose elements go unprefixed. Undefined means the URI is not recognized.
+  // Canonical prefix for the URI, or an empty string when the URI is a primary namespace, whose
+  // elements go unprefixed. Undefined means the URI is not recognized.
   const resolveUri = (uri: string): string | undefined => {
     const normalized = uri.trim().toLowerCase()
 
@@ -616,9 +614,9 @@ export const createNamespaceResolver = <T extends Record<string, Array<string>>>
   // Far above the deepest alternate-prefix declaration observed in real feeds.
   const seedScanLimit = 65536
 
-  // Everything before the root element is a comment, a processing instruction or a
-  // doctype, none of which can carry a declaration. A document with no root is not a feed
-  // and never reaches the parser; the scan then simply starts at the beginning.
+  // Everything before the root element is a comment, a processing instruction or a doctype, none of
+  // which can carry a declaration. A document with no root is not a feed and never reaches the
+  // parser; the scan then simply starts at the beginning.
   const findRootIndex = (document: string): number => {
     let index = document.indexOf('<')
 
@@ -644,14 +642,14 @@ export const createNamespaceResolver = <T extends Record<string, Array<string>>>
     return -1
   }
 
-  // Every declaration a document makes lives in this call, so nothing survives the parse
-  // it belongs to and no state can leak into the next document.
+  // Every declaration a document makes lives in this call, so nothing survives the parse it belongs
+  // to and no state can leak into the next document.
   return (document?: string) => {
     const prefixMap = new Map<string, string>()
     const seededPrefixes = new Set<string>()
     let defaultCanonical: string | undefined
-    // Stays false while every declaration binds its conventional prefix, which keeps the
-    // per-tag work at a single boolean check for the overwhelming majority of feeds.
+    // Stays false while every declaration binds its conventional prefix, which keeps the per-tag
+    // work at a single boolean check for the overwhelming majority of feeds.
     let hasRemapping = false
     let tagsSeen = 0
 
@@ -669,24 +667,22 @@ export const createNamespaceResolver = <T extends Record<string, Array<string>>>
       }
     }
 
-    // The parser matches stop nodes against an element's name before reading its own
-    // attributes, so an element that declares its own prefix would miss them. Seeding the
-    // map from the raw document first closes that gap. Only prefixed declarations are
-    // seeded: a default `xmlns` cannot be scoped without parsing. The scan starts at the
-    // root element because junk before it is the one case a later real declaration cannot
-    // repair, the root's own name being resolved before its attributes are read.
+    // The parser matches stop nodes against an element's name before reading its own attributes, so
+    // an element that declares its own prefix would miss them. Seeding the map from the raw
+    // document first closes that gap. Only prefixed declarations are seeded: a default `xmlns`
+    // cannot be scoped without parsing. The scan starts at the root element because junk before it
+    // is the one case a later real declaration cannot repair, the root's own name being resolved
+    // before its attributes are read.
     if (document) {
-      // Only the head of the document is scanned, which keeps the cost flat on
-      // multi-megabyte feeds. Alternate prefixes, the reason the seed exists, are declared
-      // at the top of real documents; declarations found deeper either already spell the
-      // canonical prefix or resolve to no known namespace, so seeding them would change
-      // nothing. An alternate past the cap falls back to in-order discovery, the behavior
-      // every element had before seeding existed.
+      // Only the head of the document is scanned, which keeps the cost flat on multi-megabyte
+      // feeds. Alternate prefixes, the reason the seed exists, are declared at the top of real
+      // documents; declarations found deeper either already spell the canonical prefix or resolve
+      // to no known namespace, so seeding them would change nothing. An alternate past the cap
+      // falls back to in-order discovery, the behavior every element had before seeding existed.
       const head = document.length > seedScanLimit ? document.slice(0, seedScanLimit) : document
 
-      // indexOf jumps from one `xmlns:` occurrence to the next, and the sticky regex then
-      // reads just the `prefix="uri"` pair at that spot, so no regex ever scans the
-      // document itself.
+      // indexOf jumps from one `xmlns:` occurrence to the next, and the sticky regex then reads
+      // just the `prefix="uri"` pair at that spot, so no regex ever scans the document itself.
       const declarationTailRegex = /([\w.-]+)\s*=\s*(?:"([^"]*)"|'([^']*)')/y
 
       let index = head.indexOf('xmlns:', findRootIndex(head))
@@ -707,9 +703,9 @@ export const createNamespaceResolver = <T extends Record<string, Array<string>>>
     }
 
     const recordDeclaration = (rawAttrName: string, value: unknown) => {
-      // Anything not starting with "x" cannot be an xmlns declaration; bail before the
-      // string comparisons since this runs for every attribute in the document. The name
-      // arrives as written, so both cases are checked.
+      // Anything not starting with "x" cannot be an xmlns declaration; bail before the string
+      // comparisons since this runs for every attribute in the document. The name arrives as
+      // written, so both cases are checked.
       const firstCharCode = rawAttrName.charCodeAt(0)
 
       if ((firstCharCode !== 120 && firstCharCode !== 88) || typeof value !== 'string') {
@@ -719,10 +715,10 @@ export const createNamespaceResolver = <T extends Record<string, Array<string>>>
       const attrName = rawAttrName.toLowerCase()
 
       if (attrName === 'xmlns') {
-        // Only the root's default namespace is honored. A default declared deeper scopes
-        // to its own subtree, which the parser gives no way to track, and applying it
-        // document wide would rename every later element: a feed carrying
-        // `<atom:link xmlns="...atom"/>` inside its channel would lose the items after it.
+        // Only the root's default namespace is honored. A default declared deeper scopes to its own
+        // subtree, which the parser gives no way to track, and applying it document wide would
+        // rename every later element: a feed carrying `<atom:link xmlns="...atom"/>` inside its
+        // channel would lose the items after it.
         if (tagsSeen === 1 && defaultCanonical === undefined) {
           defaultCanonical = resolveUri(value)
 
@@ -737,8 +733,8 @@ export const createNamespaceResolver = <T extends Record<string, Array<string>>>
       if (attrName.startsWith('xmlns:')) {
         const prefix = attrName.slice(6)
 
-        // A seeded entry is a guess read out of the raw text; the parser reporting the
-        // declaration is the document itself, so it replaces the guess.
+        // A seeded entry is a guess read out of the raw text; the parser reporting the declaration
+        // is the document itself, so it replaces the guess.
         if (seededPrefixes.delete(prefix)) {
           prefixMap.delete(prefix)
         }
@@ -796,10 +792,10 @@ export const createNamespaceResolver = <T extends Record<string, Array<string>>>
       return value
     }
 
-    // Re-canonicalize with the now-complete maps: a name transformed before its own
-    // element's declarations were read gets its final form here. The name arrives already
-    // lowercased and usually already canonical, so every unchanged path returns the same
-    // string without allocating.
+    // Re-canonicalize with the now-complete maps: a name transformed before its own element's
+    // declarations were read gets its final form here. The name arrives already lowercased and
+    // usually already canonical, so every unchanged path returns the same string without
+    // allocating.
     const updateTag = (tagName: string) => {
       if (!hasRemapping) {
         return tagName
@@ -811,8 +807,8 @@ export const createNamespaceResolver = <T extends Record<string, Array<string>>>
         return defaultCanonical ? `${defaultCanonical}:${tagName}` : tagName
       }
 
-      // The reserved xmlns/xml prefixes never appear as element names and are never
-      // recorded in the map, so the lookup alone leaves them unchanged.
+      // The reserved xmlns/xml prefixes never appear as element names and are never recorded in the
+      // map, so the lookup alone leaves them unchanged.
       const prefix = tagName.slice(0, colonIndex)
       const canonical = prefixMap.get(prefix)
 

--- a/src/feeds/atom/common/types.ts
+++ b/src/feeds/atom/common/types.ts
@@ -60,7 +60,7 @@ export namespace AtomFeed {
 
   export type Link<TDate, TStrict extends boolean = false> = Strict<
     {
-      href: Requirable<string> // Required in spec.
+      href: Requirable<string> // Required in spec
       rel?: string
       type?: string
       hreflang?: string
@@ -73,7 +73,7 @@ export namespace AtomFeed {
 
   export type Person<TStrict extends boolean = false> = Strict<
     {
-      name: Requirable<string> // Required in spec.
+      name: Requirable<string> // Required in spec
       uri?: string
       email?: string
       arxiv?: ArxivNs.Author
@@ -83,7 +83,7 @@ export namespace AtomFeed {
 
   export type Category<TStrict extends boolean = false> = Strict<
     {
-      term: Requirable<string> // Required in spec.
+      term: Requirable<string> // Required in spec
       scheme?: string
       label?: string
     },
@@ -92,7 +92,7 @@ export namespace AtomFeed {
 
   export type Generator<TStrict extends boolean = false> = Strict<
     {
-      text: Requirable<string> // Required in spec.
+      text: Requirable<string> // Required in spec
       uri?: string
       version?: string
     },
@@ -120,14 +120,14 @@ export namespace AtomFeed {
       categories?: Array<Category<TStrict>>
       content?: Content
       contributors?: Array<Person<TStrict>>
-      id: Requirable<string> // Required in spec.
+      id: Requirable<string> // Required in spec
       links?: Array<Link<TDate, TStrict>>
       published?: TDate
       rights?: Text
       source?: Source<TDate, TStrict>
       summary?: Text
-      title: Requirable<Text> // Required in spec.
-      updated: Requirable<TDate> // Required in spec.
+      title: Requirable<Text> // Required in spec
+      updated: Requirable<TDate> // Required in spec
       app?: AppNs.Entry<TDate>
       arxiv?: ArxivNs.Entry
       cc?: CcNs.ItemOrFeed
@@ -158,13 +158,13 @@ export namespace AtomFeed {
       contributors?: Array<Person<TStrict>>
       generator?: Generator<TStrict>
       icon?: string
-      id: Requirable<string> // Required in spec.
+      id: Requirable<string> // Required in spec
       links?: Array<Link<TDate, TStrict>>
       logo?: string
       rights?: Text
       subtitle?: Text
-      title: Requirable<Text> // Required in spec.
-      updated: Requirable<TDate> // Required in spec.
+      title: Requirable<Text> // Required in spec
+      updated: Requirable<TDate> // Required in spec
       entries?: Array<Entry<TDate, TStrict>>
       cc?: CcNs.ItemOrFeed
       dc?: DcNs.ItemOrFeed<TDate>

--- a/src/feeds/atom/generate/config.ts
+++ b/src/feeds/atom/generate/config.ts
@@ -4,8 +4,8 @@ import { textConstructs } from '../../../namespaces/atom/common/config.js'
 
 export const builder = new XMLBuilder({
   ...builderConfig,
-  // A `type="xhtml"` construct holds its value as raw markup (see generateXhtmlValue in
-  // utils.ts), so the builder must not entity-encode it. Stop nodes match on the type
-  // attribute, leaving constructs of every other type on the normal escaping path.
+  // A `type="xhtml"` construct holds its value as raw markup (see generateXhtmlValue in utils.ts),
+  // so the builder must not entity-encode it. Stop nodes match on the type attribute, leaving
+  // constructs of every other type on the normal escaping path.
   stopNodes: textConstructs.map((element) => `..${element}[type=xhtml]`),
 })

--- a/src/feeds/atom/generate/utils.ts
+++ b/src/feeds/atom/generate/utils.ts
@@ -58,16 +58,16 @@ export const createNamespaceSetter = (prefix: string | undefined) => {
   return (key: string) => (prefix ? `${prefix}${key}` : key)
 }
 
-// A `type="xhtml"` construct must hold its markup as XML inside a single div (RFC 4287
-// §3.1.1.3), not as escaped text or CDATA, so the value is wrapped in the div. The builder
-// emits these constructs raw (see the stop nodes in config.ts), which is only correct when
-// the wrapped value is well-formed XML.
+// A `type="xhtml"` construct must hold its markup as XML inside a single div (RFC 4287 §3.1.1.3),
+// not as escaped text or CDATA, so the value is wrapped in the div. The builder emits these
+// constructs raw (see the stop nodes in config.ts), which is only correct when the wrapped value is
+// well-formed XML.
 
-// XMLValidator accepts entity references it cannot resolve, but a document without a DTD
-// can only resolve the five predefined entities and numeric references; anything else,
-// `&nbsp;` included, leaves it not well-formed for strict parsers. Any other name-shaped
-// reference is matched, since flagging one too many only routes the value to the escaped
-// fallback while missing one emits markup that will not parse.
+// XMLValidator accepts entity references it cannot resolve, but a document without a DTD can only
+// resolve the five predefined entities and numeric references; anything else, `&nbsp;` included,
+// leaves it not well-formed for strict parsers. Any other name-shaped reference is matched, since
+// flagging one too many only routes the value to the escaped fallback while missing one emits
+// markup that will not parse.
 const nonXmlEntityRegex = /&(?!(?:amp|lt|gt|quot|apos);|#\d+;|#x[0-9a-fA-F]+;)[^;\s&<]+;/
 
 export const generateXhtmlValue: GenerateUtil<string> = (value) => {
@@ -75,8 +75,8 @@ export const generateXhtmlValue: GenerateUtil<string> = (value) => {
     return
   }
 
-  // A literal carriage return would be normalized away by the reading XML parser
-  // (XML §2.11); the character reference survives, so the value round-trips exactly.
+  // A literal carriage return would be normalized away by the reading XML parser (XML §2.11); the
+  // character reference survives, so the value round-trips exactly.
   const inner = value.trim().replace(/\r/g, '&#13;')
   const wrapped = `<div xmlns="http://www.w3.org/1999/xhtml">${inner}</div>`
 
@@ -84,14 +84,14 @@ export const generateXhtmlValue: GenerateUtil<string> = (value) => {
     return
   }
 
-  // The builder emits this value raw and puts the closing tag right after it; the newline
-  // lets that tag land indented on its own line instead of glued to the div.
+  // The builder emits this value raw and puts the closing tag right after it; the newline lets that
+  // tag land indented on its own line instead of glued to the div.
   return { '#text': `${wrapped}\n` }
 }
 
-// A construct emitted raw by the builder (see the stop nodes in config.ts) has its
-// attributes emitted verbatim too, so their values are escaped here. Constructs of every
-// other type go through the builder's own attribute encoding, which would double-escape.
+// A construct emitted raw by the builder (see the stop nodes in config.ts) has its attributes
+// emitted verbatim too, so their values are escaped here. Constructs of every other type go through
+// the builder's own attribute encoding, which would double-escape.
 const escapeStopNodeAttributes = <T extends Record<string, unknown>>(value: T): T => {
   if (value['@type'] !== 'xhtml') {
     return value
@@ -110,12 +110,12 @@ const escapeStopNodeAttributes = <T extends Record<string, unknown>>(value: T): 
   return escaped as T
 }
 
-// A value that cannot be embedded as XML (unclosed HTML tags, a bare `&`, an HTML-only
-// entity) is emitted as type="html" instead: an xhtml construct without its div is invalid,
-// while escaped markup under type="html" is the conformant spelling of the same value.
-// The type is normalized once and decides both the routing and the emitted attribute: a
-// padded ` xhtml` would otherwise take the escaped path while the trimmed attribute matches
-// the stop node, and the builder would serialize the CDATA key as an element.
+// A value that cannot be embedded as XML (unclosed HTML tags, a bare `&`, an HTML-only entity) is
+// emitted as type="html" instead: an xhtml construct without its div is invalid, while escaped
+// markup under type="html" is the conformant spelling of the same value. The type is normalized
+// once and decides both the routing and the emitted attribute: a padded ` xhtml` would otherwise
+// take the escaped path while the trimmed attribute matches the stop node, and the builder would
+// serialize the CDATA key as an element.
 const generateTypedText = (value: string | undefined, rawType: string | undefined) => {
   const type = generatePlainString(rawType)
 
@@ -139,9 +139,9 @@ export const generateText: GenerateUtil<AtomFeed.Text> = (text) => {
 
   const typed = generateTypedText(text.value, text.type)
 
-  // A text construct carries nothing but its value, so without one there is no element to
-  // emit: a bare `type="xhtml"` would even violate the single-div content model. Content
-  // differs here, since `src` makes an empty element meaningful.
+  // A text construct carries nothing but its value, so without one there is no element to emit: a
+  // bare `type="xhtml"` would even violate the single-div content model. Content differs here,
+  // since `src` makes an empty element meaningful.
   if (!typed?.['#text'] && !typed?.['#cdata']) {
     return
   }

--- a/src/feeds/atom/parse/index.ts
+++ b/src/feeds/atom/parse/index.ts
@@ -14,8 +14,8 @@ const createNamespaceOptions = createNamespaceResolver({
   primaryNamespaces: ['atom'],
 })
 
-// Replaced per document, so the hooks below always read the declarations of the feed
-// being parsed and nothing survives into the next one.
+// Replaced per document, so the hooks below always read the declarations of the feed being parsed
+// and nothing survives into the next one.
 let namespaceOptions = createNamespaceOptions()
 
 const parser = new XMLParser({

--- a/src/feeds/atom/parse/utils.ts
+++ b/src/feeds/atom/parse/utils.ts
@@ -65,25 +65,25 @@ export const createNamespaceGetter = (
   return (key: string) => value[prefix + key]
 }
 
-// The value of a `type="xhtml"` text construct is the content of its single wrapping
-// <div>: RFC 4287 §3.1.1.3 requires the div itself to be excluded. The wrapper may also
-// bind the XHTML namespace to a prefix (`<xhtml:div>`), in which case every descendant tag
-// carries it too; the prefix is stripped along with the wrapper so the value is plain HTML.
-// Only the XHTML prefix gets this treatment. SVG and MathML are the two other namespaces
-// HTML represents unprefixed (foreign content: WHATWG HTML §13.2.6.5, "The rules for
-// parsing tokens in foreign content", https://html.spec.whatwg.org/multipage/parsing.html#parsing-main-inforeign),
-// but prefixed SVG/MathML inside xhtml constructs has no observed real-world usage; extend
-// to those bindings if such feeds ever appear.
+// The value of a `type="xhtml"` text construct is the content of its single wrapping <div>: RFC
+// 4287 §3.1.1.3 requires the div itself to be excluded. The wrapper may also bind the XHTML
+// namespace to a prefix (`<xhtml:div>`), in which case every descendant tag carries it too; the
+// prefix is stripped along with the wrapper so the value is plain HTML. Only the XHTML prefix gets
+// this treatment. SVG and MathML are the two other namespaces HTML represents unprefixed (foreign
+// content: WHATWG HTML §13.2.6.5, "The rules for parsing tokens in foreign content",
+// https://html.spec.whatwg.org/multipage/parsing.html#parsing-main-inforeign), but prefixed
+// SVG/MathML inside xhtml constructs has no observed real-world usage; extend to those bindings if
+// such feeds ever appear.
 const xhtmlDivStartRegex = /^\s*<(?:([a-zA-Z][\w.-]*):)?div[\s/>]/
 
-// The wrapper is located by re-parsing the value with the div as a stop node, which hands
-// back its raw inner markup byte for byte while a real tag scan deals with a `>` inside a
-// quoted attribute, comments and nested divs. A spec-violating shape (sibling divs, text
-// or comments around the wrapper, a mismatched closing tag) surfaces as extra root
-// children or a parse error, and the value is then kept unchanged.
+// The wrapper is located by re-parsing the value with the div as a stop node, which hands back its
+// raw inner markup byte for byte while a real tag scan deals with a `>` inside a quoted attribute,
+// comments and nested divs. A spec-violating shape (sibling divs, text or comments around the
+// wrapper, a mismatched closing tag) surfaces as extra root children or a parse error, and the
+// value is then kept unchanged.
 //
-// The synthetic root exists because the parser silently drops text standing outside the
-// root element; inside `x-wrap`, that text stays visible to the shape check below.
+// The synthetic root exists because the parser silently drops text standing outside the root
+// element; inside `x-wrap`, that text stays visible to the shape check below.
 const xhtmlDivParser = new XMLParser({
   preserveOrder: true,
   stopNodes: ['x-wrap.div'],
@@ -158,11 +158,10 @@ export const unwrapXhtmlDiv = (value: Unreliable): Unreliable => {
   return inner
 }
 
-// The wrapper div is excluded from the content (RFC 4287 §3.1.1.3), so xml:base and
-// xml:lang declared on it would vanish with it. They are read here through the same
-// mini-parse that located the wrapper, only when it was actually stripped: a value kept
-// verbatim still carries its div, declarations included.
-// Atom 0.3 spelled the construct type as `application/xhtml+xml`.
+// The wrapper div is excluded from the content (RFC 4287 §3.1.1.3), so xml:base and xml:lang
+// declared on it would vanish with it. They are read here through the same mini-parse that located
+// the wrapper, only when it was actually stripped: a value kept verbatim still carries its div,
+// declarations included. Atom 0.3 spelled the construct type as `application/xhtml+xml`.
 const isXhtmlType = (type: string | undefined): boolean => {
   return type === 'xhtml' || type === 'application/xhtml+xml'
 }
@@ -181,8 +180,8 @@ export const retrieveXhtmlDivXml = (
     return
   }
 
-  // The wrapper was stripped, so this identical parse is known to succeed and to hold
-  // exactly one div child; no guards are needed on the way to it.
+  // The wrapper was stripped, so this identical parse is known to succeed and to hold exactly one
+  // div child; no guards are needed on the way to it.
   const children = xhtmlDivParser.parse(`<x-wrap>${escaped}</x-wrap>`)[0]['x-wrap']
 
   for (const child of children) {
@@ -198,9 +197,9 @@ export const retrieveXhtmlDivXml = (
   }
 }
 
-// The div is the inner scope, so its lang replaces the element's, and its base resolves
-// against the element's when relative (XML Base §4.3); a pair the URL parser rejects keeps
-// the div's value as declared.
+// The div is the inner scope, so its lang replaces the element's, and its base resolves against the
+// element's when relative (XML Base §4.3); a pair the URL parser rejects keeps the div's value as
+// declared.
 export const mergeXhtmlDivXml = (
   elementXml: XmlNs.ItemOrFeed | undefined,
   divXml: XmlNs.ItemOrFeed | undefined,
@@ -224,10 +223,10 @@ export const mergeXhtmlDivXml = (
   return trimObject(merged)
 }
 
-// A CDATA section is XML's other spelling for literal text, so its content becomes entities
-// in the verbatim value: dropping only the markers would hand a literal `<` to an HTML
-// parser as markup, the same corruption the verbatim path exists to avoid. A section
-// without its `]]>` terminator is malformed XML and is left untouched.
+// A CDATA section is XML's other spelling for literal text, so its content becomes entities in the
+// verbatim value: dropping only the markers would hand a literal `<` to an HTML parser as markup,
+// the same corruption the verbatim path exists to avoid. A section without its `]]>` terminator is
+// malformed XML and is left untouched.
 const cdataSectionRegex = /<!\[CDATA\[([\s\S]*?)\]\]>/g
 
 export const escapeCdataSections = (value: Unreliable): Unreliable => {
@@ -240,15 +239,14 @@ export const escapeCdataSections = (value: Unreliable): Unreliable => {
   })
 }
 
-// Inside a genuine xhtml construct an escaped `&lt;` stands for that character and not for
-// markup (RFC 4287 §3.1.1.3), so decoding it would turn text into tags that an HTML parser
-// then swallows. Such a value is taken verbatim instead. The wrapper div identifies the
-// genuine case: a value without one is not a valid construct, and the spec does not say how
-// to read an invalid one, so it keeps the decoding, which suits a feed that labels escaped
-// HTML as xhtml. That is a choice, not a rule: 1 of 554 wrapper-less constructs in the
-// corpus sample carries escaped markup, and for the rest both paths produce the same string.
-// Atom 0.3 spelled the same construct as `type="application/xhtml+xml"`, so that type gets
-// the identical treatment.
+// Inside a genuine xhtml construct an escaped `&lt;` stands for that character and not for markup
+// (RFC 4287 §3.1.1.3), so decoding it would turn text into tags that an HTML parser then swallows.
+// Such a value is taken verbatim instead. The wrapper div identifies the genuine case: a value
+// without one is not a valid construct, and the spec does not say how to read an invalid one, so it
+// keeps the decoding, which suits a feed that labels escaped HTML as xhtml. That is a choice, not a
+// rule: 1 of 554 wrapper-less constructs in the corpus sample carries escaped markup, and for the
+// rest both paths produce the same string. Atom 0.3 spelled the same construct as
+// `type="application/xhtml+xml"`, so that type gets the identical treatment.
 export const parseTypedText = (value: Unreliable, type: string | undefined): string | undefined => {
   const text = retrieveText(value)
 
@@ -256,8 +254,8 @@ export const parseTypedText = (value: Unreliable, type: string | undefined): str
     return parseString(text)
   }
 
-  // CDATA is escaped before the wrapper is stripped: its content is literal text, so a
-  // `</xhtml:p>` or `<div>` inside it must not be seen as markup by the prefix strip.
+  // CDATA is escaped before the wrapper is stripped: its content is literal text, so a `</xhtml:p>`
+  // or `<div>` inside it must not be seen as markup by the prefix strip.
   const escaped = escapeCdataSections(text)
   const unwrapped = unwrapXhtmlDiv(escaped)
 
@@ -265,9 +263,9 @@ export const parseTypedText = (value: Unreliable, type: string | undefined): str
     return parseVerbatimString(unwrapped)
   }
 
-  // A value that opens with a div is markup even when the wrapper cannot be stripped
-  // (sibling divs, an unterminated wrapper, text around it); only wrapper-less values keep
-  // the decoding path for feeds that label escaped HTML as xhtml.
+  // A value that opens with a div is markup even when the wrapper cannot be stripped (sibling divs,
+  // an unterminated wrapper, text around it); only wrapper-less values keep the decoding path for
+  // feeds that label escaped HTML as xhtml.
   if (isNonEmptyString(escaped) && xhtmlDivStartRegex.test(escaped)) {
     return parseVerbatimString(escaped)
   }
@@ -350,8 +348,8 @@ export const retrievePersonUri: ParseUtilPartial<string> = (value, options) => {
   }
 
   const get = createNamespaceGetter(value, options?.prefix)
-  const uri = parseSingularOf(get('uri'), (value) => parseString(retrieveText(value))) // Atom 1.0.
-  const url = parseSingularOf(get('url'), (value) => parseString(retrieveText(value))) // Atom 0.3.
+  const uri = parseSingularOf(get('uri'), (value) => parseString(retrieveText(value))) // Atom 1.0
+  const url = parseSingularOf(get('url'), (value) => parseString(retrieveText(value))) // Atom 0.3
 
   return uri || url
 }
@@ -392,8 +390,8 @@ export const retrieveGeneratorUri: ParseUtilPartial<string> = (value) => {
     return
   }
 
-  const uri = parseString(value['@uri']) // Atom 1.0.
-  const url = parseString(value['@url']) // Atom 0.3.
+  const uri = parseString(value['@uri']) // Atom 1.0
+  const url = parseString(value['@url']) // Atom 0.3
 
   return uri || url
 }
@@ -448,9 +446,9 @@ export const retrievePublished: ParseUtilPartial<DateAny> = (value, options) => 
     parseDate(retrieveText(value), options?.parseDateFn),
   ) // Atom 0.3.
 
-  // The "created" date is not entirely valid as "published date", but if it's there when
-  // no other date is present, it's a good-enough fallback especially that it's not present
-  // in 1.0 version of the specfication.
+  // The "created" date is not entirely valid as "published date", but if it's there when no other
+  // date is present, it's a good-enough fallback especially that it's not present in 1.0 version of
+  // the specfication.
   return published || issued || created
 }
 
@@ -476,8 +474,8 @@ export const retrieveSubtitle: ParseUtilPartial<AtomFeed.Text> = (value, options
   }
 
   const get = createNamespaceGetter(value, options?.prefix)
-  const subtitle = parseSingularOf(get('subtitle'), parseText) // Atom 1.0.
-  const tagline = parseSingularOf(get('tagline'), parseText) // Atom 0.3.
+  const subtitle = parseSingularOf(get('subtitle'), parseText) // Atom 1.0
+  const tagline = parseSingularOf(get('tagline'), parseText) // Atom 0.3
 
   return subtitle || tagline
 }

--- a/src/feeds/json/common/types.ts
+++ b/src/feeds/json/common/types.ts
@@ -21,8 +21,8 @@ export namespace JsonFeed {
 
   export type Attachment<TStrict extends boolean = false> = Strict<
     {
-      url: Requirable<string> // Required in spec.
-      mime_type: Requirable<string> // Required in spec.
+      url: Requirable<string> // Required in spec
+      mime_type: Requirable<string> // Required in spec
       title?: string
       size_in_bytes?: number
       duration_in_seconds?: number
@@ -32,12 +32,12 @@ export namespace JsonFeed {
 
   export type Item<TDate, TStrict extends boolean = false> = Strict<
     {
-      id: Requirable<string> // Required in spec.
+      id: Requirable<string> // Required in spec
       url?: string
       external_url?: string
       title?: string
-      content_html?: string // At least one of content_html or content_text is required in spec.
-      content_text?: string // At least one of content_html or content_text is required in spec.
+      content_html?: string // At least one of content_html or content_text is required in spec
+      content_text?: string // At least one of content_html or content_text is required in spec
       summary?: string
       image?: string
       banner_image?: string
@@ -54,15 +54,15 @@ export namespace JsonFeed {
 
   export type Hub<TStrict extends boolean = false> = Strict<
     {
-      type: Requirable<string> // Required in spec.
-      url: Requirable<string> // Required in spec.
+      type: Requirable<string> // Required in spec
+      url: Requirable<string> // Required in spec
     },
     TStrict
   >
 
   export type Feed<TDate, TStrict extends boolean = false> = Strict<
     {
-      title: Requirable<string> // Required in spec.
+      title: Requirable<string> // Required in spec
       home_page_url?: string
       feed_url?: string
       description?: string
@@ -74,7 +74,7 @@ export namespace JsonFeed {
       expired?: boolean
       hubs?: Array<Hub<TStrict>>
       authors?: Array<Author>
-      items: Requirable<Array<Item<TDate, TStrict>>> // Required in spec.
+      items: Requirable<Array<Item<TDate, TStrict>>> // Required in spec
     },
     TStrict
   >

--- a/src/feeds/json/parse/utils.ts
+++ b/src/feeds/json/parse/utils.ts
@@ -54,9 +54,9 @@ export const retrieveAuthors: ParseUtilPartial<Array<JsonFeed.Author>> = (value)
     return
   }
 
-  // Regardless of the JSON Feed version, the 'authors' property is returned in the item/feed.
-  // Some feeds use author/authors incorrectly based on the feed version, so this function helps
-  // to unify those into one value.
+  // Regardless of the JSON Feed version, the 'authors' property is returned in the item/feed. Some
+  // feeds use author/authors incorrectly based on the feed version, so this function helps to unify
+  // those into one value.
   const get = createCaseInsensitiveGetter(value)
   const parsedAuthors = parseArrayOf(get('authors'), parseAuthor)
   const parsedAuthor = parseArrayOf(get('author'), parseAuthor)

--- a/src/feeds/rdf/common/types.ts
+++ b/src/feeds/rdf/common/types.ts
@@ -24,9 +24,9 @@ export type ParseUtilPartial<R> = BaseParseUtilPartial<R, ParseMainOptions<DateA
 export namespace RdfFeed {
   export type Image<TStrict extends boolean = false> = Strict<
     {
-      title: Requirable<string> // Required in spec.
-      link: Requirable<string> // Required in spec.
-      url: Requirable<string> // Required in spec.
+      title: Requirable<string> // Required in spec
+      link: Requirable<string> // Required in spec
+      url: Requirable<string> // Required in spec
       rdf?: RdfNs.About
     },
     TStrict
@@ -34,10 +34,10 @@ export namespace RdfFeed {
 
   export type TextInput<TStrict extends boolean = false> = Strict<
     {
-      title: Requirable<string> // Required in spec.
-      description: Requirable<string> // Required in spec.
-      name: Requirable<string> // Required in spec.
-      link: Requirable<string> // Required in spec.
+      title: Requirable<string> // Required in spec
+      description: Requirable<string> // Required in spec
+      name: Requirable<string> // Required in spec
+      link: Requirable<string> // Required in spec
       rdf?: RdfNs.About
     },
     TStrict
@@ -45,8 +45,8 @@ export namespace RdfFeed {
 
   export type Item<TDate, TStrict extends boolean = false> = Strict<
     {
-      title: Requirable<string> // Required in spec.
-      link: Requirable<string> // Required in spec.
+      title: Requirable<string> // Required in spec
+      link: Requirable<string> // Required in spec
       description?: string
       rdf?: RdfNs.About
       atom?: AtomNs.Entry<TDate>
@@ -64,9 +64,9 @@ export namespace RdfFeed {
 
   export type Feed<TDate, TStrict extends boolean = false> = Strict<
     {
-      title: Requirable<string> // Required in spec.
-      link: Requirable<string> // Required in spec.
-      description: Requirable<string> // Required in spec.
+      title: Requirable<string> // Required in spec
+      link: Requirable<string> // Required in spec
+      description: Requirable<string> // Required in spec
       image?: Image<TStrict>
       items?: Array<Item<TDate, TStrict>>
       textInput?: TextInput<TStrict>

--- a/src/feeds/rdf/detect/index.ts
+++ b/src/feeds/rdf/detect/index.ts
@@ -1,8 +1,8 @@
 import { isNonEmptyString } from 'trousse'
 import { namespaceUris } from '../../../common/config.js'
 
-// RSS 0.9/1.0 namespace URIs (used for detection only, not in namespacePrefixes
-// since these elements are the default/unprefixed content in RDF feeds).
+// RSS 0.9/1.0 namespace URIs (used for detection only, not in namespacePrefixes since these
+// elements are the default/unprefixed content in RDF feeds).
 const rssNamespaceUris = [
   'http://purl.org/rss/1.0/',
   'https://purl.org/rss/1.0/',

--- a/src/feeds/rdf/parse/config.ts
+++ b/src/feeds/rdf/parse/config.ts
@@ -1,8 +1,8 @@
 import { namespaceStopNodes } from '../../../common/config.js'
 
-// The pre-parse seed canonicalizes the root's primary prefix before matching, so the root
-// spells as `rdf`. A document that never declares the prefix keeps `rdf:rdf` as its key
-// and fails retrieval regardless, so only the canonical form is matched.
+// The pre-parse seed canonicalizes the root's primary prefix before matching, so the root spells as
+// `rdf`. A document that never declares the prefix keeps `rdf:rdf` as its key and fails retrieval
+// regardless, so only the canonical form is matched.
 export const stopNodes = [
   ...namespaceStopNodes,
   'rdf.channel.title',

--- a/src/feeds/rdf/parse/index.ts
+++ b/src/feeds/rdf/parse/index.ts
@@ -14,8 +14,8 @@ const createNamespaceOptions = createNamespaceResolver({
   primaryNamespaces: ['rdf', 'rss'],
 })
 
-// Replaced per document, so the hooks below always read the declarations of the feed
-// being parsed and nothing survives into the next one.
+// Replaced per document, so the hooks below always read the declarations of the feed being parsed
+// and nothing survives into the next one.
 let namespaceOptions = createNamespaceOptions()
 
 const parser = new XMLParser({

--- a/src/feeds/rss/common/types.ts
+++ b/src/feeds/rss/common/types.ts
@@ -45,14 +45,14 @@ export namespace RssFeed {
   export type Person = {
     name?: string
     email?: string
-    // Parse-only. Extracted from URLs found in person strings. Not included in generated output,
-    // as the RSS spec has no standard way to encode links in person fields.
+    // Parse-only. Extracted from URLs found in person strings. Not included in generated output, as
+    // the RSS spec has no standard way to encode links in person fields.
     link?: string
   }
 
   export type Category<TStrict extends boolean = false> = Strict<
     {
-      name: Requirable<string> // Required in spec.
+      name: Requirable<string> // Required in spec
       domain?: string
     },
     TStrict
@@ -60,20 +60,20 @@ export namespace RssFeed {
 
   export type Cloud<TStrict extends boolean = false> = Strict<
     {
-      domain: Requirable<string> // Required in spec.
-      port: Requirable<number> // Required in spec.
-      path: Requirable<string> // Required in spec.
-      registerProcedure: Requirable<string> // Required in spec.
-      protocol: Requirable<string> // Required in spec.
+      domain: Requirable<string> // Required in spec
+      port: Requirable<number> // Required in spec
+      path: Requirable<string> // Required in spec
+      registerProcedure: Requirable<string> // Required in spec
+      protocol: Requirable<string> // Required in spec
     },
     TStrict
   >
 
   export type Image<TStrict extends boolean = false> = Strict<
     {
-      url: Requirable<string> // Required in spec.
-      title: Requirable<string> // Required in spec.
-      link: Requirable<string> // Required in spec.
+      url: Requirable<string> // Required in spec
+      title: Requirable<string> // Required in spec
+      link: Requirable<string> // Required in spec
       description?: string
       height?: number
       width?: number
@@ -83,19 +83,19 @@ export namespace RssFeed {
 
   export type TextInput<TStrict extends boolean = false> = Strict<
     {
-      title: Requirable<string> // Required in spec.
-      description: Requirable<string> // Required in spec.
-      name: Requirable<string> // Required in spec.
-      link: Requirable<string> // Required in spec.
+      title: Requirable<string> // Required in spec
+      description: Requirable<string> // Required in spec
+      name: Requirable<string> // Required in spec
+      link: Requirable<string> // Required in spec
     },
     TStrict
   >
 
   export type Enclosure<TStrict extends boolean = false> = Strict<
     {
-      url: Requirable<string> // Required in spec.
-      length: Requirable<number> // Required in spec.
-      type: Requirable<string> // Required in spec.
+      url: Requirable<string> // Required in spec
+      length: Requirable<number> // Required in spec
+      type: Requirable<string> // Required in spec
     },
     TStrict
   >
@@ -106,7 +106,7 @@ export namespace RssFeed {
 
   export type Guid<TStrict extends boolean = false> = Strict<
     {
-      value: Requirable<string> // Required in spec.
+      value: Requirable<string> // Required in spec
       isPermaLink?: boolean
     },
     TStrict
@@ -114,17 +114,17 @@ export namespace RssFeed {
 
   export type Source<TStrict extends boolean = false> = Strict<
     {
-      title: Requirable<string> // Required in spec.
-      url: Requirable<string> // Required in spec.
+      title: Requirable<string> // Required in spec
+      url: Requirable<string> // Required in spec
     },
     TStrict
   >
 
   export type Item<TDate, TStrict extends boolean = false> = Strict<
     {
-      title?: string // At least one of title or description is required in spec.
+      title?: string // At least one of title or description is required in spec
       link?: string
-      description?: string // At least one of title or description is required in spec.
+      description?: string // At least one of title or description is required in spec
       authors?: Array<Person>
       categories?: Array<Category<TStrict>>
       comments?: string
@@ -163,9 +163,9 @@ export namespace RssFeed {
 
   export type Feed<TDate, TStrict extends boolean = false> = Strict<
     {
-      title: Requirable<string> // Required in spec.
-      link: Requirable<string> // Required in spec (but may be missing when atom:link rel="self" is present).
-      description: Requirable<string> // Required in spec.
+      title: Requirable<string> // Required in spec
+      link: Requirable<string> // Required in spec (but may be missing when atom:link rel="self" is present)
+      description: Requirable<string> // Required in spec
       language?: string
       copyright?: string
       managingEditor?: Person

--- a/src/feeds/rss/generate/config.ts
+++ b/src/feeds/rss/generate/config.ts
@@ -4,7 +4,7 @@ import { textConstructs } from '../../../namespaces/atom/common/config.js'
 
 export const builder = new XMLBuilder({
   ...builderConfig,
-  // Atom text constructs embedded via the atom namespace hold raw xhtml markup when their
-  // type is xhtml, exactly like in Atom feeds (see src/feeds/atom/generate/config.ts).
+  // Atom text constructs embedded via the atom namespace hold raw xhtml markup when their type is
+  // xhtml, exactly like in Atom feeds (see src/feeds/atom/generate/config.ts).
   stopNodes: textConstructs.map((element) => `..atom:${element}[type=xhtml]`),
 })

--- a/src/feeds/rss/parse/config.ts
+++ b/src/feeds/rss/parse/config.ts
@@ -1,7 +1,7 @@
 import { namespaceStopNodes } from '../../../common/config.js'
 
-// These elements can appear both inside <channel> and as direct children of
-// <rss> in malformed feeds, so stop nodes are generated for both paths.
+// These elements can appear both inside <channel> and as direct children of <rss> in malformed
+// feeds, so stop nodes are generated for both paths.
 const sharedStopNodes = [
   'image.description',
   'image.height',
@@ -16,8 +16,8 @@ const sharedStopNodes = [
   'item.title',
   'item.link',
   'item.description',
-  // INFO: Added support for nested *.name under author to support cases as
-  // described here: https://github.com/macieklamberski/feedsmith/issues/22.
+  // INFO: Added support for nested *.name under author to support cases as described here:
+  // https://github.com/macieklamberski/feedsmith/issues/22.
   'item.author.name',
   'item.category',
   'item.comments',

--- a/src/feeds/rss/parse/index.ts
+++ b/src/feeds/rss/parse/index.ts
@@ -10,8 +10,8 @@ import { retrieveFeed } from './utils.js'
 
 const createNamespaceOptions = createNamespaceResolver({ namespaceUris, namespacePrefixes })
 
-// Replaced per document, so the hooks below always read the declarations of the feed
-// being parsed and nothing survives into the next one.
+// Replaced per document, so the hooks below always read the declarations of the feed being parsed
+// and nothing survives into the next one.
 let namespaceOptions = createNamespaceOptions()
 
 const parser = new XMLParser({

--- a/src/feeds/rss/parse/utils.ts
+++ b/src/feeds/rss/parse/utils.ts
@@ -189,7 +189,7 @@ const parseBracketedPerson = (raw: string): RssFeed.Person | undefined => {
         chunk = parseString(raw.slice(start, end - 1))
         i = end
       } else {
-        // Unmatched bracket — treat as literal text.
+        // Unmatched bracket: treat as literal text.
         const literalStart = i
         i = start
         while (i < length && raw[i] !== '<' && raw[i] !== '(' && raw[i] !== '[') {

--- a/src/index.ts
+++ b/src/index.ts
@@ -54,7 +54,7 @@ export type { Opml } from './opml/common/types.js'
 export { generate as generateOpml } from './opml/generate/index.js'
 export { parse as parseOpml } from './opml/parse/index.js'
 
-// Deprecated aliases — declared here so JSDoc survives tsdown's .d.ts bundling.
+// Deprecated aliases: declared here so JSDoc survives tsdown's .d.ts bundling.
 // Remove this block in 4.x.
 
 import type { AtomFeed } from './feeds/atom/common/types.js'

--- a/src/namespaces/acast/common/config.ts
+++ b/src/namespaces/acast/common/config.ts
@@ -1,5 +1,5 @@
 export const uris = [
-  'https://schema.acast.com/1.0/', // Official URI.
+  'https://schema.acast.com/1.0/', // Official URI
   'http://schema.acast.com/1.0/',
   'https://schema.acast.com/1.0',
   'http://schema.acast.com/1.0',

--- a/src/namespaces/admin/common/config.ts
+++ b/src/namespaces/admin/common/config.ts
@@ -1,5 +1,5 @@
 export const uris = [
-  'http://webns.net/mvcb/', // Official URI.
+  'http://webns.net/mvcb/', // Official URI
   'https://webns.net/mvcb/',
   'http://webns.net/mvcb',
   'https://webns.net/mvcb',

--- a/src/namespaces/app/common/config.ts
+++ b/src/namespaces/app/common/config.ts
@@ -1,5 +1,5 @@
 export const uris = [
-  'http://www.w3.org/2007/app', // Official URI.
+  'http://www.w3.org/2007/app', // Official URI
   'https://www.w3.org/2007/app',
   'http://www.w3.org/2007/app/',
   'https://www.w3.org/2007/app/',

--- a/src/namespaces/arxiv/common/config.ts
+++ b/src/namespaces/arxiv/common/config.ts
@@ -1,5 +1,5 @@
 export const uris = [
-  'http://arxiv.org/schemas/atom', // Official URI.
+  'http://arxiv.org/schemas/atom', // Official URI
   'https://arxiv.org/schemas/atom',
   'http://arxiv.org/schemas/atom/',
   'https://arxiv.org/schemas/atom/',

--- a/src/namespaces/atom/common/config.ts
+++ b/src/namespaces/atom/common/config.ts
@@ -1,23 +1,23 @@
 export const uris = [
-  'http://www.w3.org/2005/Atom', // Official URI (Atom 1.0).
+  'http://www.w3.org/2005/Atom', // Official URI (Atom 1.0)
   'https://www.w3.org/2005/Atom',
   'http://www.w3.org/2005/Atom/',
   'https://www.w3.org/2005/Atom/',
-  'http://purl.org/atom/ns#', // Official URI (Atom 0.3).
+  'http://purl.org/atom/ns#', // Official URI (Atom 0.3)
   'https://purl.org/atom/ns#',
 ]
 
-// The elements that can carry a type="xhtml" value with inline markup. Atom 0.3's tagline
-// is left out: generated feeds are normalized to 1.0, so its stop node would never match.
+// The elements that can carry a type="xhtml" value with inline markup. Atom 0.3's tagline is left
+// out: generated feeds are normalized to 1.0, so its stop node would never match.
 export const textConstructs = ['title', 'subtitle', 'rights', 'summary', 'content']
 
-// Leaf paths the parser reads, relative to the feed and to the entry. Text constructs can
-// hold inline xhtml markup, which must reach parseText as raw text; containers (author,
-// contributor, source) appear only as segments so they parse into structure.
+// Leaf paths the parser reads, relative to the feed and to the entry. Text constructs can hold
+// inline xhtml markup, which must reach parseText as raw text; containers (author, contributor,
+// source) appear only as segments so they parse into structure.
 const personPaths = (parent: string) => [
   `${parent}.name`,
   `${parent}.uri`,
-  `${parent}.url`, // Atom 0.3.
+  `${parent}.url`, // Atom 0.3
   `${parent}.email`,
 ]
 
@@ -32,10 +32,10 @@ export const feedPaths = [
   'logo',
   'rights',
   'subtitle',
-  'tagline', // Atom 0.3.
+  'tagline', // Atom 0.3
   'title',
   'updated',
-  'modified', // Atom 0.3.
+  'modified', // Atom 0.3
 ]
 
 export const entryPaths = [
@@ -46,8 +46,8 @@ export const entryPaths = [
   'id',
   'link',
   'published',
-  'issued', // Atom 0.3.
-  'created', // Atom 0.3.
+  'issued', // Atom 0.3
+  'created', // Atom 0.3
   'rights',
   ...personPaths('source.author'),
   'source.category',
@@ -61,11 +61,11 @@ export const entryPaths = [
   'source.subtitle',
   'source.title',
   'source.updated',
-  'source.modified', // Atom 0.3.
+  'source.modified', // Atom 0.3
   'summary',
   'title',
   'updated',
-  'modified', // Atom 0.3.
+  'modified', // Atom 0.3
 ]
 
 const prefixSegments = (path: string) => {
@@ -75,8 +75,8 @@ const prefixSegments = (path: string) => {
     .join('.')
 }
 
-// Prefixes are canonicalized to `atom:` during parsing (createNamespaceHooks), so
-// alternates like `a10:` match these entries too.
+// Prefixes are canonicalized to `atom:` during parsing (createNamespaceHooks), so alternates like
+// `a10:` match these entries too.
 export const stopNodes = [...new Set([...feedPaths, ...entryPaths])].map((path) => {
   return `*.${prefixSegments(path)}`
 })

--- a/src/namespaces/atom/common/types.ts
+++ b/src/namespaces/atom/common/types.ts
@@ -1,8 +1,8 @@
 import type { DeepOmit } from 'trousse'
 import type { AtomFeed } from '../../../feeds/atom/common/types.js'
 
-// Namespace properties to exclude when Atom is used as a namespace (not as a feed format).
-// This includes keys from all levels: Entry/Feed, Person (arxiv), Link (thr), etc.
+// Namespace properties to exclude when Atom is used as a namespace (not as a feed format). This
+// includes keys from all levels: Entry/Feed, Person (arxiv), Link (thr), etc.
 type NsKeys =
   | 'admin'
   | 'app'

--- a/src/namespaces/blogchannel/common/config.ts
+++ b/src/namespaces/blogchannel/common/config.ts
@@ -1,5 +1,5 @@
 export const uris = [
-  'http://backend.userland.com/blogChannelModule', // Official URI.
+  'http://backend.userland.com/blogChannelModule', // Official URI
   'https://backend.userland.com/blogChannelModule',
   'http://backend.userland.com/blogChannelModule/',
   'https://backend.userland.com/blogChannelModule/',

--- a/src/namespaces/cc/common/config.ts
+++ b/src/namespaces/cc/common/config.ts
@@ -1,5 +1,5 @@
 export const uris = [
-  'http://creativecommons.org/ns#', // Official URI.
+  'http://creativecommons.org/ns#', // Official URI
   'https://creativecommons.org/ns#',
   'http://web.resource.org/cc/',
   'https://web.resource.org/cc/',

--- a/src/namespaces/content/common/config.ts
+++ b/src/namespaces/content/common/config.ts
@@ -1,5 +1,5 @@
 export const uris = [
-  'http://purl.org/rss/1.0/modules/content/', // Official URI.
+  'http://purl.org/rss/1.0/modules/content/', // Official URI
   'https://purl.org/rss/1.0/modules/content/',
   'http://purl.org/rss/1.0/modules/content',
   'https://purl.org/rss/1.0/modules/content',

--- a/src/namespaces/content/common/types.ts
+++ b/src/namespaces/content/common/types.ts
@@ -1,9 +1,9 @@
 // #region reference
 export namespace ContentNs {
   export type Item = {
-    // Spec (https://web.resource.org/rss/1.0/modules/content/) also mentions content:items,
-    // but it is not clear what it is used for. Also, it's not widely used so its implementation
-    // will be skipped for now. If it's requested in the future, it can be added here.
+    // Spec (https://web.resource.org/rss/1.0/modules/content/) also mentions content:items, but it
+    // is not clear what it is used for. Also, it's not widely used so its implementation will be
+    // skipped for now. If it's requested in the future, it can be added here.
     encoded?: string
   }
 }

--- a/src/namespaces/creativecommons/common/config.ts
+++ b/src/namespaces/creativecommons/common/config.ts
@@ -1,5 +1,5 @@
 export const uris = [
-  'http://backend.userland.com/creativeCommonsRssModule', // Official URI.
+  'http://backend.userland.com/creativeCommonsRssModule', // Official URI
   'https://backend.userland.com/creativeCommonsRssModule',
   'http://backend.userland.com/creativeCommonsRssModule/',
   'https://backend.userland.com/creativeCommonsRssModule/',

--- a/src/namespaces/dc/common/config.ts
+++ b/src/namespaces/dc/common/config.ts
@@ -1,5 +1,5 @@
 export const uris = [
-  'http://purl.org/dc/elements/1.1/', // Official URI.
+  'http://purl.org/dc/elements/1.1/', // Official URI
   'https://purl.org/dc/elements/1.1/',
   'http://purl.org/dc/elements/1.1',
   'https://purl.org/dc/elements/1.1',

--- a/src/namespaces/dcterms/common/config.ts
+++ b/src/namespaces/dcterms/common/config.ts
@@ -1,5 +1,5 @@
 export const uris = [
-  'http://purl.org/dc/terms/', // Official URI.
+  'http://purl.org/dc/terms/', // Official URI
   'https://purl.org/dc/terms/',
   'http://purl.org/dc/terms',
   'https://purl.org/dc/terms',

--- a/src/namespaces/feedpress/common/config.ts
+++ b/src/namespaces/feedpress/common/config.ts
@@ -1,5 +1,5 @@
 export const uris = [
-  'https://feed.press/xmlns', // Official URI.
+  'https://feed.press/xmlns', // Official URI
   'http://feed.press/xmlns',
   'https://feed.press/xmlns/',
   'http://feed.press/xmlns/',

--- a/src/namespaces/geo/common/config.ts
+++ b/src/namespaces/geo/common/config.ts
@@ -1,5 +1,5 @@
 export const uris = [
-  'http://www.w3.org/2003/01/geo/wgs84_pos#', // Official URI.
+  'http://www.w3.org/2003/01/geo/wgs84_pos#', // Official URI
   'https://www.w3.org/2003/01/geo/wgs84_pos#',
 ]
 

--- a/src/namespaces/georss/common/config.ts
+++ b/src/namespaces/georss/common/config.ts
@@ -1,5 +1,5 @@
 export const uris = [
-  'http://www.georss.org/georss', // Official URI.
+  'http://www.georss.org/georss', // Official URI
   'http://www.georss.org/georss/',
   'https://www.georss.org/georss',
   'https://www.georss.org/georss/',

--- a/src/namespaces/georss/common/types.ts
+++ b/src/namespaces/georss/common/types.ts
@@ -4,30 +4,30 @@ import type { Requirable, Strict } from '../../../common/types.js'
 export namespace GeoRssNs {
   export type Point<TStrict extends boolean = false> = Strict<
     {
-      lat: Requirable<number> // Required in spec.
-      lng: Requirable<number> // Required in spec.
+      lat: Requirable<number> // Required in spec
+      lng: Requirable<number> // Required in spec
     },
     TStrict
   >
 
   export type Line<TStrict extends boolean = false> = Strict<
     {
-      points: Requirable<Array<Point<TStrict>>> // Required in spec.
+      points: Requirable<Array<Point<TStrict>>> // Required in spec
     },
     TStrict
   >
 
   export type Polygon<TStrict extends boolean = false> = Strict<
     {
-      points: Requirable<Array<Point<TStrict>>> // Required in spec.
+      points: Requirable<Array<Point<TStrict>>> // Required in spec
     },
     TStrict
   >
 
   export type Box<TStrict extends boolean = false> = Strict<
     {
-      lowerCorner: Requirable<Point<TStrict>> // Required in spec.
-      upperCorner: Requirable<Point<TStrict>> // Required in spec.
+      lowerCorner: Requirable<Point<TStrict>> // Required in spec
+      upperCorner: Requirable<Point<TStrict>> // Required in spec
     },
     TStrict
   >

--- a/src/namespaces/googleplay/common/config.ts
+++ b/src/namespaces/googleplay/common/config.ts
@@ -1,5 +1,5 @@
 export const uris = [
-  'https://www.google.com/schemas/play-podcasts/1.0/', // Official URI.
+  'https://www.google.com/schemas/play-podcasts/1.0/', // Official URI
   'http://www.google.com/schemas/play-podcasts/1.0/',
   'https://www.google.com/schemas/play-podcasts/1.0',
   'http://www.google.com/schemas/play-podcasts/1.0',

--- a/src/namespaces/googleplay/common/types.ts
+++ b/src/namespaces/googleplay/common/types.ts
@@ -4,7 +4,7 @@ import type { Requirable, Strict } from '../../../common/types.js'
 export namespace GooglePlayNs {
   export type Image<TStrict extends boolean = false> = Strict<
     {
-      href: Requirable<string> // Required in spec.
+      href: Requirable<string> // Required in spec
     },
     TStrict
   >

--- a/src/namespaces/itunes/common/config.ts
+++ b/src/namespaces/itunes/common/config.ts
@@ -1,5 +1,5 @@
 export const uris = [
-  'http://www.itunes.com/dtds/podcast-1.0.dtd', // Official URI.
+  'http://www.itunes.com/dtds/podcast-1.0.dtd', // Official URI
   'https://www.itunes.com/dtds/podcast-1.0.dtd',
 ]
 

--- a/src/namespaces/itunes/common/types.ts
+++ b/src/namespaces/itunes/common/types.ts
@@ -2,11 +2,11 @@ import type { Requirable, Strict } from '../../../common/types.js'
 
 // #region reference
 export namespace ItunesNs {
-  // NOTE: BaseCategory contains non-recursive fields wrapped in Strict<>.
-  // Category extends it and adds recursive categories field separately.
+  // NOTE: BaseCategory contains non-recursive fields wrapped in Strict<>. Category extends it and
+  // adds recursive categories field separately.
   export type BaseCategory<TStrict extends boolean = false> = Strict<
     {
-      text: Requirable<string> // Required in spec.
+      text: Requirable<string> // Required in spec
     },
     TStrict
   >

--- a/src/namespaces/itunes/parse/utils.ts
+++ b/src/namespaces/itunes/parse/utils.ts
@@ -76,8 +76,8 @@ export const parseDuration: ParseUtilPartial<number> = (value) => {
 }
 
 export const parseImage: ParseUtilPartial<string> = (value) => {
-  // Support non-standard format of the image tag where href is not provided in the @href
-  // attribute but rather provided as a node value.
+  // Support non-standard format of the image tag where href is not provided in the @href attribute
+  // but rather provided as a node value.
   if (isNonEmptyStringOrNumber(value)) {
     return parseString(value)
   }

--- a/src/namespaces/media/common/config.ts
+++ b/src/namespaces/media/common/config.ts
@@ -1,5 +1,5 @@
 export const uris = [
-  'http://search.yahoo.com/mrss/', // Official URI.
+  'http://search.yahoo.com/mrss/', // Official URI
   'https://search.yahoo.com/mrss/',
   'http://search.yahoo.com/mrss',
   'https://search.yahoo.com/mrss',

--- a/src/namespaces/media/common/types.ts
+++ b/src/namespaces/media/common/types.ts
@@ -4,7 +4,7 @@ import type { Requirable, Strict } from '../../../common/types.js'
 export namespace MediaNs {
   export type Rating<TStrict extends boolean = false> = Strict<
     {
-      value: Requirable<string> // Required in spec.
+      value: Requirable<string> // Required in spec
       scheme?: string
     },
     TStrict
@@ -12,7 +12,7 @@ export namespace MediaNs {
 
   export type TitleOrDescription<TStrict extends boolean = false> = Strict<
     {
-      value: Requirable<string> // Required in spec.
+      value: Requirable<string> // Required in spec
       type?: string
     },
     TStrict
@@ -20,7 +20,7 @@ export namespace MediaNs {
 
   export type Thumbnail<TStrict extends boolean = false> = Strict<
     {
-      url: Requirable<string> // Required in spec.
+      url: Requirable<string> // Required in spec
       height?: number
       width?: number
       time?: string
@@ -30,7 +30,7 @@ export namespace MediaNs {
 
   export type Category<TStrict extends boolean = false> = Strict<
     {
-      name: Requirable<string> // Required in spec.
+      name: Requirable<string> // Required in spec
       scheme?: string
       label?: string
     },
@@ -39,7 +39,7 @@ export namespace MediaNs {
 
   export type Hash<TStrict extends boolean = false> = Strict<
     {
-      value: Requirable<string> // Required in spec.
+      value: Requirable<string> // Required in spec
       algo?: string
     },
     TStrict
@@ -47,7 +47,7 @@ export namespace MediaNs {
 
   export type Player<TStrict extends boolean = false> = Strict<
     {
-      url: Requirable<string> // Required in spec.
+      url: Requirable<string> // Required in spec
       height?: number
       width?: number
     },
@@ -56,7 +56,7 @@ export namespace MediaNs {
 
   export type Credit<TStrict extends boolean = false> = Strict<
     {
-      value: Requirable<string> // Required in spec.
+      value: Requirable<string> // Required in spec
       role?: string
       scheme?: string
     },
@@ -65,7 +65,7 @@ export namespace MediaNs {
 
   export type Copyright<TStrict extends boolean = false> = Strict<
     {
-      value: Requirable<string> // Required in spec.
+      value: Requirable<string> // Required in spec
       url?: string
     },
     TStrict
@@ -73,7 +73,7 @@ export namespace MediaNs {
 
   export type Text<TStrict extends boolean = false> = Strict<
     {
-      value: Requirable<string> // Required in spec.
+      value: Requirable<string> // Required in spec
       type?: string
       lang?: string
       start?: string
@@ -84,8 +84,8 @@ export namespace MediaNs {
 
   export type Restriction<TStrict extends boolean = false> = Strict<
     {
-      value: Requirable<string> // Required in spec.
-      relationship: Requirable<string> // Required in spec.
+      value: Requirable<string> // Required in spec
+      relationship: Requirable<string> // Required in spec
       type?: string
     },
     TStrict
@@ -111,7 +111,7 @@ export namespace MediaNs {
 
   export type Tag<TStrict extends boolean = false> = Strict<
     {
-      name: Requirable<string> // Required in spec.
+      name: Requirable<string> // Required in spec
       weight?: number
     },
     TStrict
@@ -119,7 +119,7 @@ export namespace MediaNs {
 
   export type Embed<TStrict extends boolean = false> = Strict<
     {
-      url: Requirable<string> // Required in spec.
+      url: Requirable<string> // Required in spec
       width?: number
       height?: number
       params?: Array<Param<TStrict>>
@@ -129,15 +129,15 @@ export namespace MediaNs {
 
   export type Param<TStrict extends boolean = false> = Strict<
     {
-      name: Requirable<string> // Required in spec.
-      value: Requirable<string> // Required in spec.
+      name: Requirable<string> // Required in spec
+      value: Requirable<string> // Required in spec
     },
     TStrict
   >
 
   export type Status<TStrict extends boolean = false> = Strict<
     {
-      state: Requirable<string> // Required in spec.
+      state: Requirable<string> // Required in spec
       reason?: string
     },
     TStrict
@@ -151,16 +151,16 @@ export namespace MediaNs {
   }
 
   export type License<TStrict extends boolean = false> = {
-    name?: string // At least one of name or href is required in spec.
+    name?: string // At least one of name or href is required in spec
     type?: string
-    href?: string // At least one of name or href is required in spec.
+    href?: string // At least one of name or href is required in spec
   } & (TStrict extends true ? { name: string } | { href: string } : unknown)
 
   export type SubTitle<TStrict extends boolean = false> = Strict<
     {
       type?: string
       lang?: string
-      href: Requirable<string> // Required in spec.
+      href: Requirable<string> // Required in spec
     },
     TStrict
   >
@@ -168,7 +168,7 @@ export namespace MediaNs {
   export type PeerLink<TStrict extends boolean = false> = Strict<
     {
       type?: string
-      href: Requirable<string> // Required in spec.
+      href: Requirable<string> // Required in spec
     },
     TStrict
   >

--- a/src/namespaces/opensearch/common/config.ts
+++ b/src/namespaces/opensearch/common/config.ts
@@ -1,9 +1,9 @@
 export const uris = [
-  'http://a9.com/-/spec/opensearch/1.1/', // Official URI (OpenSearch 1.1).
+  'http://a9.com/-/spec/opensearch/1.1/', // Official URI (OpenSearch 1.1)
   'https://a9.com/-/spec/opensearch/1.1/',
-  'http://a9.com/-/spec/opensearch/1.0/', // Official URI (OpenSearch 1.0).
+  'http://a9.com/-/spec/opensearch/1.0/', // Official URI (OpenSearch 1.0)
   'https://a9.com/-/spec/opensearch/1.0/',
-  'http://a9.com/-/spec/opensearchrss/1.0/', // Official URI (legacy).
+  'http://a9.com/-/spec/opensearchrss/1.0/', // Official URI (legacy)
   'https://a9.com/-/spec/opensearchrss/1.0/',
 ]
 

--- a/src/namespaces/opensearch/common/types.ts
+++ b/src/namespaces/opensearch/common/types.ts
@@ -4,7 +4,7 @@ import type { Requirable, Strict } from '../../../common/types.js'
 export namespace OpenSearchNs {
   export type Query<TStrict extends boolean = false> = Strict<
     {
-      role: Requirable<string> // Required in spec.
+      role: Requirable<string> // Required in spec
       searchTerms?: string
       count?: number
       startIndex?: number

--- a/src/namespaces/pingback/common/config.ts
+++ b/src/namespaces/pingback/common/config.ts
@@ -1,5 +1,5 @@
 export const uris = [
-  'http://madskills.com/public/xml/rss/module/pingback/', // Official URI.
+  'http://madskills.com/public/xml/rss/module/pingback/', // Official URI
   'https://madskills.com/public/xml/rss/module/pingback/',
   'http://madskills.com/public/xml/rss/module/pingback',
   'https://madskills.com/public/xml/rss/module/pingback',

--- a/src/namespaces/podcast/common/config.ts
+++ b/src/namespaces/podcast/common/config.ts
@@ -1,5 +1,5 @@
 export const uris = [
-  'https://podcastindex.org/namespace/1.0', // Official URI.
+  'https://podcastindex.org/namespace/1.0', // Official URI
   'http://podcastindex.org/namespace/1.0',
   'https://podcastindex.org/namespace/1.0/',
   'http://podcastindex.org/namespace/1.0/',

--- a/src/namespaces/podcast/common/types.ts
+++ b/src/namespaces/podcast/common/types.ts
@@ -22,8 +22,8 @@ export namespace PodcastNs {
 
   export type Transcript<TStrict extends boolean = false> = Strict<
     {
-      url: Requirable<string> // Required in spec.
-      type: Requirable<string> // Required in spec.
+      url: Requirable<string> // Required in spec
+      type: Requirable<string> // Required in spec
       language?: string
       rel?: string
     },
@@ -32,7 +32,7 @@ export namespace PodcastNs {
 
   export type Locked<TStrict extends boolean = false> = Strict<
     {
-      value: Requirable<boolean> // Required in spec.
+      value: Requirable<boolean> // Required in spec
       owner?: string
     },
     TStrict
@@ -40,7 +40,7 @@ export namespace PodcastNs {
 
   export type Funding<TStrict extends boolean = false> = Strict<
     {
-      url: Requirable<string> // Required in spec.
+      url: Requirable<string> // Required in spec
       display?: string
     },
     TStrict
@@ -48,16 +48,16 @@ export namespace PodcastNs {
 
   export type Chapters<TStrict extends boolean = false> = Strict<
     {
-      url: Requirable<string> // Required in spec.
-      type: Requirable<string> // Required in spec.
+      url: Requirable<string> // Required in spec
+      type: Requirable<string> // Required in spec
     },
     TStrict
   >
 
   export type Soundbite<TStrict extends boolean = false> = Strict<
     {
-      startTime: Requirable<number> // Required in spec.
-      duration: Requirable<number> // Required in spec.
+      startTime: Requirable<number> // Required in spec
+      duration: Requirable<number> // Required in spec
       display?: string
     },
     TStrict
@@ -65,7 +65,7 @@ export namespace PodcastNs {
 
   export type Person<TStrict extends boolean = false> = Strict<
     {
-      display: Requirable<string> // Required in spec.
+      display: Requirable<string> // Required in spec
       role?: string
       group?: string
       img?: string
@@ -76,7 +76,7 @@ export namespace PodcastNs {
 
   export type Location<TStrict extends boolean = false> = Strict<
     {
-      display: Requirable<string> // Required in spec.
+      display: Requirable<string> // Required in spec
       rel?: string
       geo?: string
       osm?: string
@@ -87,7 +87,7 @@ export namespace PodcastNs {
 
   export type Season<TStrict extends boolean = false> = Strict<
     {
-      number: Requirable<number> // Required in spec.
+      number: Requirable<number> // Required in spec
       name?: string
     },
     TStrict
@@ -95,7 +95,7 @@ export namespace PodcastNs {
 
   export type Episode<TStrict extends boolean = false> = Strict<
     {
-      number: Requirable<number> // Required in spec.
+      number: Requirable<number> // Required in spec
       display?: string
     },
     TStrict
@@ -103,9 +103,9 @@ export namespace PodcastNs {
 
   export type Trailer<TDate, TStrict extends boolean = false> = Strict<
     {
-      display: Requirable<string> // Required in spec.
-      url: Requirable<string> // Required in spec.
-      pubDate: Requirable<TDate> // Required in spec.
+      display: Requirable<string> // Required in spec
+      url: Requirable<string> // Required in spec
+      pubDate: Requirable<TDate> // Required in spec
       length?: number
       type?: string
       season?: number
@@ -115,7 +115,7 @@ export namespace PodcastNs {
 
   export type License<TStrict extends boolean = false> = Strict<
     {
-      display: Requirable<string> // Required in spec.
+      display: Requirable<string> // Required in spec
       url?: string
     },
     TStrict
@@ -123,7 +123,7 @@ export namespace PodcastNs {
 
   export type AlternateEnclosure<TStrict extends boolean = false> = Strict<
     {
-      type: Requirable<string> // Required in spec.
+      type: Requirable<string> // Required in spec
       length?: number
       bitrate?: number
       height?: number
@@ -140,7 +140,7 @@ export namespace PodcastNs {
 
   export type Source<TStrict extends boolean = false> = Strict<
     {
-      uri: Requirable<string> // Required in spec.
+      uri: Requirable<string> // Required in spec
       contentType?: string
     },
     TStrict
@@ -148,16 +148,16 @@ export namespace PodcastNs {
 
   export type Integrity<TStrict extends boolean = false> = Strict<
     {
-      type: Requirable<string> // Required in spec.
-      value: Requirable<string> // Required in spec.
+      type: Requirable<string> // Required in spec
+      value: Requirable<string> // Required in spec
     },
     TStrict
   >
 
   export type Value<TStrict extends boolean = false> = Strict<
     {
-      type: Requirable<string> // Required in spec.
-      method: Requirable<string> // Required in spec.
+      type: Requirable<string> // Required in spec
+      method: Requirable<string> // Required in spec
       suggested?: number
       valueRecipients?: Array<ValueRecipient<TStrict>>
       valueTimeSplits?: Array<ValueTimeSplit<TStrict>>
@@ -170,9 +170,9 @@ export namespace PodcastNs {
       name?: string
       customKey?: string
       customValue?: string
-      type: Requirable<string> // Required in spec.
-      address: Requirable<string> // Required in spec.
-      split: Requirable<number> // Required in spec.
+      type: Requirable<string> // Required in spec
+      address: Requirable<string> // Required in spec
+      split: Requirable<number> // Required in spec
       fee?: boolean
     },
     TStrict
@@ -185,7 +185,7 @@ export namespace PodcastNs {
 
   export type Image<TStrict extends boolean = false> = Strict<
     {
-      href: Requirable<string> // Required in spec.
+      href: Requirable<string> // Required in spec
       alt?: string
       aspectRatio?: string
       width?: number
@@ -199,9 +199,9 @@ export namespace PodcastNs {
   export type LiveItem<TDate, TStrict extends boolean = false> = BaseItem<TStrict> &
     Strict<
       {
-        status: Requirable<string> // Required in spec.
-        start: Requirable<TDate> // Required in spec. Date: ISO 8601.
-        end?: TDate // Date: ISO 8601.
+        status: Requirable<string> // Required in spec
+        start: Requirable<TDate> // Required in spec. Date: ISO 8601
+        end?: TDate // Date: ISO 8601
         contentLinks?: Array<ContentLink<TStrict>>
       },
       TStrict
@@ -209,7 +209,7 @@ export namespace PodcastNs {
 
   export type ContentLink<TStrict extends boolean = false> = Strict<
     {
-      href: Requirable<string> // Required in spec.
+      href: Requirable<string> // Required in spec
       display?: string
     },
     TStrict
@@ -221,7 +221,7 @@ export namespace PodcastNs {
       // to `disabled`, no other attributes are necessary. To bypass the protocol value check, which
       // may be invalid, only the protocol is required to ensure consistent behavior.
       uri?: string
-      protocol: Requirable<string> // Required in spec.
+      protocol: Requirable<string> // Required in spec
       accountId?: string
       accountUrl?: string
       priority?: number
@@ -231,8 +231,8 @@ export namespace PodcastNs {
 
   export type Chat<TStrict extends boolean = false> = Strict<
     {
-      server: Requirable<string> // Required in spec.
-      protocol: Requirable<string> // Required in spec.
+      server: Requirable<string> // Required in spec
+      protocol: Requirable<string> // Required in spec
       accountId?: string
       space?: string
     },
@@ -241,7 +241,7 @@ export namespace PodcastNs {
 
   export type Block<TStrict extends boolean = false> = Strict<
     {
-      value: Requirable<boolean> // Required in spec.
+      value: Requirable<boolean> // Required in spec
       id?: string
     },
     TStrict
@@ -249,7 +249,7 @@ export namespace PodcastNs {
 
   export type Txt<TStrict extends boolean = false> = Strict<
     {
-      display: Requirable<string> // Required in spec.
+      display: Requirable<string> // Required in spec
       purpose?: string
     },
     TStrict
@@ -257,7 +257,7 @@ export namespace PodcastNs {
 
   export type RemoteItem<TStrict extends boolean = false> = Strict<
     {
-      feedGuid: Requirable<string> // Required in spec.
+      feedGuid: Requirable<string> // Required in spec
       feedUrl?: string
       itemGuid?: string
       medium?: string
@@ -272,7 +272,7 @@ export namespace PodcastNs {
 
   export type UpdateFrequency<TDate, TStrict extends boolean = false> = Strict<
     {
-      display: Requirable<string> // Required in spec.
+      display: Requirable<string> // Required in spec
       complete?: boolean
       dtstart?: TDate
       rrule?: string
@@ -290,8 +290,8 @@ export namespace PodcastNs {
 
   export type ValueTimeSplit<TStrict extends boolean = false> = Strict<
     {
-      startTime: Requirable<number> // Required in spec.
-      duration: Requirable<number> // Required in spec.
+      startTime: Requirable<number> // Required in spec
+      duration: Requirable<number> // Required in spec
       remoteStartTime?: number
       remotePercentage?: number
       remoteItem?: RemoteItem<TStrict>

--- a/src/namespaces/prism/common/config.ts
+++ b/src/namespaces/prism/common/config.ts
@@ -1,37 +1,37 @@
 export const uris = [
-  'http://prismstandard.org/namespaces/basic/3.0/', // Official URI (PRISM 3.0).
+  'http://prismstandard.org/namespaces/basic/3.0/', // Official URI (PRISM 3.0)
   'https://prismstandard.org/namespaces/basic/3.0/',
   'http://prismstandard.org/namespaces/basic/3.0',
   'https://prismstandard.org/namespaces/basic/3.0',
-  'http://prismstandard.org/namespaces/basic/2.2/', // PRISM 2.2.
+  'http://prismstandard.org/namespaces/basic/2.2/', // PRISM 2.2
   'https://prismstandard.org/namespaces/basic/2.2/',
   'http://prismstandard.org/namespaces/basic/2.2',
   'https://prismstandard.org/namespaces/basic/2.2',
-  'http://prismstandard.org/namespaces/basic/2.1/', // PRISM 2.1.
+  'http://prismstandard.org/namespaces/basic/2.1/', // PRISM 2.1
   'https://prismstandard.org/namespaces/basic/2.1/',
   'http://prismstandard.org/namespaces/basic/2.1',
   'https://prismstandard.org/namespaces/basic/2.1',
-  'http://prismstandard.org/namespaces/basic/2.0/', // PRISM 2.0.
+  'http://prismstandard.org/namespaces/basic/2.0/', // PRISM 2.0
   'https://prismstandard.org/namespaces/basic/2.0/',
   'http://prismstandard.org/namespaces/basic/2.0',
   'https://prismstandard.org/namespaces/basic/2.0',
-  'http://prismstandard.org/namespaces/2.0/basic/', // PRISM 2.0 (alternative path).
+  'http://prismstandard.org/namespaces/2.0/basic/', // PRISM 2.0 (alternative path)
   'https://prismstandard.org/namespaces/2.0/basic/',
   'http://prismstandard.org/namespaces/2.0/basic',
   'https://prismstandard.org/namespaces/2.0/basic',
-  'http://prismstandard.org/namespaces/1.2/basic/', // PRISM 1.2 (most common).
+  'http://prismstandard.org/namespaces/1.2/basic/', // PRISM 1.2 (most common)
   'https://prismstandard.org/namespaces/1.2/basic/',
   'http://prismstandard.org/namespaces/1.2/basic',
   'https://prismstandard.org/namespaces/1.2/basic',
-  'http://prismstandard.org/namespaces/1.1/basic/', // PRISM 1.1.
+  'http://prismstandard.org/namespaces/1.1/basic/', // PRISM 1.1
   'https://prismstandard.org/namespaces/1.1/basic/',
   'http://prismstandard.org/namespaces/1.1/basic',
   'https://prismstandard.org/namespaces/1.1/basic',
-  'http://prismstandard.org/namespaces/1.0/basic/', // PRISM 1.0.
+  'http://prismstandard.org/namespaces/1.0/basic/', // PRISM 1.0
   'https://prismstandard.org/namespaces/1.0/basic/',
   'http://prismstandard.org/namespaces/1.0/basic',
   'https://prismstandard.org/namespaces/1.0/basic',
-  'http://purl.org/rss/1.0/modules/prism/', // Legacy purl.org URI.
+  'http://purl.org/rss/1.0/modules/prism/', // Legacy purl.org URI
   'https://purl.org/rss/1.0/modules/prism/',
   'http://purl.org/rss/1.0/modules/prism',
   'https://purl.org/rss/1.0/modules/prism',

--- a/src/namespaces/psc/common/config.ts
+++ b/src/namespaces/psc/common/config.ts
@@ -1,5 +1,5 @@
 export const uris = [
-  'http://podlove.org/simple-chapters', // Official URI.
+  'http://podlove.org/simple-chapters', // Official URI
   'https://podlove.org/simple-chapters',
   'http://podlove.org/simple-chapters/',
   'https://podlove.org/simple-chapters/',

--- a/src/namespaces/psc/common/types.ts
+++ b/src/namespaces/psc/common/types.ts
@@ -4,8 +4,8 @@ import type { Requirable, Strict } from '../../../common/types.js'
 export namespace PscNs {
   export type Chapter<TStrict extends boolean = false> = Strict<
     {
-      start: Requirable<string> // Required in spec.
-      title: Requirable<string> // Required in spec.
+      start: Requirable<string> // Required in spec
+      title: Requirable<string> // Required in spec
       href?: string
       image?: string
     },

--- a/src/namespaces/rawvoice/common/config.ts
+++ b/src/namespaces/rawvoice/common/config.ts
@@ -1,5 +1,5 @@
 export const uris = [
-  'http://www.rawvoice.com/rawvoiceRssModule/', // Official URI.
+  'http://www.rawvoice.com/rawvoiceRssModule/', // Official URI
   'https://www.rawvoice.com/rawvoiceRssModule/',
   'http://www.rawvoice.com/rawvoiceRssModule',
   'https://www.rawvoice.com/rawvoiceRssModule',

--- a/src/namespaces/rawvoice/common/types.ts
+++ b/src/namespaces/rawvoice/common/types.ts
@@ -11,8 +11,8 @@ export namespace RawVoiceNs {
   export type LiveStream<TDate, TStrict extends boolean = false> = Strict<
     {
       url?: string
-      schedule: Requirable<TDate> // Required in spec.
-      duration: Requirable<string> // Required in spec.
+      schedule: Requirable<TDate> // Required in spec
+      duration: Requirable<string> // Required in spec
       type?: string
     },
     TStrict
@@ -20,14 +20,14 @@ export namespace RawVoiceNs {
 
   export type Poster<TStrict extends boolean = false> = Strict<
     {
-      url: Requirable<string> // Required in spec.
+      url: Requirable<string> // Required in spec
     },
     TStrict
   >
 
   export type AlternateEnclosure<TStrict extends boolean = false> = Strict<
     {
-      src: Requirable<string> // Required in spec.
+      src: Requirable<string> // Required in spec
       type?: string
       length?: number
     },
@@ -46,7 +46,7 @@ export namespace RawVoiceNs {
 
   export type Donate<TStrict extends boolean = false> = Strict<
     {
-      href: Requirable<string> // Required in spec.
+      href: Requirable<string> // Required in spec
       value?: string
     },
     TStrict

--- a/src/namespaces/rdf/common/config.ts
+++ b/src/namespaces/rdf/common/config.ts
@@ -1,5 +1,5 @@
 export const uris = [
-  'http://www.w3.org/1999/02/22-rdf-syntax-ns#', // Official URI.
+  'http://www.w3.org/1999/02/22-rdf-syntax-ns#', // Official URI
   'https://www.w3.org/1999/02/22-rdf-syntax-ns#',
 ]
 

--- a/src/namespaces/rss/common/config.ts
+++ b/src/namespaces/rss/common/config.ts
@@ -1,5 +1,5 @@
 export const uris = [
-  'http://purl.org/rss/1.0/', // Official URI.
+  'http://purl.org/rss/1.0/', // Official URI
   'https://purl.org/rss/1.0/',
   'http://purl.org/rss/1.0',
   'https://purl.org/rss/1.0',

--- a/src/namespaces/slash/common/config.ts
+++ b/src/namespaces/slash/common/config.ts
@@ -1,5 +1,5 @@
 export const uris = [
-  'http://purl.org/rss/1.0/modules/slash/', // Official URI.
+  'http://purl.org/rss/1.0/modules/slash/', // Official URI
   'https://purl.org/rss/1.0/modules/slash/',
   'http://purl.org/rss/1.0/modules/slash',
   'https://purl.org/rss/1.0/modules/slash',

--- a/src/namespaces/source/common/config.ts
+++ b/src/namespaces/source/common/config.ts
@@ -1,5 +1,5 @@
 export const uris = [
-  'http://source.scripting.com/', // Official URI.
+  'http://source.scripting.com/', // Official URI
   'https://source.scripting.com/',
   'http://source.scripting.com',
   'https://source.scripting.com',

--- a/src/namespaces/source/common/types.ts
+++ b/src/namespaces/source/common/types.ts
@@ -4,7 +4,7 @@ import type { Requirable, Strict } from '../../../common/types.js'
 export namespace SourceNs {
   export type Account<TStrict extends boolean = false> = Strict<
     {
-      service: Requirable<string> // Required in spec.
+      service: Requirable<string> // Required in spec
       value?: string
     },
     TStrict
@@ -12,15 +12,15 @@ export namespace SourceNs {
 
   export type Likes<TStrict extends boolean = false> = Strict<
     {
-      server: Requirable<string> // Required in spec.
+      server: Requirable<string> // Required in spec
     },
     TStrict
   >
 
   export type Archive<TStrict extends boolean = false> = Strict<
     {
-      url: Requirable<string> // Required in spec.
-      startDay: Requirable<string> // Required in spec.
+      url: Requirable<string> // Required in spec
+      startDay: Requirable<string> // Required in spec
       endDay?: string
       filename?: string
     },
@@ -29,7 +29,7 @@ export namespace SourceNs {
 
   export type SubscriptionList<TStrict extends boolean = false> = Strict<
     {
-      url: Requirable<string> // Required in spec.
+      url: Requirable<string> // Required in spec
       value?: string
     },
     TStrict
@@ -37,7 +37,7 @@ export namespace SourceNs {
 
   export type InReplyTo<TStrict extends boolean = false> = Strict<
     {
-      value: Requirable<string> // Required in spec.
+      value: Requirable<string> // Required in spec
       isPermaLink?: boolean
     },
     TStrict

--- a/src/namespaces/spotify/common/config.ts
+++ b/src/namespaces/spotify/common/config.ts
@@ -1,5 +1,5 @@
 export const uris = [
-  'http://www.spotify.com/ns/rss', // Official URI.
+  'http://www.spotify.com/ns/rss', // Official URI
   'https://www.spotify.com/ns/rss',
   'http://www.spotify.com/ns/rss/',
   'https://www.spotify.com/ns/rss/',

--- a/src/namespaces/spotify/common/types.ts
+++ b/src/namespaces/spotify/common/types.ts
@@ -8,14 +8,14 @@ export namespace SpotifyNs {
 
   export type Partner<TStrict extends boolean = false> = Strict<
     {
-      id: Requirable<string> // Required in spec.
+      id: Requirable<string> // Required in spec
     },
     TStrict
   >
 
   export type Sandbox<TStrict extends boolean = false> = Strict<
     {
-      enabled: Requirable<boolean> // Required in spec.
+      enabled: Requirable<boolean> // Required in spec
     },
     TStrict
   >
@@ -27,7 +27,7 @@ export namespace SpotifyNs {
 
   export type Entitlement<TStrict extends boolean = false> = Strict<
     {
-      name: Requirable<string> // Required in spec.
+      name: Requirable<string> // Required in spec
     },
     TStrict
   >

--- a/src/namespaces/sy/common/config.ts
+++ b/src/namespaces/sy/common/config.ts
@@ -1,5 +1,5 @@
 export const uris = [
-  'http://purl.org/rss/1.0/modules/syndication/', // Official URI.
+  'http://purl.org/rss/1.0/modules/syndication/', // Official URI
   'https://purl.org/rss/1.0/modules/syndication/',
   'http://purl.org/rss/1.0/modules/syndication',
   'https://purl.org/rss/1.0/modules/syndication',

--- a/src/namespaces/thr/common/config.ts
+++ b/src/namespaces/thr/common/config.ts
@@ -1,5 +1,5 @@
 export const uris = [
-  'http://purl.org/syndication/thread/1.0', // Official URI.
+  'http://purl.org/syndication/thread/1.0', // Official URI
   'https://purl.org/syndication/thread/1.0',
   'http://purl.org/syndication/thread/1.0/',
   'https://purl.org/syndication/thread/1.0/',

--- a/src/namespaces/thr/common/types.ts
+++ b/src/namespaces/thr/common/types.ts
@@ -4,7 +4,7 @@ import type { Requirable, Strict } from '../../../common/types.js'
 export namespace ThrNs {
   export type InReplyTo<TStrict extends boolean = false> = Strict<
     {
-      ref: Requirable<string> // Required in spec.
+      ref: Requirable<string> // Required in spec
       href?: string
       type?: string
       source?: string

--- a/src/namespaces/trackback/common/config.ts
+++ b/src/namespaces/trackback/common/config.ts
@@ -1,5 +1,5 @@
 export const uris = [
-  'http://madskills.com/public/xml/rss/module/trackback/', // Official URI.
+  'http://madskills.com/public/xml/rss/module/trackback/', // Official URI
   'https://madskills.com/public/xml/rss/module/trackback/',
   'http://madskills.com/public/xml/rss/module/trackback',
   'https://madskills.com/public/xml/rss/module/trackback',

--- a/src/namespaces/wfw/common/config.ts
+++ b/src/namespaces/wfw/common/config.ts
@@ -1,5 +1,5 @@
 export const uris = [
-  'http://wellformedweb.org/CommentAPI/', // Official URI.
+  'http://wellformedweb.org/CommentAPI/', // Official URI
   'https://wellformedweb.org/CommentAPI/',
   'http://wellformedweb.org/CommentAPI',
   'https://wellformedweb.org/CommentAPI',

--- a/src/namespaces/yt/common/config.ts
+++ b/src/namespaces/yt/common/config.ts
@@ -1,5 +1,5 @@
 export const uris = [
-  'http://www.youtube.com/xml/schemas/2015', // Official URI.
+  'http://www.youtube.com/xml/schemas/2015', // Official URI
   'https://www.youtube.com/xml/schemas/2015',
   'http://www.youtube.com/xml/schemas/2015/',
   'https://www.youtube.com/xml/schemas/2015/',

--- a/src/opml/common/types.ts
+++ b/src/opml/common/types.ts
@@ -25,15 +25,15 @@ export type GenerateUtil<V> = BaseGenerateUtil<V, GenerateMainOptions>
 
 // #region reference
 export namespace Opml {
-  // NOTE: BaseOutline contains non-recursive fields wrapped in Strict<>.
-  // Outline extends it and adds recursive outlines field separately.
+  // NOTE: BaseOutline contains non-recursive fields wrapped in Strict<>. Outline extends it and
+  // adds recursive outlines field separately.
   export type BaseOutline<
     TDate,
     TExtra extends ReadonlyArray<string> = ReadonlyArray<string>,
     TStrict extends boolean = false,
   > = Strict<
     {
-      text: Requirable<string> // Required in spec.
+      text: Requirable<string> // Required in spec
       type?: string
       isComment?: boolean
       isBreakpoint?: boolean

--- a/src/opml/parse/config.ts
+++ b/src/opml/parse/config.ts
@@ -17,8 +17,8 @@ export const stopNodes = [
   'opml.head.windowright',
   // Not a stop node because it supports recursive nesting that requires parser traversal.
   // '*.outline',
-  // Not a stop node because *.X.Y wildcard patterns don't work in fast-xml-parser
-  // (the part after *. is matched against a single tag name, not a path).
+  // Not a stop node because *.X.Y wildcard patterns don't work in fast-xml-parser (the part after
+  // *. is matched against a single tag name, not a path).
   // '*.outline.outline',
 ]
 


### PR DESCRIPTION
This PR reformats every comment in `src` to the house form and deletes none of them: wrapped at 100 characters, written as sentences with a period, em-dashes replaced by a colon, a period or a comma, and a bare url written as See: url. JSDoc blocks are untouched, and so are code lines.